### PR TITLE
(A better method solving the same bug as PR@425) Debug train.py (in DDP mode) by using self.model.module.num_param

### DIFF
--- a/train.py
+++ b/train.py
@@ -292,6 +292,7 @@ class Trainer:
 
         if self.ddp:
             self.model = DDP(self.model, device_ids=[self.ddp_local_rank])
+            self.model.num_param = self.model.module.num_param
 
         self.raw_model = self.model.module if self.ddp else self.model
 
@@ -301,10 +302,7 @@ class Trainer:
 
         # Tensorboard
         if self.args.tensorboard_log:
-            if self.ddp:
-                timestamped_run_name = f"{self.model.module.num_param:.2e}_{timestamp_prefix}_{self.args.tensorboard_run_name}"
-            else:
-                timestamped_run_name = f"{self.model.num_param:.2e}_{timestamp_prefix}_{self.args.tensorboard_run_name}"
+            timestamped_run_name = f"{self.model.num_param:.2e}_{timestamp_prefix}_{self.args.tensorboard_run_name}"
             if self.args.csv_log:
                 self.args.csv_name = timestamped_run_name
             log_subpath = os.path.join(self.args.tensorboard_log_dir, timestamped_run_name)
@@ -1289,4 +1287,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
This PR undo PR@425 and solve the same problem by a better method.

> This one-line code change will solve all 15 times of errors caused by `not finding self.model.num_param` when using DDP mode.

Here is the evidence that my small change is correct:
When you use one GPU:
![屏幕截图 2025-04-09 031047](https://github.com/user-attachments/assets/00be11d2-4806-4624-a966-8fd59dd9185d)
![屏幕截图 2025-04-09 030046](https://github.com/user-attachments/assets/95129ba6-fec5-4631-ae28-156fb79e7826)


As expected, you will get **1.632x** speedup if you use 2 A100 GPU (40GB VRAM):
![屏幕截图 2025-04-09 025220](https://github.com/user-attachments/assets/d5e1e1ba-526c-48ff-b7ef-a893ce5368cf)
![屏幕截图 2025-04-09 025656](https://github.com/user-attachments/assets/b7ccdac5-ee00-4070-bf86-f9b642474c42)

