### PR TITLE
Update application of c down proj

### DIFF
--- a/explorations/mlp_bias_comparison.yaml
+++ b/explorations/mlp_bias_comparison.yaml
@@ -21,11 +21,15 @@ parameter_groups:
     mlp_down_bias: [true, false]
 
 # base hyperparameters (defaults)
-block_size: [512]
-n_layer: [12]
-n_head: [12]
-n_embd: [768]
+block_size: [256]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
 bias: [false]
+
+# pos embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
 
 # training configuration
 dataset: "minipile"

--- a/explorations/multi_proj_mlp.yaml
+++ b/explorations/multi_proj_mlp.yaml
@@ -22,6 +22,7 @@ compile: [true]
 # Logging settings
 eval_interval: [10000]
 max_iters: [10000]
+eta_variant: ["iteration"]
 
 # Positional embeddings
 use_rotary_embeddings: [true]
@@ -32,4 +33,5 @@ seed:
   range:
     start: 1337
     end: 1339
-    step: 1 
+    step: 1
+


### PR DESCRIPTION
This makes it equivalent to normal c down proj unless number of c down project > 1.

This also ensures we don't average for the cdown project, as it should be summed.