### PR TITLE
feat: show latency and GPU usage in progress bar

### DIFF
--- a/train.py
+++ b/train.py
@@ -1328,6 +1328,8 @@ class Trainer:
                 TextColumn("-- [bold purple3]ETA:[/bold purple3]{task.fields[eta]}"),
                 TextColumn("[bold purple3]Remaining:[/bold purple3]{task.fields[hour]}h{task.fields[min]}m"),
                 TextColumn("[bold purple3]total_est:[/bold purple3]{task.fields[total_hour]}h{task.fields[total_min]}m"),
+                TextColumn("-- [bold dark_magenta]iter_latency:[/bold dark_magenta]{task.fields[iter_latency]}ms"),
+                TextColumn("[bold dark_magenta]peak_gpu_mb:[/bold dark_magenta]{task.fields[peak_gpu_mb]}MB"),
                 console=self.console
                 )
 
@@ -1342,6 +1344,8 @@ class Trainer:
                     min=f"{int((self.time_remaining_ms // 60000) % 60):02d}",
                     best_val_loss=f"{self.best_val_loss:.3f}",
                     best_iter=f"{self.best_iter}",
+                    iter_latency=f"{self.iter_latency_avg:.1f}",
+                    peak_gpu_mb=f"{self.peak_gpu_usage / (1024 ** 2):.1f}",
                     )
 
             while True:
@@ -1678,6 +1682,8 @@ class Trainer:
                         min=f"{int((self.time_remaining_ms // 60_000) % 60):02d}",
                         best_val_loss=f"{self.best_val_loss:.3f}",
                         best_iter=f"{self.best_iter}",
+                        iter_latency=f"{self.iter_latency_avg:.1f}",
+                        peak_gpu_mb=f"{self.peak_gpu_usage / (1024 ** 2):.1f}",
                         )
                 live.update(Group(progress.get_renderable(), cli_text))
 


### PR DESCRIPTION
Adds average iteration latency and peak gpu in MB to the progress bar:

<img width="1921" height="89" alt="image" src="https://github.com/user-attachments/assets/50d8cb83-9b56-4fde-bb14-07964c5bfc08" />
