### PR TITLE
support byte tokenizer in training and sampling

### DIFF
--- a/data/template/prepare.py
+++ b/data/template/prepare.py
@@ -7,6 +7,7 @@ from tokenizers import (
     SentencePieceTokenizer,
     TiktokenTokenizer,
     CustomTokenizer,
+    ByteTokenizer,
     CharTokenizer,
     CustomCharTokenizerWithByteFallback,
     JsonByteTokenizerWithByteFallback,
@@ -26,7 +27,7 @@ def parse_arguments():
 
     # Tokenizer selection and configuration
     parser.add_argument("--method", type=str,
-                       choices=["sentencepiece", "tiktoken", "char", "custom", "custom_char_byte_fallback", "json_byte_fallback"],
+                       choices=["sentencepiece", "tiktoken", "char", "custom", "byte", "custom_char_byte_fallback", "json_byte_fallback"],
                        default="tiktoken", help="Tokenization method")
 
     # SentencePiece arguments
@@ -90,6 +91,8 @@ def main():
         tokenizer = TiktokenTokenizer(args)
     elif args.method == "custom":
         tokenizer = CustomTokenizer(args)
+    elif args.method == "byte":
+        tokenizer = ByteTokenizer(args)
     elif args.method == "char":
         tokenizer = CharTokenizer(args, train_data, val_data)
     elif args.method == "custom_char_byte_fallback":

--- a/data/template/tokenizers.py
+++ b/data/template/tokenizers.py
@@ -256,6 +256,27 @@ class CustomTokenizer(Tokenizer):
     def detokenize(self, ids):
         return ''.join([self.itos[id] for id in ids])
 
+class ByteTokenizer(Tokenizer):
+    def __init__(self, args):
+        super().__init__(args)
+
+    def tokenize(self, data):
+        data_bytes = data.encode('utf-8')
+        ids = list(data_bytes)
+        for token_id in ids:
+            self.record_token(token_id)
+        meta = {
+            "vocab_size": 256,
+            "tokenizer": "byte",
+            "itos": {i: bytes([i]) for i in range(256)},
+        }
+        self.finalize_meta(meta)
+        return ids
+
+    def detokenize(self, ids):
+        return bytes(ids).decode('utf-8', errors='replace')
+
+
 class CharTokenizer(Tokenizer):
     def __init__(self, args, train_data, val_data):
         super().__init__(args)

--- a/sample.py
+++ b/sample.py
@@ -825,6 +825,16 @@ def custom_char_with_byte_fallback_decode(ids: list[int], itos: dict) -> str:
     flush_bytes()
     return "".join(out_parts)
 
+
+def byte_encode(text: str) -> list[int]:
+    """Encode text into raw UTF-8 byte values."""
+    return list(text.encode("utf-8"))
+
+
+def byte_decode(ids: list[int]) -> str:
+    """Decode a list of raw byte values back into text."""
+    return bytes(ids).decode("utf-8", errors="replace")
+
 def get_tokenizer_functions(meta):
     """Get encode/decode functions based on tokenizer metadata"""
     if 'tokenizer' not in meta:
@@ -839,6 +849,9 @@ def get_tokenizer_functions(meta):
         encode = lambda s: enc.encode(s, allowed_special={""})
         decode = lambda l: enc.decode(l)
         return encode, decode
+
+    if meta['tokenizer'] == 'byte':
+        return byte_encode, byte_decode
 
     if meta['tokenizer'] == 'custom_char_with_byte_fallback':
         stoi, itos = meta['stoi'], meta['itos']

--- a/train.py
+++ b/train.py
@@ -48,8 +48,6 @@ from utils.model_stats import (
 
 from sample import (
     sample_with_existing_model,
-    custom_char_with_byte_fallback_encode as ccwb_encode,
-    custom_char_with_byte_fallback_decode as ccwb_decode,
     get_tokenizer_functions,
 )
 
@@ -487,8 +485,9 @@ class Trainer:
                 else:
                     print("Using default character-level tokenizer")
 
-                if 'stoi' in meta and 'itos' in meta:
+                if 'stoi' in meta:
                     self.stoi = meta['stoi']
+                if 'itos' in meta:
                     self.itos = meta['itos']
             else:
                 sys.exit("Error: meta.pkl not found")


### PR DESCRIPTION
# Summary

* Implemented a ByteTokenizer that encodes text into raw UTF-8 bytes and records token counts for metadata persistence
* Exposed a new byte option in the template preparation script, instantiating ByteTokenizer alongside existing methods
*Added raw-byte encode/decode helpers and integrated them into get_tokenizer_functions so sampling recognizes byte-level vocabularies
* Updated the training workflow to import get_tokenizer_functions and load encoder/decoder mappings while persisting stoi/itos separately, ensuring compatibility with byte-based vocabs
* Expanded unit tests to cover ByteTokenizer round-trip behavior and token-count tracking
* Tested to make sure it works with train.py max sample tokens

## Screencapture of train.py with max sample tokens
<img width="531" height="506" alt="image" src="https://github.com/user-attachments/assets/1b2d820e-29d6-450b-bfd5-4506ce85ac96" />

