### PR TITLE
Fix gradient checkpointing to avoid passing module to checkpoint

### DIFF
--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -1,6 +1,7 @@
 """Block definitions and forward variations."""
 from __future__ import annotations
 from typing import Callable
+from functools import partial
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as checkpoint
@@ -338,7 +339,7 @@ class Block(nn.Module):
             variant = "attn_then_mlp"
 
         # Set Block Forward Variant
-        self.block_forward = block_forward_variations[variant]
+        self.block_forward = partial(block_forward_variations[variant], self)
 
         ## Instantiate norms for Block Forward Variant
         normalization_setup_variations[variant](self, config, norm_cls)
@@ -362,6 +363,6 @@ class Block(nn.Module):
 
     def forward(self, x: torch.Tensor, iter_num: int):
         if self.use_gradient_checkpointing and x.requires_grad:
-            return checkpoint.checkpoint(self.block_forward, self, x, iter_num, use_reentrant=False)
-        return self.block_forward(self, x, iter_num)
+            return checkpoint.checkpoint(self.block_forward, x, iter_num, use_reentrant=False)
+        return self.block_forward(x, iter_num)
 


### PR DESCRIPTION
# Fixing gradient checkpointing implementation

Demonstration below that gradient checkpointing works now:

##  Before:
<img width="798" height="250" alt="image" src="https://github.com/user-attachments/assets/36be58e5-1600-4434-9d88-d11fe4596605" />

## After:
<img width="798" height="250" alt="image" src="https://github.com/user-attachments/assets/3d5712f7-7288-4ece-a741-3f71ba1ce54a" />
