### PR TITLE
Modify gradient checkpointing search sweep

### DIFF
--- a/explorations/gradient_checkpointing_sweep.yaml
+++ b/explorations/gradient_checkpointing_sweep.yaml
@@ -4,23 +4,24 @@
 # Activation memory per layer ≈ batch_size * block_size * n_embd * bytes_per_elem.
 # Without checkpointing: activations scale with n_layer -> VRAM ≈ L * S.
 # With checkpointing: only boundary activations stored -> ≈0.5 × VRAM but requires recomputation (~25% slower).
-# PyTorch compile fuses ops, giving ~30% faster iterations but ~10% more VRAM; combining with checkpointing recovers speed while retaining memory savings.
+# PyTorch compile fuses ops, giving ~30% faster iterations but potentially more VRAM;
+# Combining with checkpointing recovers speed while retaining memory savings.
 
 parameter_groups:
   - compile: [false]
-    use_gradient_checkpointing: [false]  # baseline
+    use_gradient_checkpointing: [false]  # CF_GF: baseline
   - compile: [false]
-    use_gradient_checkpointing: [true]   # ≈50% less activation VRAM, ≈25% slower
+    use_gradient_checkpointing: [true]   # CF_GT: -50% VRAM, +25% iter_ms
   - compile: [true]
-    use_gradient_checkpointing: [false]  # ≈30% faster, ≈10% more VRAM
+    use_gradient_checkpointing: [false]  # CT_GF: -20% VRAM, -25% iter_ms
   - compile: [true]
-    use_gradient_checkpointing: [true]   # ≈55% less VRAM, speed ≈ baseline
+    use_gradient_checkpointing: [true]   # CT_GT: -50% VRAM, -12% iter_ms
 
 # base hyperparameters
-max_iters: [500]
-batch_size: [2, 4, 6]
-n_head: [6]
-dataset: ["shakespeare_char"]
+max_iters: [250]
+batch_size: [1, 2, 3]
+n_head: [12]
+dataset: ["minipile"]
 device: ["cuda"]
 dtype: ["bfloat16"]
 
@@ -29,9 +30,10 @@ use_rotary_embeddings: [true]
 use_abs_pos_embeddings: [false]
 
 # sweep variables
-n_layer: [2, 4, 6]           # memory scales linearly with layers
-n_embd: [120, 240, 360]      # wider models increase activation memory; checkpointing saves proportionally
-block_size: [64, 128, 192]   # attention memory scales ~block_size^2; checkpointing can't reduce quadratic term
+n_layer: [32]           # memory scales linearly with layers; checkpointing should save proportionally
+n_embd: [768]           # wider models increase activation memory; checkpointing saves proportionally
+block_size: [2048]      # attention memory scales ~block_size^2
 
 # checkpoint settings
 never_save_checkpoint: [true]
+

--- a/explorations/gradient_checkpointing_sweep.yaml
+++ b/explorations/gradient_checkpointing_sweep.yaml
@@ -1,0 +1,37 @@
+# explorations/gradient_checkpointing_sweep.yaml
+---
+# Study VRAM and iteration speed trade-offs when using gradient checkpointing.
+# Activation memory per layer ≈ batch_size * block_size * n_embd * bytes_per_elem.
+# Without checkpointing: activations scale with n_layer -> VRAM ≈ L * S.
+# With checkpointing: only boundary activations stored -> ≈0.5 × VRAM but requires recomputation (~25% slower).
+# PyTorch compile fuses ops, giving ~30% faster iterations but ~10% more VRAM; combining with checkpointing recovers speed while retaining memory savings.
+
+parameter_groups:
+  - compile: [false]
+    use_gradient_checkpointing: [false]  # baseline
+  - compile: [false]
+    use_gradient_checkpointing: [true]   # ≈50% less activation VRAM, ≈25% slower
+  - compile: [true]
+    use_gradient_checkpointing: [false]  # ≈30% faster, ≈10% more VRAM
+  - compile: [true]
+    use_gradient_checkpointing: [true]   # ≈55% less VRAM, speed ≈ baseline
+
+# base hyperparameters
+max_iters: [500]
+batch_size: [2, 4, 6]
+n_head: [6]
+dataset: ["shakespeare_char"]
+device: ["cuda"]
+dtype: ["bfloat16"]
+
+# Position Encoding
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+# sweep variables
+n_layer: [2, 4, 6]           # memory scales linearly with layers
+n_embd: [120, 240, 360]      # wider models increase activation memory; checkpointing saves proportionally
+block_size: [64, 128, 192]   # attention memory scales ~block_size^2; checkpointing can't reduce quadratic term
+
+# checkpoint settings
+never_save_checkpoint: [true]


### PR DESCRIPTION
# Gradient Checkpointing / PyTorch Compile Sweep and Results:

 Results of sweep summarized in images and in the yaml file notes.

<img width="237" height="196" alt="image" src="https://github.com/user-attachments/assets/89aafcaa-1ab9-42a2-8a76-9147232e448b" />

Gradient Checkpointing and compile are now confirmed to be compatible.

<img width="1400" height="1200" alt="Peak_Gpu_Mb___Iter_Latency_Avg_by_Batch_Size___Use_Gradient_br_Checkpointing___Compile" src="https://github.com/user-attachments/assets/53df6eaf-43aa-4b0a-ba86-a541ff76c564" />

<img width="1400" height="1200" alt="Peak_Gpu_Mb___Iter_Latency_Avg_by_Use_Gradient_Checkpointing_br___Compile" src="https://github.com/user-attachments/assets/ed2b345f-846b-4df1-b825-6cd1c99deb05" />

## Notes:

However, if one has the VRAM capacity, iteration speed is still 10% or so faster without gradient checkpointing.

This may be interesting to combine with searches for optimal batch size schedules and gns.