### PR TITLE
Added edgellm_asic mlp variant

### DIFF
--- a/demos/asic_quantization_demo.sh
+++ b/demos/asic_quantization_demo.sh
@@ -17,7 +17,7 @@ popd
 python3 train.py \
     --out_dir asic_quant \
     --use_edgellm_asic \
-    --mlp_variant edgellm_asic \
+    --mlp_variant edgellm_asic_mlp \
     --max_iters 20000 \
     --full_quant_iteration 10000 \
     --dataset "$dataset" \

--- a/train_args.py
+++ b/train_args.py
@@ -518,7 +518,7 @@ def parse_args():
     # MLP Variations
     mlp_variants = [
             "mlp",
-            "edgellm_asic",
+            "edgellm_asic_mlp",
             "kan",
             "swiglu",
             "dual_path",

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -635,7 +635,7 @@ class MLP_Identity(nn.Module):
 
 mlp_dictionary = {
     "mlp": OriginalMLP,
-    "edgellm_asic": EdgeLLMASICMLP,
+    "edgellm_asic_mlp": EdgeLLMASICMLP,
     "swiglu": Swiglu,
     "identity": MLP_Identity,
     "kan": KanMLP,


### PR DESCRIPTION
- Introduces a new MLP variation, EdgeLLMASICMLP, implemented in variations/mlp_variations.py. It is a copy of OriginalMLP with the embed/hidden L2-normalization steps removed for the up and down projections 

Files Changes:
- [mlp_variations.py]
Added EdgeLLMASICMLP class (based on OriginalMLP). Registered variant key "edgellm_asic" in the MLP dictionary so it can be selected via --mlp_variant edgellm_asic

- [asic_quantization_demo.sh]
Demo script updated to exercise the ASIC quantized path (uses --use_edgellm_asic and --mlp_variant edgellm_asic)