### PR TITLE
Added asic attention variant

### DIFF
--- a/demos/asic_quantization_demo.sh
+++ b/demos/asic_quantization_demo.sh
@@ -33,6 +33,10 @@ python3 train.py \
     --quantize_attn_act \
     --quantize_mlp_act \
     --quantize_asic_prenorm \
+    --quantize_asic_attn_softmax_denom \
+    --quantize_asic_attn_softmax_denom_bits 16 \
+    --quantize_asic_attn_softmax_numerator \
+    --quantize_asic_attn_softmax_numerator_bits 8 \
     --linear_variant_attn quantized_linear \
     --linear_variant_mlp quantized_linear \
     --quantize_linear_method symmetric_quant \

--- a/demos/asic_quantization_demo.sh
+++ b/demos/asic_quantization_demo.sh
@@ -18,6 +18,7 @@ python3 train.py \
     --out_dir asic_quant \
     --use_edgellm_asic \
     --mlp_variant edgellm_asic_mlp \
+    --attention_variant edgellm_asic_attn \
     --max_iters 20000 \
     --full_quant_iteration 10000 \
     --dataset "$dataset" \

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -479,6 +479,10 @@ class GPTConfig:
     quantize_asic_prenorm: bool = False
     quantize_asic_offchip_residual: bool = False
     quantize_asic_bits: int = None
+    quantize_asic_attn_softmax_denom: bool = False
+    quantize_asic_attn_softmax_denom_bits: int = None
+    quantize_asic_attn_softmax_numerator: bool = False
+    quantize_asic_attn_softmax_numerator_bits: int = None
     store_activations: bool = False
 
     ## Linear Quantizations

--- a/train_args.py
+++ b/train_args.py
@@ -903,6 +903,10 @@ def parse_args():
     ### ASIC Activations
     model_group.add_argument("--quantize_asic_prenorm", action=argparse.BooleanOptionalAction, default=False, help="quantize the ASIC input to norm")
     model_group.add_argument("--quantize_asic_offchip_residual", action=argparse.BooleanOptionalAction, default=False, help="quantize the ASIC off-chip residual")
+    model_group.add_argument("--quantize_asic_attn_softmax_denom", action=argparse.BooleanOptionalAction, default=False, help="quantize the ASIC attention softmax denominator")
+    model_group.add_argument("--quantize_asic_attn_softmax_denom_bits", type=int, default=16, help="number of bits for ASIC attention softmax denominator quantization")
+    model_group.add_argument("--quantize_asic_attn_softmax_numerator", action=argparse.BooleanOptionalAction, default=False, help="quantize the ASIC attention softmax numerator")
+    model_group.add_argument("--quantize_asic_attn_softmax_numerator_bits", type=int, default=8, help="number of bits for ASIC attention softmax numerator quantization")
 
     ### Default Precisions for ASIC Activations
     model_group.add_argument("--quantize_asic_bits", type=int, default=8, help="number of bits for asic quantization")

--- a/train_args.py
+++ b/train_args.py
@@ -720,6 +720,7 @@ def parse_args():
     # Attention Variations
     attention_variants = [
                           "causal",
+                          "edgellm_asic_attn",
                           "linear",
                           "ssm",
                           "identity",

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -687,13 +687,13 @@ class EdgeLLMASICAttention(nn.Module):
         if self.quantization_attn_dict["quantize_asic_attn_softmax_denom"]:
             num_bits = self.quantization_attn_dict["quantize_asic_attn_softmax_denom_bits"]
             quant_method = self.quantization_attn_dict["activations_quant_method"]
-            inv_sum_per_row = fake_quantize_act(self, "asic_attn_softmax_denom", inv_sum_per_row, num_bits, quant_method, iter_num, causal_mask=True)
+            inv_sum_per_row = fake_quantize_act(self, "asic_attn_softmax_denom", inv_sum_per_row, num_bits, quant_method, iter_num)
 
         # quantize exp
         if self.quantization_attn_dict["quantize_asic_attn_softmax_numerator"]:
             num_bits = self.quantization_attn_dict["quantize_asic_attn_softmax_numerator_bits"]
             quant_method = self.quantization_attn_dict["activations_quant_method"]
-            att = fake_quantize_act(self, "asic_attn_softmax_numerator", att, num_bits, quant_method, iter_num, causal_mask=True)
+            att = fake_quantize_act(self, "asic_attn_softmax_numerator", att, num_bits, quant_method, iter_num)
 
         if self.quantization_attn_dict["quantize_attn_act_pv_mult_v_input"]:
             num_bits = self.quantization_attn_dict["quantize_attn_act_pv_mult_v_input_bits"]

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -420,6 +420,314 @@ class CausalSelfAttention(nn.Module):
 
         return y
 
+class EdgeLLMASICAttention(nn.Module):
+    def __init__(self, config, fire_pos_enc=None):
+        super().__init__()
+
+        self.attn_logit_softcapping = config.attn_logit_softcapping
+
+        self.full_quant_iteration = config.full_quant_iteration
+        self.eval_interval = config.eval_interval
+        self.start_quant_level = config.start_quant_level
+        self.quant_scheduler = config.quant_scheduler
+
+        if (config.n_kv_group is None):
+            config.n_kv_group = config.n_head
+        else:
+            assert config.n_embd % config.n_kv_group == 0
+
+        self.quantization_attn_dict = {}
+        self.quantization_attn_dict["activations_quant_method"] = config.activations_quant_method
+        self.quantization_attn_dict["quantize_asic_attn_softmax_denom"] = config.quantize_asic_attn_softmax_denom
+        self.quantization_attn_dict["quantize_asic_attn_softmax_denom_bits"] = config.quantize_asic_attn_softmax_denom_bits
+        self.quantization_attn_dict["quantize_asic_attn_softmax_numerator"] = config.quantize_asic_attn_softmax_numerator
+        self.quantization_attn_dict["quantize_asic_attn_softmax_numerator_bits"] = config.quantize_asic_attn_softmax_numerator_bits
+        for arg, val in vars(config).items():
+            # Set each attention Activation precision and method
+            if arg.startswith("quantize_") and "attn_act" in arg and arg.endswith("_bits"):
+                self.quantization_attn_dict[arg] = set_variant(val, config.quantize_attn_act_bits)
+            elif arg.startswith("quantize_") and "attn_act" in arg:
+                self.quantization_attn_dict[arg] = set_variant(val, config.quantize_attn_act)
+                if config.store_activations and arg != "quantize_attn_act" and self.quantization_attn_dict[arg]:
+                    create_activation_buffers(self, arg)
+            # Set each attention Linear precision and method
+            elif arg.startswith("quantize_") and "linear_attn" in arg and arg.endswith("_bits"):
+                self.quantization_attn_dict[arg] = set_variant(val, config.quantize_linear_bits)
+            elif arg.startswith("quantize_") and "linear_attn" in arg and arg.endswith("_method"):
+                self.quantization_attn_dict[arg] = set_variant(val, config.quantize_linear_method)
+
+        self.linear_variant_q = linear_dictionary[set_variant(config.linear_variant_q, config.linear_variant_attn)]
+        self.linear_variant_k = linear_dictionary[set_variant(config.linear_variant_k, config.linear_variant_attn)]
+        self.linear_variant_v = linear_dictionary[set_variant(config.linear_variant_v, config.linear_variant_attn)]
+        self.linear_variant_attn_proj = linear_dictionary[set_variant(config.linear_variant_attn_proj, config.linear_variant_attn)]
+
+        # key, query, value projections for all heads, but in a batch
+        self.c_attn_q = self.linear_variant_q(config.n_embd, config.n_embd, config, self.quantization_attn_dict["quantize_linear_attn_q_method"], self.quantization_attn_dict["quantize_linear_attn_q_bits"], bias=config.bias)
+
+        self.n_head = config.n_head
+        if config.n_kv_group is None:
+            self.n_kv_group = config.n_head
+        else:
+            assert config.n_head % config.n_kv_group == 0
+            self.n_kv_group = config.n_kv_group
+
+        self.kv_dim = (config.n_embd // config.n_head) * self.n_kv_group
+        self.c_attn_k = self.linear_variant_k(config.n_embd, self.kv_dim, config, self.quantization_attn_dict["quantize_linear_attn_k_method"], self.quantization_attn_dict["quantize_linear_attn_k_bits"], bias=config.bias)
+        self.c_attn_v = self.linear_variant_v(config.n_embd, self.kv_dim, config, self.quantization_attn_dict["quantize_linear_attn_v_method"], self.quantization_attn_dict["quantize_linear_attn_v_bits"], bias=config.bias)
+        self.c_proj = self.linear_variant_attn_proj(config.n_embd, config.n_embd, config, self.quantization_attn_dict["quantize_linear_attn_proj_method"], self.quantization_attn_dict["quantize_linear_attn_proj_bits"], bias=config.bias)
+
+        # Regularization
+        self.attn_dropout = nn.Dropout(config.dropout)
+        self.resid_dropout = nn.Dropout(config.dropout)
+        self.dropout = config.dropout
+
+        # Embedding
+        self.n_embd = config.n_embd
+        self.dropout = config.dropout
+        self.n_embd = config.n_embd
+        self.gate = config.gate
+        self.use_fire_embeddings = None
+        self.disable_flash_attention = config.disable_flash_attention
+        if config.use_fire_embeddings:
+            self.use_fire_embeddings = config.use_fire_embeddings
+            if fire_pos_enc is not None:
+                self.fire_pos_enc = fire_pos_enc
+                print("shared fire")
+            else:
+                self.fire_pos_enc = FIRE(config, num_heads=config.n_head)
+                print("indiv fire")
+
+        # Rotary Positional Embeddings
+        self.rotary_emb_q = None
+        self.rotary_emb_k = None
+        if config.use_rotary_embeddings:
+            # Note: size is the size of the head dimension
+            if config.rope_variant == "soap":
+                self.sym_rot_num_angles = config.sym_rot_num_angles
+                self.rotary_emb_q = SymmetricalOverlapAngularPositions(config, size=config.n_embd // self.n_head, num_angles=self.sym_rot_num_angles)
+                self.rotary_emb_k = SymmetricalOverlapAngularPositions(config, size=config.n_embd // self.n_head, num_angles=self.sym_rot_num_angles)
+            elif config.rope_variant == "rope":
+                self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd // self.n_head)
+                self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // self.n_head)
+
+        # Sliding window size
+        self.window_size = config.window_size
+        print(f"sliding window size: {self.window_size}")
+
+        # qk_norm and v_norm
+        self.use_qk_norm = config.use_qk_norm
+        self.use_qk_norm_scale = config.use_qk_norm_scale
+        self.use_v_norm = config.use_v_norm
+
+        # Using flex attention
+        self.use_flex_attn = config.use_flex_attn
+
+        # Gating
+        self.gate = config.gate
+
+        # Fire Embeddings
+        self.use_fire_embeddings = None
+        if config.use_fire_embeddings:
+            self.use_fire_embeddings = config.use_fire_embeddings
+            if fire_pos_enc is not None:
+                self.fire_pos_enc = fire_pos_enc
+                print("shared fire")
+            else:
+                self.fire_pos_enc = FIRE(config, num_heads=config.n_head)
+                print("indiv fire")
+
+        # Rotary Positional Embeddings
+        self.rotary_emb_q = None
+        self.rotary_emb_k = None
+        if config.use_rotary_embeddings:
+            # Note: size is the size of the head dimension
+            if config.rope_variant == "soap":
+                self.sym_rot_num_angles = config.sym_rot_num_angles
+                self.rotary_emb_q = SymmetricalOverlapAngularPositions(config, size=config.n_embd // self.n_head, num_angles=self.sym_rot_num_angles)
+                self.rotary_emb_k = SymmetricalOverlapAngularPositions(config, size=config.n_embd // self.n_head, num_angles=self.sym_rot_num_angles)
+            elif config.rope_variant == "rope":
+                self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd // self.n_head)
+                self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // self.n_head)
+
+        # qk norm factor
+        if self.use_qk_norm_scale:
+            L = config.block_size
+            g0 = math.log2(L*L - L)
+            self.qk_norm_factor = nn.Parameter(torch.tensor(g0))
+
+        print("WARNING: using slow attention. Flash Attention requires PyTorch >= 2.0")
+        # causal mask to ensure that attention is only applied to the left in the input sequence
+        self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
+                                    .view(1, 1, config.block_size, config.block_size))
+
+    def forward(self, x, iter_num):
+        B, T, C = x.size() # batch size, sequence length, embedding dimensionality (n_embd)
+
+        if self.quantization_attn_dict["quantize_attn_act_input"]:
+            num_bits = self.quantization_attn_dict["quantize_attn_act_input_bits"]
+            quant_method = self.quantization_attn_dict["activations_quant_method"]
+            x = fake_quantize_act(self, "attn_act_input", x, num_bits, quant_method, iter_num)
+
+        q = self.c_attn_q(x)
+        k = self.c_attn_k(x)
+        v = self.c_attn_v(x)
+
+        if self.window_size is not None:
+            if self.use_flex_attn is not None:
+                self.block_masks = {}
+            else:
+                self.window_mask = torch.ones((1, 1, T, T), device=x.device)
+                self.window_mask = torch.triu(self.window_mask, diagonal=-self.window_size)
+                self.window_mask = self.bias[:,:,:T,:T] * self.window_mask
+
+        if self.gate:
+            if self.n_kv_group == self.n_head:
+                Gating = nn.Linear(self.n_embd, self.n_embd, bias=True, device=x.device)
+                gate_ = torch.sigmoid(Gating(x))
+                q = q * gate_
+                k = k * gate_
+                v = v * gate_
+            else:
+                # TODO: Test more methods to merge Attention Gates with GQA
+                # TODO: Evaluate each method's ability to even out parameter sizes
+                Gating_q = nn.Linear(self.n_embd, self.n_embd, bias=True, device=x.device)
+                Gating_kv = nn.Linear(self.n_embd, self.kv_dim, bias=True, device=x.device)
+                gate_qx = Gating_q(x)
+                gate_q = torch.sigmoid(gate_qx)
+                gate_kv = torch.sigmoid(Gating_kv(gate_qx))
+                q = q * gate_q
+                k = k * gate_kv
+                v = v * gate_kv
+
+        q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, n_h, T, hs)
+        k = k.view(B, T, self.n_kv_group, C // self.n_head).transpose(1, 2) # (B, n_kv, T, hs)
+        v = v.view(B, T, self.n_kv_group, C // self.n_head).transpose(1, 2) # (B, n_kv, T, hs)
+
+        # rotate q and k before evaluating with the heads
+        if (self.rotary_emb_q is not None) and (self.rotary_emb_k is not None):
+            q = self.rotary_emb_q(q)
+            k = self.rotary_emb_k(k)
+
+        y = None
+
+        if self.use_qk_norm:
+            q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
+            k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+
+        if self.use_v_norm:
+            v = v / (v.norm(dim=-1, keepdim=True) + 1e-6)
+
+        if self.quantization_attn_dict["quantize_attn_act_qk_mult_q_input"]:
+            num_bits = self.quantization_attn_dict["quantize_attn_act_qk_mult_q_input_bits"]
+            quant_method = self.quantization_attn_dict["activations_quant_method"]
+            q = fake_quantize_act(self, "attn_act_qk_mult_q_input", q, num_bits, quant_method, iter_num)
+        if self.quantization_attn_dict["quantize_attn_act_qk_mult_k_input"]:
+            num_bits = self.quantization_attn_dict["quantize_attn_act_qk_mult_k_input_bits"]
+            quant_method = self.quantization_attn_dict["activations_quant_method"]
+            k = fake_quantize_act(self, "attn_act_qk_mult_k_input", k, num_bits, quant_method, iter_num)
+
+        att = None
+        # manual implementation of attention
+        head_dim = math.sqrt(k.size(-1))
+        if self.n_head != self.n_kv_group:
+            k_repeated = k.repeat_interleave(self.n_head // self.n_kv_group, dim=1)
+            att = (q @ k_repeated.transpose(-2, -1))
+        else:
+            att = (q @ k.transpose(-2, -1))
+
+        if self.use_qk_norm_scale:
+            att = att * self.qk_norm_factor
+        else:
+            att = att / head_dim
+
+        # apply logit softcapping after qk but before masking
+        if self.attn_logit_softcapping is not None:
+            att = att / self.attn_logit_softcapping
+            att = torch.tanh(att)
+            att = att * self.attn_logit_softcapping
+
+        if self.quantization_attn_dict["quantize_attn_act_softmax_input"]:
+            num_bits = self.quantization_attn_dict["quantize_attn_act_softmax_input_bits"]
+            quant_method = self.quantization_attn_dict["activations_quant_method"]
+            att = fake_quantize_act(self, "attn_act_softmax_input", att, num_bits, quant_method, iter_num)
+
+        # apply masks
+        if self.window_size is not None:
+            # add mask for sliding window attention
+            att = att.masked_fill(self.window_mask == 0, float('-inf'))
+        else:
+            # regular lower triangle attention
+            att = att.masked_fill(self.bias[:,:,:T,:T].to(x.device) == 0, float('-inf'))
+
+        # fire position embeddings
+        if self.use_fire_embeddings is not None:
+            # add learned fire bias
+            att = att + self.fire_pos_enc(x)
+
+        # subtract row-wise max
+        max_per_row = att.max(dim=-1, keepdim=True)[0]
+        att = att - max_per_row
+
+        att = torch.exp(att)
+        
+        # mask again to force future tokens to zero (following numpy implementation)
+        if self.window_size is not None:
+            # add mask for sliding window attention
+            att = att.masked_fill(self.window_mask == 0, 0.0)
+        else:
+            # regular lower triangle attention
+            att = att.masked_fill(self.bias[:,:,:T,:T].to(x.device) == 0, 0.0)
+
+        # sum and normalize
+        sum_per_row = att.sum(dim=-1, keepdim=True)
+        # add small epsilon to avoid divide by zero
+        inv_sum_per_row = (1.0 / (sum_per_row + 1e-12))
+
+        # quantize inv_sum_per_row
+        if self.quantization_attn_dict["quantize_asic_attn_softmax_denom"]:
+            num_bits = self.quantization_attn_dict["quantize_asic_attn_softmax_denom_bits"]
+            quant_method = self.quantization_attn_dict["activations_quant_method"]
+            inv_sum_per_row = fake_quantize_act(self, "asic_attn_softmax_denom", inv_sum_per_row, num_bits, quant_method, iter_num, causal_mask=True)
+
+        # quantize exp
+        if self.quantization_attn_dict["quantize_asic_attn_softmax_numerator"]:
+            num_bits = self.quantization_attn_dict["quantize_asic_attn_softmax_numerator_bits"]
+            quant_method = self.quantization_attn_dict["activations_quant_method"]
+            att = fake_quantize_act(self, "asic_attn_softmax_numerator", att, num_bits, quant_method, iter_num, causal_mask=True)
+
+        if self.quantization_attn_dict["quantize_attn_act_pv_mult_v_input"]:
+            num_bits = self.quantization_attn_dict["quantize_attn_act_pv_mult_v_input_bits"]
+            quant_method = self.quantization_attn_dict["activations_quant_method"]
+            v = fake_quantize_act(self, "attn_act_pv_mult_v_input", v, num_bits, quant_method, iter_num)
+
+        att = self.attn_dropout(att)
+
+        if self.n_head != self.n_kv_group:
+            v_repeated = v.repeat_interleave(self.n_head // self.n_kv_group, dim=1)
+            y = att @ v_repeated # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+        else:
+            y = att @ v # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+
+        # normalize manually
+        y = y * inv_sum_per_row
+
+        if self.quantization_attn_dict["quantize_attn_act_pv_mult_output"]:
+            num_bits = self.quantization_attn_dict["quantize_attn_act_pv_mult_output_bits"]
+            quant_method = self.quantization_attn_dict["activations_quant_method"]
+            y = fake_quantize_act(self, "attn_act_pv_mult_output", y, num_bits, quant_method, iter_num)
+
+        y = y.transpose(1, 2).contiguous().view(B, T, C) # re-assemble all head outputs side by side
+
+        # output projection
+        y = self.resid_dropout(self.c_proj(y))
+
+        if self.quantization_attn_dict["quantize_attn_act_output"]:
+            num_bits = self.quantization_attn_dict["quantize_attn_act_output_bits"]
+            quant_method = self.quantization_attn_dict["activations_quant_method"]
+            y = fake_quantize_act(self, "attn_act_output", y, num_bits, quant_method, iter_num)
+
+        return y
+
 class LinearAttention(nn.Module):
     """ Implements Linear Attention as described in:
     Katharopoulos, A., et al. (2020). Transformers are RNNs:
@@ -1115,6 +1423,7 @@ class Co4Attention(nn.Module):
 
 attention_dictionary = {
     "causal": CausalSelfAttention,
+    "edgellm_asic_attn": EdgeLLMASICAttention,
     "linear": LinearAttention,
     # "ssm": MambaBlock,
     "identity": AttnIdentity,


### PR DESCRIPTION
Added EdgeLLMASIC attention variant

# Changes from causal attention
- Removed torch.flash/flex attention and softmax variants 
- Added granular quantization for softmax numerator (8 bits) and denominator (16 bits)
- Manually implemented Softmax to match numpy implementation

Sample intermediate outputs:
<img width="800" height="267" alt="image" src="https://github.com/user-attachments/assets/fb9ee2b3-bcf3-4bc5-82f0-a854edbf2a66" />
<img width="868" height="268" alt="image" src="https://github.com/user-attachments/assets/ecebef15-ec58-4c67-b513-b97851b27266" />
<img width="722" height="268" alt="image" src="https://github.com/user-attachments/assets/db5cad75-3bd4-4752-b7c8-8f0c3e14b660" />
<img width="809" height="265" alt="image" src="https://github.com/user-attachments/assets/94437513-b142-4537-a871-34a5aba17fd1" />
