### PR TITLE
Add common_group handling to experiment runner

### DIFF
--- a/explorations/sample.yaml
+++ b/explorations/sample.yaml
@@ -7,6 +7,11 @@ parameter_groups:
   - use_rotary_embeddings: [false]
     use_abs_pos_embeddings: [true]
 
+# common_group: parameters applied to every run but omitted from run names
+common_group:
+  learning_rate: [0.0003]
+  weight_decay: [0.1]
+
 # base hyperparameters
 max_iters: [250]
 n_layer: [6]


### PR DESCRIPTION
This adds a "common_group" to the yaml files that are by default skipped (should contain no variations), this will help prevent csv filesnames from getting too long.