### PR TITLE
Added FlashNorm option to ASIC

### DIFF
--- a/demos/asic_quantization_demo.sh
+++ b/demos/asic_quantization_demo.sh
@@ -30,7 +30,8 @@ python3 train.py \
     --no-bias \
     --dtype bfloat16 \
     --quantization_warmup_iters 0 \
-    --use_pre_ln \
+    --no-use_pre_ln \
+    --use_flash_norm \
     --quantize_attn_act \
     --quantize_mlp_act \
     --quantize_asic_prenorm \

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -366,6 +366,7 @@ class GPTConfig:
     # Layernorm Alternatives and Options
     norm_variant_attn: str = "rmsnorm"
     norm_variant_output: str = "rmsnorm"
+    use_flash_norm: bool = False
 
     norm_variant_wte: str | None = None
     norm_wte_radius: float | None = None

--- a/train_args.py
+++ b/train_args.py
@@ -637,6 +637,7 @@ def parse_args():
 
     model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=norm_variations)
     model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=norm_variations)
+    model_group.add_argument("--use_flash_norm", type=bool, default=None, action=argparse.BooleanOptionalAction)
 
     ### WTE and Abs Pos Embedding Post Norms (optional, and default None)
     model_group.add_argument("--norm_variant_wte", type=str, default=None, choices=norm_variations)

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -181,6 +181,8 @@ def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     # Attn Pre-LN
     x_attn_in = x_quantized_residual
     if block.use_pre_ln_attn:
+        if block.use_flash_norm:
+            print("Warning: FlashNorm is used with pre_ln, causing double normalization.")
         x_attn_in = block.pre_ln_attn(x_attn_in)
 
     # Attn Operation
@@ -207,6 +209,8 @@ def edgellm_asic_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
 
     # MLP Pre-LN
     if block.use_pre_ln_mlp:
+        if block.use_flash_norm:
+            print("Warning: FlashNorm is used with pre_ln, causing double normalization.")
         x_mlp_in = block.pre_ln_mlp(x_mlp_in)
 
     # MLP Operation
@@ -377,6 +381,8 @@ class Block(nn.Module):
         # Forward variation choice
         self.use_parallel_mlp = getattr(config, "use_parallel_mlp", False)
         self.use_edgellm_asic = getattr(config, "use_edgellm_asic", False)
+
+        self.use_flash_norm = getattr(config, "use_flash_norm", False)
 
         if self.use_parallel_mlp:
             variant = "parallel_mlp"

--- a/variations/linear_variations.py
+++ b/variations/linear_variations.py
@@ -412,7 +412,7 @@ def wrap_with_flashnorm(linear_cls, config):
         return linear_cls
     
     class FlashNormWrapper(nn.Module):
-        def __init__(self, in_features, out_features, config=None, **kwargs):
+        def __init__(self, in_features, out_features, config=None, method=None, bits=None, bias=True, **kwargs):
             super().__init__()
             self.in_features = in_features
             self.out_features = out_features
@@ -421,7 +421,7 @@ def wrap_with_flashnorm(linear_cls, config):
             self.gain = nn.Parameter(torch.ones(in_features))
             
             # Instantiate the base linear (QuantizedLinear, BitLinear, etc.)
-            self.linear = linear_cls(in_features, out_features, config, **kwargs)
+            self.linear = linear_cls(in_features, out_features, config=config, method=method, bits=bits, bias=bias, **kwargs)
             
             # Fuse gain into weights
             self._fuse_gain_into_weights()

--- a/variations/linear_variations.py
+++ b/variations/linear_variations.py
@@ -398,6 +398,54 @@ class KAL_Net(nn.Module):
             x = self.base_activation(layer_norm(combined_output))
 
         return x
+    
+def wrap_with_flashnorm(linear_cls, config):
+    """
+    Wraps any linear class with FlashNorm-style deferred RMS normalization.
+    Only applies if config.use_flash_norm is True.
+
+    Based on "FlashNorm: fast normalization for LLMs"
+    Source: https://arxiv.org/pdf/2407.09577
+    Key insight: RMSNorm(x) @ W = (x @ W) / RMS(x) when bias=0
+    """
+    if not getattr(config, "use_flash_norm", False):
+        return linear_cls
+    
+    class FlashNormWrapper(nn.Module):
+        def __init__(self, in_features, out_features, config=None, **kwargs):
+            super().__init__()
+            self.in_features = in_features
+            self.out_features = out_features
+            
+            # RMSNorm gain parameter
+            self.gain = nn.Parameter(torch.ones(in_features))
+            
+            # Instantiate the base linear (QuantizedLinear, BitLinear, etc.)
+            self.linear = linear_cls(in_features, out_features, config, **kwargs)
+            
+            # Fuse gain into weights
+            self._fuse_gain_into_weights()
+        
+        def _fuse_gain_into_weights(self):
+            """Merge gain into weight matrix: W* = W @ diag(gain)"""
+            if hasattr(self.linear, 'weight') and self.linear.weight is not None:
+                with torch.no_grad():
+                    # Broadcast multiply: each output row scaled by corresponding gain
+                    self.linear.weight.data = self.linear.weight.data * self.gain.unsqueeze(0)
+        
+        def forward(self, x):
+            rms = x.norm(2, dim=-1, keepdim=True) / math.sqrt(x.size(-1))
+            
+            # Forward through base linear (gain already fused into weights)
+            out = self.linear(x)
+            
+            # Deferred normalization (happens after matmul)
+            out = out / rms
+            
+            return out
+    
+    FlashNormWrapper.__name__ = f"FlashNorm_{linear_cls.__name__}"
+    return FlashNormWrapper
 
 linear_dictionary = {
     "linear": WrappedLinear,
@@ -405,5 +453,5 @@ linear_dictionary = {
     "bitlinear_optimized": BitLinearOptimized,
     "bitlinear_1p58": BitLinear1p58,
     "kan": KAL_Net,
-    "quantized_linear": QuantizedLinear
+    "quantized_linear": QuantizedLinear,
 }

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 from torch.nn import functional as F
 
 from variations.activation_variations import activation_dictionary
-from variations.linear_variations import linear_dictionary
+from variations.linear_variations import linear_dictionary, wrap_with_flashnorm
 from quantization.quantize import fake_quantize_act
 from quantization.quant_utils import set_variant, create_activation_buffers
 
@@ -186,7 +186,7 @@ class EdgeLLMASICMLP(nn.Module):
             self.register_buffer("activation_y_offset", torch.tensor(config.mlp_y_offset))
 
         # Sets the class of linear for MLP
-        self.linear_variant_mlp_up = linear_dictionary[set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)]
+        self.linear_variant_mlp_up = wrap_with_flashnorm(linear_dictionary[set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)], config)
         self.linear_variant_mlp_down = linear_dictionary[set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)]
 
         self.quantization_mlp_dict = {}


### PR DESCRIPTION
For an ASIC RMSNorm implementation, this PR introduces FlashNorm-style deferred normalization. 

# Changes
- Added --use_flash_norm flag
- Introduced FlashNorm wrapper in variations/linear_variations.py.
- This function dynamically wraps any linear class (e.g., QuantizedLinear, BitLinear, WrappedLinear) with FlashNorm-style deferred RMS normalization.

# FlashNorm
- defers normalization until after the matrix multiply
- merges gain parameter with weight