### PR TITLE
Fix all gradient issue for Bit-Balanced Adaptive Learner, add quantization tools, analysis scripts with tensorboard integration

### DIFF
--- a/analysis/plot_bit_alloc.py
+++ b/analysis/plot_bit_alloc.py
@@ -1,0 +1,101 @@
+# scripts/plot_bit_alloc.py
+import os
+import csv
+import argparse
+from collections import defaultdict
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def read_csv(path):
+    with open(path, "r") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run_dir", type=str, required=True, help="e.g. out/repro_adaptive_bitbalanced_w1e-5")
+    ap.add_argument("--out_dir", type=str, default=None, help="where to save figures; default: <run_dir>/bit_alloc/figs")
+    args = ap.parse_args()
+
+    if os.path.exists(os.path.join(args.run_dir, "bit_layers.csv")):
+        bit_dir = args.run_dir
+    else:
+        bit_dir = os.path.join(args.run_dir, "bit_alloc")
+        
+    layers_csv = os.path.join(bit_dir, "bit_layers.csv")
+    types_csv  = os.path.join(bit_dir, "bit_types.csv")
+    events_csv = os.path.join(bit_dir, "bit_events.csv")
+
+    out_dir = args.out_dir or os.path.join(bit_dir, "figs")
+    os.makedirs(out_dir, exist_ok=True)
+
+    layers = read_csv(layers_csv)
+    types_ = read_csv(types_csv)
+
+    # -------- plot: per-layer avg_b_int vs iter --------
+    by_layer = defaultdict(list)
+    for r in layers:
+        it = int(float(r["iter"]))
+        layer = int(float(r["layer"]))
+        b = float(r["avg_b_int_weighted"])
+        by_layer[layer].append((it, b))
+
+    plt.figure()
+    for layer in sorted(by_layer.keys()):
+        xs = [x for x, _ in sorted(by_layer[layer], key=lambda t: t[0])]
+        ys = [y for _, y in sorted(by_layer[layer], key=lambda t: t[0])]
+        plt.plot(xs, ys, label=f"layer {layer}")
+    plt.xlabel("iter")
+    plt.ylabel("avg_b_int (weighted)")
+    plt.title("Per-layer average integer bitwidth")
+    plt.legend()
+    fig_path = os.path.join(out_dir, "layer_avg_b_int.png")
+    plt.savefig(fig_path, dpi=160)
+    plt.close()
+
+    # -------- plot: attn vs mlp avg_b_int vs iter --------
+    by_type = defaultdict(list)
+    for r in types_:
+        it = int(float(r["iter"]))
+        fam = r["family"]
+        b = float(r["avg_b_int_weighted"])
+        by_type[fam].append((it, b))
+
+    plt.figure()
+    for fam in sorted(by_type.keys()):
+        xs = [x for x, _ in sorted(by_type[fam], key=lambda t: t[0])]
+        ys = [y for _, y in sorted(by_type[fam], key=lambda t: t[0])]
+        plt.plot(xs, ys, label=fam)
+    plt.xlabel("iter")
+    plt.ylabel("avg_b_int (weighted)")
+    plt.title("Attention vs MLP average integer bitwidth")
+    plt.legend()
+    fig_path = os.path.join(out_dir, "type_avg_b_int.png")
+    plt.savefig(fig_path, dpi=160)
+    plt.close()
+
+    # -------- report: who drops bits first --------
+    if os.path.exists(events_csv):
+        events = read_csv(events_csv)
+        first_drop = {}
+        for e in events:
+            name = e["module_name"]
+            it = int(float(e["iter"]))
+            if name not in first_drop:
+                first_drop[name] = it
+
+        ranked = sorted(first_drop.items(), key=lambda kv: kv[1])
+        txt_path = os.path.join(out_dir, "first_drop_ranking.txt")
+        with open(txt_path, "w") as f:
+            for name, it in ranked:
+                f.write(f"{it}\t{name}\n")
+        print("Saved:", txt_path)
+
+    print("Saved figures to:", out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/plot_bit_loss_breakdown.py
+++ b/analysis/plot_bit_loss_breakdown.py
@@ -1,0 +1,68 @@
+import sys, os
+import pandas as pd
+import matplotlib.pyplot as plt
+
+run_dir = sys.argv[1]
+w = float(sys.argv[2])
+
+layers = pd.read_csv(os.path.join(run_dir, "bit_layers.csv"))
+mods   = pd.read_csv(os.path.join(run_dir, "bit_modules.csv"))
+
+# ---- total params per iter ----
+total_param = layers.groupby("iter")["param_count"].sum().rename("total_param")
+layers = layers.merge(total_param, on="iter", how="left")
+
+# ---- average bit loss (global) ----
+avg_bit = layers.groupby("iter").apply(
+    lambda g: g["total_bits_int"].sum() / g["param_count"].sum()
+).rename("avg_b_int").reset_index()
+
+avg_bit["avg_bit_loss"] = w * avg_bit["avg_b_int"]
+
+plt.figure()
+plt.plot(avg_bit["iter"], avg_bit["avg_bit_loss"])
+plt.xlabel("iter"); plt.ylabel("avg_bit_loss")
+plt.title("Average bit loss (normalized)")
+plt.tight_layout()
+plt.savefig("avg_bit_loss.png", dpi=200)
+plt.close()
+
+# ---- per-layer contribution ----
+layers["layer_bit_loss"] = w * (layers["total_bits_int"] / layers["total_param"])
+
+plt.figure()
+for lid, g in layers.groupby("layer"):
+    g = g.sort_values("iter")
+    plt.plot(g["iter"], g["layer_bit_loss"], label=f"layer {int(lid)}")
+plt.legend()
+plt.xlabel("iter"); plt.ylabel("layer_bit_loss")
+plt.title("Per-layer bit loss contribution (normalized)")
+plt.tight_layout()
+plt.savefig("layer_bit_loss.png", dpi=200)
+plt.close()
+
+# ---- per-module contribution (top-k by average) ----
+mods["module_total_bits_int"] = mods["b_int"] * mods["param_count"]
+total_param_m = mods.groupby("iter")["param_count"].sum().rename("total_param")
+mods = mods.merge(total_param_m, on="iter", how="left")
+mods["module_bit_loss"] = w * (mods["module_total_bits_int"] / mods["total_param"])
+
+topk = (
+    mods.groupby("module_name")["module_bit_loss"].mean()
+    .sort_values(ascending=False)
+    .head(10)
+    .index
+)
+
+plt.figure(figsize=(10,6))
+for name in topk:
+    g = mods[mods["module_name"]==name].sort_values("iter")
+    plt.plot(g["iter"], g["module_bit_loss"], label=name)
+plt.legend(fontsize=7)
+plt.xlabel("iter"); plt.ylabel("module_bit_loss")
+plt.title("Top-10 module bit loss contributions (normalized)")
+plt.tight_layout()
+plt.savefig("top10_module_bit_loss.png", dpi=200)
+plt.close()
+
+print("Saved: avg_bit_loss.png, layer_bit_loss.png, top10_module_bit_loss.png")

--- a/sample.py
+++ b/sample.py
@@ -1,6 +1,7 @@
 # sample.py
 import argparse
 import importlib.util
+import inspect
 import json
 import math
 import os
@@ -1178,7 +1179,9 @@ def main():
             checkpoint['model_args']['apply_vector_file']= "temp.npy"
             checkpoint['model_args']['apply_vector_at_layer_idx']= args.apply_to_layer_idx
             checkpoint['model_args']['apply_vector_scaling_factor']= args.steering_vector_scaling_factor
-        gptconf = GPTConfig(**checkpoint['model_args'])
+        allowed = set(inspect.signature(GPTConfig.__init__).parameters.keys()) - {"self"}
+        model_args = {k: v for k, v in checkpoint["model_args"].items() if k in allowed}
+        gptconf = GPTConfig(**model_args)
         model = GPT(gptconf)
         state_dict = checkpoint['model']
         unwanted_prefix = '_orig_mod.'

--- a/train.py
+++ b/train.py
@@ -16,6 +16,10 @@ from rich.console import Group
 from rich.console import Console
 from rich.text import Text
 from rich.live import Live
+import inspect
+import random
+from utils.bit_allocation_logger import BitAllocationLogger
+from utils.bit_logger import BitLogger
 
 
 from train_variations.optimizer_variants import (
@@ -420,29 +424,76 @@ class Trainer:
 
         self.raw_model = self.model.module if self.ddp else self.model
 
-        if hasattr(self.loss_fn, "set_model"):
-            self.loss_fn.set_model(self.raw_model)
-
+        # -----------------------------
+        # (1) Decide run_name EARLY (even if tensorboard_log is False)
+        # -----------------------------
         timestamp_prefix = time.strftime("%Y%m%d-%H%M%S")
         if self.args.timestamp:
             timestamp_prefix = self.args.timestamp
 
-        # Tensorboard
+        # give tensorboard_run_name a default
+        if getattr(self.args, "tensorboard_run_name", None) is None:
+            self.args.tensorboard_run_name = f"{timestamp_prefix}"
+
+        run_name = self.args.tensorboard_run_name
+
+        # make sure writer always exists as an attribute
+        self.writer = None
+
+        # -----------------------------
+        # (2) Tensorboard writer
+        # -----------------------------
         if self.args.tensorboard_log:
-            # 1) Give the run a safe default name when the user did not supply one
-            if self.args.tensorboard_run_name is None:
-                self.args.tensorboard_run_name = f"{timestamp_prefix}"
-
-            run_name = self.args.tensorboard_run_name
-
-            # 2) Derive a *filename-safe* dataset tag (slashes ⇒ underscores)
             sanitized_dataset = self.args.dataset.replace("/", "_")
 
-            # 3) Store a matching, safe CSV filename for later use
+            # optional: align csv naming with tb naming
             if self.args.csv_log:
                 self.args.csv_name = f"{sanitized_dataset}_{run_name}"
+
             log_subpath = os.path.join(self.args.tensorboard_log_dir, run_name)
             self.writer = SummaryWriter(log_subpath)
+
+        # -----------------------------
+        # (3) BitLogger (CSV tables)
+        # -----------------------------
+        bit_run_id = getattr(self.args, "bit_log_run_id", None) or run_name
+
+        self.bit_logger = BitLogger(
+            model=self.raw_model,
+            out_dir=self.args.out_dir,
+            run_id=bit_run_id,
+            dataset_name=getattr(self.args, "dataset", ""),
+            log_dir=getattr(self.args, "bit_log_dir", None),
+            log_every=getattr(self.args, "bit_log_every", 20),
+            overwrite=getattr(self.args, "bit_log_overwrite", False),
+            is_master=self.master_process,
+            enabled=True,
+        )
+
+        if self.master_process:
+            print(f"[bit_logger] writing csvs to: {self.bit_logger.get_run_dir()}")
+
+        # -----------------------------
+        # (4) LossFn can access model (needed for bit penalty stats)
+        # -----------------------------
+        if hasattr(self.loss_fn, "set_model"):
+            self.loss_fn.set_model(self.raw_model)
+
+        # -----------------------------
+        # (5) BitAllocationLogger (TB optional) — keep it if you want TB histograms
+        # -----------------------------
+        if self.master_process:
+            self.bit_alloc_logger = BitAllocationLogger(
+                model=self.raw_model,
+                out_dir=self.args.out_dir,
+                writer=self.writer if self.args.tensorboard_log else None,
+                log_per_module_tb=True,
+                log_hist_tb=True,
+            )
+        else:
+            self.bit_alloc_logger = None
+
+
 
         # Wandb
         if self.args.wandb_log and self.master_process:
@@ -1305,6 +1356,20 @@ class Trainer:
             self.writer.add_scalar(
                 f"{target_dataset}/bit_loss_penalty_tokens", penalty_term, tokens_trained
             )
+        
+        if total_bits is not None and getattr(self, "tracked_bit_param_count", 0) > 0:
+            avg_bitwidth = total_bits / float(self.tracked_bit_param_count)
+            self.writer.add_scalar(f"{target_dataset}/bit_avg_bitwidth", avg_bitwidth, self.iter_num)
+            self.writer.add_scalar(f"{target_dataset}/bit_avg_bitwidth_tokens", avg_bitwidth, tokens_trained)
+
+            # Porportion of compression (<1 meaning saving more than 8 bit)
+            self.writer.add_scalar(
+                f"{target_dataset}/bit_compression_vs_8bit",
+                avg_bitwidth / 8.0,
+                self.iter_num
+            )
+
+        
 
     def log_metrics(self, losses, running_mfu, epoch, tokens_trained, target_dataset, val_better_than_chance):
 
@@ -1706,6 +1771,16 @@ class Trainer:
             if self.args.export_scale_matrices_each_eval and self.args.export_scale_matrices_npz:
                 self.raw_model.export_scale_matrices(self.args.export_scale_matrices_npz)
 
+            # Snapshot per-layer/per-matrix bit allocations
+            if self.master_process and (self.bit_alloc_logger is not None):
+                # Use self.tokens_trained for single dataset
+                tokens = self.tokens_trained
+                self.bit_alloc_logger.snapshot(
+                    iter_num=self.iter_num,
+                    tokens_trained=tokens,
+                    dataset=current_dataset if current_dataset is not None else "dataset",
+                )
+
         return losses, num_steps_with_worse_loss
 
     def log_training_step(self, lossf, training_losses, running_mfu, current_epoch, prior_dataset, dt):
@@ -1957,10 +2032,39 @@ class Trainer:
                         approx_gns_results = gather_hook_results(self.model)
                         self.gns_ema.update(*gns_utils.gnsify(approx_gns_results, self.args.batch_size, ddp=self.ddp))
 
-
-
-                if self.args.grad_clip != 0.0:
+                # ---- Unscale ONCE (so logged grads are real grads, not scaled grads) ----
+                if self.scaler.is_enabled():
                     self.scaler.unscale_(self.optimizer)
+                    
+                # ---- Log bit tables (CSV) after unscale, before clipping/step ----
+                if self.master_process and getattr(self, "bit_logger", None) is not None:
+                    self.bit_logger.maybe_log(
+                        iter_num=self.iter_num,
+                        tokens_trained=self.tokens_trained,
+                        phase="train",
+                        dataset_name=prior_dataset if prior_dataset is not None else "dataset",
+                    )
+                
+
+                # ---- Log bit_param gradients (after unscale, before clipping/step) ----
+                if self.master_process and getattr(self, "bit_alloc_logger", None) is not None:
+                    if (self.iter_num % self.args.bit_log_every == 0):
+                        top = self.bit_alloc_logger.snapshot_grads(
+                            iter_num=self.iter_num,
+                            tokens_trained=self.tokens_trained,
+                            dataset=prior_dataset if prior_dataset is not None else "dataset",
+                            topk=8,
+                        )
+                        # Optional Printing top k gradient
+                        self.console.print("[bit_grad] top modules by |grad|:")
+                        for abs_g, name, layer_id, fam, role, b_int, b_cont, b_param in top:
+                            self.console.print(
+                                f"  |g|={abs_g:.3e}  b_int={b_int:.0f}  b_cont={b_cont:.3f}  "
+                                f"layer={layer_id}  {fam}/{role}  {name}"
+                            )
+
+                # ---- Optional clipping (already unscaled) ----
+                if self.args.grad_clip != 0.0:
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.args.grad_clip)
 
                 if isinstance(self.optimizer, ActRegularizedAdamW):

--- a/train.py
+++ b/train.py
@@ -1362,7 +1362,7 @@ class Trainer:
             self.writer.add_scalar(f"{target_dataset}/bit_avg_bitwidth", avg_bitwidth, self.iter_num)
             self.writer.add_scalar(f"{target_dataset}/bit_avg_bitwidth_tokens", avg_bitwidth, tokens_trained)
 
-            # Porportion of compression (<1 meaning saving more than 8 bit)
+            # Aggresiveness of compression (<1 meaning saving more than 8 bit)
             self.writer.add_scalar(
                 f"{target_dataset}/bit_compression_vs_8bit",
                 avg_bitwidth / 8.0,

--- a/train.py
+++ b/train.py
@@ -294,7 +294,7 @@ class Trainer:
                             self.dataset_perm[d] = np.arange(available)
                         self.dataset_ptr[d] = 0
 
-            gptconf = GPTConfig(**self.model_args)
+            gptconf = GPTConfig(**self._filter_gptconfig_kwargs(self.model_args))
             self.model = GPT(gptconf)
             self.model.to(self.device)
 
@@ -328,7 +328,7 @@ class Trainer:
                 self.model_args[k] = altered_model_args[k]
 
             self.load_data()
-            gptconf = GPTConfig(**self.model_args)
+            gptconf = GPTConfig(**self._filter_gptconfig_kwargs(self.model_args))
             self.model = GPT(gptconf)
 
             ## TODO: Add ability here to swap WTE factors.
@@ -375,7 +375,7 @@ class Trainer:
             for k in variation_dict:
                 self.model_args[k] = variation_dict[k]
 
-            gptconf = GPTConfig(**self.model_args)
+            gptconf = GPTConfig(**self._filter_gptconfig_kwargs(self.model_args))
             self.model = GPT.from_pretrained(gptconf, model_type=self.args.gpt2_type)
             self.model.to(self.device)
             self.load_data()
@@ -502,6 +502,10 @@ class Trainer:
             wandb.init(project=self.args.wandb_project, name=self.args.wandb_run_name, config=self.args)
         self.load_tokenizer()
 
+    def _filter_gptconfig_kwargs(self, d: dict) -> dict:
+        sig = inspect.signature(GPTConfig.__init__)
+        allowed = set(sig.parameters.keys()) - {"self"}
+        return {k: v for k, v in d.items() if k in allowed}
 
     def _initialize_teacher_if_needed(self):
         teacher_path = getattr(self.args, "distillation_teacher_ckpt", None)

--- a/train_args.py
+++ b/train_args.py
@@ -20,6 +20,20 @@ def parse_args():
     model_group = parser.add_argument_group('model_group')
     training_group = parser.add_argument_group('training_group')
     logging_group = parser.add_argument_group('logging_group')
+    
+    # bit logging
+    parser.add_argument("--bit_log_every", type=int, default=20,
+                        help="Log bit/grad tables every N optimizer steps.")
+    parser.add_argument("--bit_log_dir", type=str, default=None,
+                        help="Where to write bit csv logs. Default: <out_dir>/bit_logs/<run_id>/")
+    parser.add_argument("--bit_log_overwrite", action="store_true",
+                        help="Overwrite existing bit csvs (recommended for debugging).")
+    parser.add_argument("--bit_log_run_id", type=str, default=None,
+                        help="Explicit run id for bit logs. Default: timestamp or tensorboard run name.")
+
+    parser.add_argument("--bit_grad_source_debug", action="store_true",
+                    help="Debug: compare grad from main loss vs bit penalty (slow).")
+
 
     # MLP Bias Configuration
     model_group.add_argument('--mlp_up_bias', default=None, action=argparse.BooleanOptionalAction, help='Whether to use bias in MLP up projections. If None, uses global bias setting.')
@@ -1265,6 +1279,54 @@ def parse_args():
     model_group.add_argument('--use_gradient_checkpointing', default=False, action=argparse.BooleanOptionalAction, help="Memory efficient training, but takes longer time to train due to trading compute time for memory efficiency. For best memory tradeoff omit the --compile flag. For medium memory tradeoff add --compile.")
     model_group.add_argument('--recompute_backward_pass', default=False, action=argparse.BooleanOptionalAction, help="Recomputes for the backward pass, must use with --use_gradient_checkpointing")
 
+    ## Learned Position Embeddings
+    model_group.add_argument( '--n_lpe', type=int, default=0, help='Number of LearnedPositionEmbedding modules to instantiate (one per transformer block)')
+
+    model_group.add_argument('--lpe_block_size', default=256, type=int)
+    model_group.add_argument('--lpe_n_layer', default=3, type=int)
+    model_group.add_argument('--lpe_n_head', default=6, type=int)
+    model_group.add_argument('--lpe_n_kv_group', default=None, type=int)
+    model_group.add_argument('--lpe_use_abs_pos_embeddings', default=True, action=argparse.BooleanOptionalAction, help='Whether LPE modules add absolute position embeddings')
+    model_group.add_argument('--lpe_use_rotary_embeddings', default=True, action=argparse.BooleanOptionalAction, help='Whether LPE modules add absolute position embeddings')
+    model_group.add_argument('--lpe_n_qk_head_dim', default=None, type=int)
+    model_group.add_argument('--lpe_n_v_head_dim', default=None, type=int)
+    model_group.add_argument("--lpe_mlp_size", type=int, default=None, help="If not None, is used instead of mlp_expansion_factor")
+
+    model_group.add_argument('--target_layer_in_lpe', default=0, type=int)
+    model_group.add_argument('--target_layer_out_lpe', default=0, type=int)
+
+    model_group.add_argument(
+        "--lpe_attention_variant",
+        type=str,
+        default="causal",
+        choices=attention_variants,
+        help="Which attention variant to use for the Transformer blocks."
+    )
+    # Learnable Gradient
+    model_group.add_argument('--use_learned_gradient', default=False, action=argparse.BooleanOptionalAction,
+                             help="Mount learned gradient on each round point")
+    model_group.add_argument('--learned_gradient_bits', type=int, default=8,
+                             help="Bit width for learned gradient")
+    model_group.add_argument('--learned_gradient_quantize_activations', default=True, action=argparse.BooleanOptionalAction,
+                             help="Quantizing Activation? Default Yes")
+    model_group.add_argument('--learned_gradient_quantize_weights', default=False, action=argparse.BooleanOptionalAction,
+                             help="Quantizing Weight? Default No")
+
+    training_group.add_argument('--outer_k', type=int, default=10,
+                                help="A outer step ever k steps")
+    training_group.add_argument('--theta_lr', type=float, default=1e-4,
+                                help="Learning Rate of MLP parameters")
+    training_group.add_argument('--gs_hidden', type=int, default=32,
+                                help="Hidden width of MLP")
+    training_group.add_argument('--gs_bound_low', type=float, default=0.5,
+                                help="MLP output lower bound")
+    training_group.add_argument('--gs_bound_high', type=float, default=1.5,
+                                help="MLP output upper bound")
+    training_group.add_argument('--use_linear_fakequant', default=False, action=argparse.BooleanOptionalAction,
+                            help="Start standard quantization (STE)")
+
+
+    model_group.add_argument("--lpe_mlp_variant", type=str, default="mlp", choices=mlp_variants, help="MLP variation type")
     # Optimizer args
     training_group.add_argument('--max_iters', default=3500, type=int)
     training_group.add_argument('--weight_decay', default=1e-1, type=float)

--- a/train_args.py
+++ b/train_args.py
@@ -1279,29 +1279,7 @@ def parse_args():
     model_group.add_argument('--use_gradient_checkpointing', default=False, action=argparse.BooleanOptionalAction, help="Memory efficient training, but takes longer time to train due to trading compute time for memory efficiency. For best memory tradeoff omit the --compile flag. For medium memory tradeoff add --compile.")
     model_group.add_argument('--recompute_backward_pass', default=False, action=argparse.BooleanOptionalAction, help="Recomputes for the backward pass, must use with --use_gradient_checkpointing")
 
-    ## Learned Position Embeddings
-    model_group.add_argument( '--n_lpe', type=int, default=0, help='Number of LearnedPositionEmbedding modules to instantiate (one per transformer block)')
 
-    model_group.add_argument('--lpe_block_size', default=256, type=int)
-    model_group.add_argument('--lpe_n_layer', default=3, type=int)
-    model_group.add_argument('--lpe_n_head', default=6, type=int)
-    model_group.add_argument('--lpe_n_kv_group', default=None, type=int)
-    model_group.add_argument('--lpe_use_abs_pos_embeddings', default=True, action=argparse.BooleanOptionalAction, help='Whether LPE modules add absolute position embeddings')
-    model_group.add_argument('--lpe_use_rotary_embeddings', default=True, action=argparse.BooleanOptionalAction, help='Whether LPE modules add absolute position embeddings')
-    model_group.add_argument('--lpe_n_qk_head_dim', default=None, type=int)
-    model_group.add_argument('--lpe_n_v_head_dim', default=None, type=int)
-    model_group.add_argument("--lpe_mlp_size", type=int, default=None, help="If not None, is used instead of mlp_expansion_factor")
-
-    model_group.add_argument('--target_layer_in_lpe', default=0, type=int)
-    model_group.add_argument('--target_layer_out_lpe', default=0, type=int)
-
-    model_group.add_argument(
-        "--lpe_attention_variant",
-        type=str,
-        default="causal",
-        choices=attention_variants,
-        help="Which attention variant to use for the Transformer blocks."
-    )
     # Learnable Gradient
     model_group.add_argument('--use_learned_gradient', default=False, action=argparse.BooleanOptionalAction,
                              help="Mount learned gradient on each round point")
@@ -1326,7 +1304,7 @@ def parse_args():
                             help="Start standard quantization (STE)")
 
 
-    model_group.add_argument("--lpe_mlp_variant", type=str, default="mlp", choices=mlp_variants, help="MLP variation type")
+    
     # Optimizer args
     training_group.add_argument('--max_iters', default=3500, type=int)
     training_group.add_argument('--weight_decay', default=1e-1, type=float)

--- a/utils/bit_allocation_logger.py
+++ b/utils/bit_allocation_logger.py
@@ -1,0 +1,465 @@
+# utils/bit_allocation_logger.py
+import os
+import csv
+import re
+import time
+from collections import defaultdict
+from typing import Optional, Dict, Any, List, Tuple
+
+import torch
+
+
+_LAYER_RE = re.compile(r"(?:^|\.)(?:transformer\.)?h\.(\d+)(?:\.|$)")
+
+
+def _safe_tb_name(name: str) -> str:
+    return name.replace(".", "/")
+
+
+def _parse_module_name(name: str) -> Tuple[int, str, str]:
+    """
+    return (layer_id, family, role)
+    family: attn / mlp / other
+    role:  attn_q / attn_k / attn_v / attn_proj / mlp_fc / mlp_proj / other
+    """
+    m = _LAYER_RE.search(name)
+    layer_id = int(m.group(1)) if m else -1
+
+    family = "other"
+    role = "other"
+
+    if ".attn." in name:
+        family = "attn"
+        if "c_attn_q" in name:
+            role = "attn_q"
+        elif "c_attn_k" in name:
+            role = "attn_k"
+        elif "c_attn_v" in name:
+            role = "attn_v"
+        elif "c_proj" in name:
+            role = "attn_proj"
+        else:
+            role = "attn_other"
+    elif ".mlp." in name:
+        family = "mlp"
+        if "c_fc" in name:
+            role = "mlp_fc"
+        elif "c_proj" in name:
+            role = "mlp_proj"
+        else:
+            role = "mlp_other"
+
+    return layer_id, family, role
+
+
+class BitAllocationLogger:
+    """
+    Log bit choice of AdaptiveBitLinear
+    - bit_param, b_cont, b_int in each module
+    - attn vs mlp weighted average mean
+    - bit bounding per tensor
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        out_dir: str,
+        writer: Optional[Any] = None,
+        log_per_module_tb: bool = True,
+        log_hist_tb: bool = True,
+    ):
+        self.model = model
+        self.writer = writer
+        self.log_per_module_tb = log_per_module_tb
+        self.log_hist_tb = log_hist_tb
+
+        self.out_dir = out_dir
+        self.save_dir = os.path.join(out_dir, "bit_alloc")
+        os.makedirs(self.save_dir, exist_ok=True)
+
+        self.modules_csv = os.path.join(self.save_dir, "bit_modules.csv")
+        self.layers_csv = os.path.join(self.save_dir, "bit_layers.csv")
+        self.types_csv = os.path.join(self.save_dir, "bit_types.csv")
+        self.events_csv = os.path.join(self.save_dir, "bit_events.csv")
+        self.grads_csv  = os.path.join(self.save_dir, "bit_grads.csv")
+
+
+        self._init_csv_files()
+
+        # Detecting bit dropping
+        self._prev_b_int: Dict[str, float] = {}
+
+    def _init_csv_files(self):
+        if not os.path.exists(self.modules_csv):
+            with open(self.modules_csv, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow([
+                    "time",
+                    "iter",
+                    "tokens_trained",
+                    "dataset",
+                    "module_name",
+                    "layer",
+                    "family",
+                    "role",
+                    "in_features",
+                    "out_features",
+                    "weight_numel",
+                    "bias_numel",
+                    "bit_param",
+                    "b_cont",
+                    "b_int",
+                    "total_bits_int",
+                    "total_bits_cont",
+                ])
+
+        if not os.path.exists(self.layers_csv):
+            with open(self.layers_csv, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow([
+                    "time",
+                    "iter",
+                    "tokens_trained",
+                    "dataset",
+                    "layer",
+                    "avg_b_int_weighted",
+                    "avg_b_cont_weighted",
+                    "param_count",
+                    "total_bits_int",
+                    "total_bits_cont",
+                ])
+
+        if not os.path.exists(self.types_csv):
+            with open(self.types_csv, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow([
+                    "time",
+                    "iter",
+                    "tokens_trained",
+                    "dataset",
+                    "family",
+                    "avg_b_int_weighted",
+                    "avg_b_cont_weighted",
+                    "param_count",
+                    "total_bits_int",
+                    "total_bits_cont",
+                ])
+
+        if not os.path.exists(self.events_csv):
+            with open(self.events_csv, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow([
+                    "time",
+                    "iter",
+                    "tokens_trained",
+                    "dataset",
+                    "module_name",
+                    "layer",
+                    "family",
+                    "role",
+                    "old_b_int",
+                    "new_b_int",
+                ])
+                
+        if not os.path.exists(self.grads_csv):
+            with open(self.grads_csv, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow([
+                    "time",
+                    "iter",
+                    "tokens_trained",
+                    "dataset",
+                    "module_name",
+                    "layer",
+                    "family",
+                    "role",
+                    "bit_param",
+                    "b_cont",
+                    "b_int",
+                    "grad",
+                    "abs_grad",
+                ])
+
+
+    def _iter_adaptive_bit_modules(self):
+        """
+        According to following attributes
+        - bit_param
+        - min_bits/max_bits
+        - weight
+        """
+        for name, m in self.model.named_modules():
+            if (
+                hasattr(m, "bit_param")
+                and hasattr(m, "min_bits")
+                and hasattr(m, "max_bits")
+                and hasattr(m, "weight")
+            ):
+                yield name, m
+
+    @torch.no_grad()
+    def _get_bits(self, m) -> Tuple[float, float, float]:
+        """
+          b_cont = clamp(bit_param)
+          b_int  = round(b_cont)
+        """
+        bit_param = float(m.bit_param.detach().float().item())
+        b_cont_t = torch.clamp(m.bit_param.detach().float(), float(m.min_bits), float(m.max_bits))
+        b_cont = float(b_cont_t.item())
+        b_int = float(torch.round(b_cont_t).item())
+        return bit_param, b_cont, b_int
+
+    @torch.no_grad()
+    def snapshot(self, iter_num: int, tokens_trained: Optional[float], dataset: str):
+        """
+        Log snapshot after some iter
+        """
+        ts = time.time()
+        tokens_val = "" if tokens_trained is None else tokens_trained
+
+        # Aggregative stats, per layer, attn/mlp
+        layer_acc = defaultdict(lambda: {"p": 0, "b_int_bits": 0.0, "b_cont_bits": 0.0})
+        family_acc = defaultdict(lambda: {"p": 0, "b_int_bits": 0.0, "b_cont_bits": 0.0})
+
+        b_int_list = []
+        b_cont_list = []
+
+        module_rows: List[List[Any]] = []
+        event_rows: List[List[Any]] = []
+
+        for name, m in self._iter_adaptive_bit_modules():
+            layer_id, family, role = _parse_module_name(name)
+            bit_param, b_cont, b_int = self._get_bits(m)
+
+            weight_numel = int(m.weight.numel())
+            bias_numel = int(m.bias.numel()) if getattr(m, "bias", None) is not None else 0
+            param_count = weight_numel + bias_numel
+
+            total_bits_int = b_int * param_count
+            total_bits_cont = b_cont * param_count
+
+            module_rows.append([
+                ts,
+                iter_num,
+                tokens_val,
+                dataset,
+                name,
+                layer_id,
+                family,
+                role,
+                int(getattr(m, "in_features", -1)),
+                int(getattr(m, "out_features", -1)),
+                weight_numel,
+                bias_numel,
+                bit_param,
+                b_cont,
+                b_int,
+                total_bits_int,
+                total_bits_cont,
+            ])
+
+            # Mean square distribution
+            b_int_list.append(b_int)
+            b_cont_list.append(b_cont)
+
+            # layer clustering
+            layer_acc[layer_id]["p"] += param_count
+            layer_acc[layer_id]["b_int_bits"] += total_bits_int
+            layer_acc[layer_id]["b_cont_bits"] += total_bits_cont
+
+            family_acc[family]["p"] += param_count
+            family_acc[family]["b_int_bits"] += total_bits_int
+            family_acc[family]["b_cont_bits"] += total_bits_cont
+
+            # b_int shifting event detection
+            prev = self._prev_b_int.get(name, None)
+            if prev is None:
+                self._prev_b_int[name] = b_int
+            else:
+                if b_int != prev:
+                    event_rows.append([
+                        ts,
+                        iter_num,
+                        tokens_val,
+                        dataset,
+                        name,
+                        layer_id,
+                        family,
+                        role,
+                        prev,
+                        b_int,
+                    ])
+                    self._prev_b_int[name] = b_int
+
+            # TensorBoard per module
+            if self.writer is not None and self.log_per_module_tb:
+                tag = _safe_tb_name(name)
+                self.writer.add_scalar(f"bit_alloc/modules/b_int/{tag}", b_int, iter_num)
+                self.writer.add_scalar(f"bit_alloc/modules/b_cont/{tag}", b_cont, iter_num)
+                self.writer.add_scalar(f"bit_alloc/modules/bit_param/{tag}", bit_param, iter_num)
+
+        # Write modules.csv
+        with open(self.modules_csv, "a", newline="") as f:
+            w = csv.writer(f)
+            w.writerows(module_rows)
+
+        # Write events.csv
+        if event_rows:
+            with open(self.events_csv, "a", newline="") as f:
+                w = csv.writer(f)
+                w.writerows(event_rows)
+
+        layer_rows = []
+        for layer_id in sorted(layer_acc.keys()):
+            p = layer_acc[layer_id]["p"]
+            if p <= 0:
+                continue
+            total_int = layer_acc[layer_id]["b_int_bits"]
+            total_cont = layer_acc[layer_id]["b_cont_bits"]
+            avg_int = total_int / p
+            avg_cont = total_cont / p
+            layer_rows.append([ts, iter_num, tokens_val, dataset, layer_id, avg_int, avg_cont, p, total_int, total_cont])
+
+        with open(self.layers_csv, "a", newline="") as f:
+            w = csv.writer(f)
+            w.writerows(layer_rows)
+
+        type_rows = []
+        for fam in sorted(family_acc.keys()):
+            p = family_acc[fam]["p"]
+            if p <= 0:
+                continue
+            total_int = family_acc[fam]["b_int_bits"]
+            total_cont = family_acc[fam]["b_cont_bits"]
+            avg_int = total_int / p
+            avg_cont = total_cont / p
+            type_rows.append([ts, iter_num, tokens_val, dataset, fam, avg_int, avg_cont, p, total_int, total_cont])
+
+        with open(self.types_csv, "a", newline="") as f:
+            w = csv.writer(f)
+            w.writerows(type_rows)
+
+        # TensorBoard：Aggregative Curve
+        if self.writer is not None:
+            # attn vs mlp average bitwidth
+            for fam, row in [(r[4], r) for r in type_rows]:
+                avg_int = float(row[5])
+                avg_cont = float(row[6])
+                self.writer.add_scalar(f"bit_alloc/type/{fam}_avg_b_int", avg_int, iter_num)
+                self.writer.add_scalar(f"bit_alloc/type/{fam}_avg_b_cont", avg_cont, iter_num)
+
+            # average bitwidth per layer
+            for r in layer_rows:
+                layer_id = int(r[4])
+                avg_int = float(r[5])
+                avg_cont = float(r[6])
+                self.writer.add_scalar(f"bit_alloc/layer_{layer_id:02d}/avg_b_int", avg_int, iter_num)
+                self.writer.add_scalar(f"bit_alloc/layer_{layer_id:02d}/avg_b_cont", avg_cont, iter_num)
+
+            # Bit distribution histogram
+            if self.log_hist_tb and len(b_int_list) > 0:
+                self.writer.add_histogram(
+                    "bit_alloc/hist/b_int",
+                    torch.tensor(b_int_list, dtype=torch.float32),
+                    iter_num
+                )
+                self.writer.add_histogram(
+                    "bit_alloc/hist/b_cont",
+                    torch.tensor(b_cont_list, dtype=torch.float32),
+                    iter_num
+                )
+
+    @torch.no_grad()
+    def snapshot_grads(self, iter_num: int, tokens_trained: Optional[float], dataset: str, topk: int = 10):
+        """
+        Logging gradient of bit_param layerwise (Require to call after unscaling gradient in train.py)
+        Deliverables
+          - CSV: out_dir/bit_alloc/bit_grads.csv
+          - TB:  bit_grad/modules/abs/<module> + layer/type Aggregation + histogram
+        """
+        ts = time.time()
+        tokens_val = "" if tokens_trained is None else tokens_trained
+
+        rows = []
+        abs_grads = []
+
+        layer_acc = defaultdict(lambda: {"sum_abs": 0.0, "cnt": 0})
+        fam_acc   = defaultdict(lambda: {"sum_abs": 0.0, "cnt": 0})
+
+        per_module = []  # for ranking
+
+        for name, m in self._iter_adaptive_bit_modules():
+            g = m.bit_param.grad
+            if g is None:
+                continue
+
+            grad = float(g.detach().float().item())
+            abs_grad = abs(grad)
+
+            bit_param, b_cont, b_int = self._get_bits(m)
+            layer_id, family, role = _parse_module_name(name)
+
+            rows.append([
+                ts,
+                iter_num,
+                tokens_val,
+                dataset,
+                name,
+                layer_id,
+                family,
+                role,
+                bit_param,
+                b_cont,
+                b_int,
+                grad,
+                abs_grad,
+            ])
+
+            abs_grads.append(abs_grad)
+            per_module.append((abs_grad, name, layer_id, family, role, b_int, b_cont, bit_param))
+
+            layer_acc[layer_id]["sum_abs"] += abs_grad
+            layer_acc[layer_id]["cnt"] += 1
+            fam_acc[family]["sum_abs"] += abs_grad
+            fam_acc[family]["cnt"] += 1
+
+            # TensorBoard per module
+            if self.writer is not None and self.log_per_module_tb:
+                tag = _safe_tb_name(name)
+                self.writer.add_scalar(f"bit_grad/modules/abs/{tag}", abs_grad, iter_num)
+                self.writer.add_scalar(f"bit_grad/modules/raw/{tag}", grad, iter_num)
+
+        # CSV
+        if rows:
+            with open(self.grads_csv, "a", newline="") as f:
+                w = csv.writer(f)
+                w.writerows(rows)
+
+        if self.writer is not None and abs_grads:
+            # histogram
+            self.writer.add_histogram(
+                "bit_grad/hist/abs_grad",
+                torch.tensor(abs_grads, dtype=torch.float32),
+                iter_num,
+            )
+
+            # family avg
+            for fam, v in fam_acc.items():
+                if v["cnt"] > 0:
+                    self.writer.add_scalar(
+                        f"bit_grad/type/{fam}_mean_abs_grad",
+                        v["sum_abs"] / v["cnt"],
+                        iter_num,
+                    )
+
+            # per-layer avg
+            for layer_id, v in layer_acc.items():
+                if v["cnt"] > 0 and layer_id >= 0:
+                    self.writer.add_scalar(
+                        f"bit_grad/layer_{layer_id:02d}/mean_abs_grad",
+                        v["sum_abs"] / v["cnt"],
+                        iter_num,
+                    )
+
+        per_module.sort(reverse=True, key=lambda t: t[0])
+        return per_module[:topk]

--- a/utils/bit_logger.py
+++ b/utils/bit_logger.py
@@ -1,0 +1,448 @@
+# utils/bit_logger.py
+import os
+import re
+import csv
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple, Any
+
+import torch
+
+
+_LAYER_RE = re.compile(r"\.h\.(\d+)\.")
+
+
+def _parse_layer_idx(module_name: str) -> Optional[int]:
+    m = _LAYER_RE.search(module_name)
+    return int(m.group(1)) if m else None
+
+
+def _parse_family(module_name: str) -> str:
+    # transformer.h.{i}.attn.xxx / transformer.h.{i}.mlp.xxx
+    if ".attn." in module_name:
+        return "attn"
+    if ".mlp." in module_name:
+        return "mlp"
+    return "other"
+
+
+def _parse_role(module_name: str) -> str:
+    # e.g. transformer.h.0.attn.c_attn_q -> c_attn_q
+    return module_name.split(".")[-1]
+
+
+def _mkdir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def _init_csv(path: str, fieldnames: List[str], overwrite: bool) -> None:
+    if overwrite or (not os.path.exists(path)):
+        _mkdir(os.path.dirname(path))
+        with open(path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=fieldnames)
+            w.writeheader()
+
+
+def _append_csv(path: str, fieldnames: List[str], rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    _mkdir(os.path.dirname(path))
+    need_header = not os.path.exists(path)
+    with open(path, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        if need_header:
+            w.writeheader()
+        w.writerows(rows)
+
+
+@dataclass
+class BitModuleInfo:
+    name: str
+    module: torch.nn.Module
+    layer: Optional[int]
+    family: str
+    role: str
+    param_count: int
+
+
+class BitLogger:
+
+    MODULE_FIELDS = [
+        "time",
+        "run_id",
+        "phase",
+        "iter",
+        "tokens_trained",
+        "dataset",
+        "module_name",
+        "layer",
+        "family",
+        "role",
+        "param_count",
+        "bit_param",
+        "b_cont",
+        "b_int",
+        "grad",
+        "abs_grad",
+    ]
+
+    GRAD_FIELDS = [
+        "time",
+        "run_id",
+        "phase",
+        "iter",
+        "tokens_trained",
+        "dataset",
+        "module_name",
+        "layer",
+        "family",
+        "role",
+        "bit_param",
+        "b_int",
+        "grad",
+        "abs_grad",
+    ]
+
+    LAYER_FIELDS = [
+        "time",
+        "run_id",
+        "phase",
+        "iter",
+        "tokens_trained",
+        "dataset",
+        "layer",
+        "avg_b_int_weighted",
+        "avg_b_cont_weighted",
+        "avg_abs_grad_weighted",
+        "param_count",
+        "total_bits_int",
+        "total_bits_cont",
+    ]
+
+    TYPE_FIELDS = [
+        "time",
+        "run_id",
+        "phase",
+        "iter",
+        "tokens_trained",
+        "dataset",
+        "family",
+        "avg_b_int_weighted",
+        "avg_b_cont_weighted",
+        "avg_abs_grad_weighted",
+        "param_count",
+        "total_bits_int",
+        "total_bits_cont",
+    ]
+
+    EVENT_FIELDS = [
+        "time",
+        "run_id",
+        "phase",
+        "iter",
+        "tokens_trained",
+        "dataset",
+        "module_name",
+        "layer",
+        "family",
+        "role",
+        "old_b_int",
+        "new_b_int",
+        "bit_param",
+        "b_cont",
+    ]
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        out_dir: str,
+        run_id: Optional[str] = None,
+        dataset_name: str = "",
+        log_dir: Optional[str] = None,
+        log_every: int = 20,
+        overwrite: bool = False,
+        is_master: bool = True,
+        enabled: bool = True,
+    ):
+        self.enabled = bool(enabled and is_master)
+        self.dataset_name = dataset_name
+        self.log_every = int(log_every)
+        self.run_id = run_id or time.strftime("%Y%m%d-%H%M%S")
+
+        base = log_dir if log_dir is not None else os.path.join(out_dir, "bit_logs")
+
+        self.run_dir = os.path.join(base, self.run_id)
+
+        _mkdir(self.run_dir)
+
+        self.paths = {
+            "modules": os.path.join(self.run_dir, "bit_modules.csv"),
+            "grads": os.path.join(self.run_dir, "bit_grads.csv"),
+            "layers": os.path.join(self.run_dir, "bit_layers.csv"),
+            "types": os.path.join(self.run_dir, "bit_types.csv"),
+            "events": os.path.join(self.run_dir, "bit_events.csv"),
+        }
+
+        # Delete old files if overwrite=True 
+        _init_csv(self.paths["modules"], self.MODULE_FIELDS, overwrite=overwrite)
+        _init_csv(self.paths["grads"], self.GRAD_FIELDS, overwrite=overwrite)
+        _init_csv(self.paths["layers"], self.LAYER_FIELDS, overwrite=overwrite)
+        _init_csv(self.paths["types"], self.TYPE_FIELDS, overwrite=overwrite)
+        _init_csv(self.paths["events"], self.EVENT_FIELDS, overwrite=overwrite)
+
+        self.modules: List[BitModuleInfo] = self._collect_bit_modules(model)
+
+        # b_int leaping events
+        self._prev_b_int: Dict[str, Optional[float]] = {m.name: None for m in self.modules}
+
+        # In case iter/phase repeatly write in each run
+        self._logged_keys: set[tuple[str, int]] = set()
+
+    @staticmethod
+    def _is_bit_module(m: torch.nn.Module) -> bool:
+        return hasattr(m, "bit_param") and isinstance(getattr(m, "bit_param"), torch.nn.Parameter)
+
+    def _collect_bit_modules(self, model: torch.nn.Module) -> List[BitModuleInfo]:
+        out: List[BitModuleInfo] = []
+        for name, m in model.named_modules():
+            if not self._is_bit_module(m):
+                continue
+
+            layer = _parse_layer_idx(name)
+            family = _parse_family(name)
+            role = _parse_role(name)
+
+            # Reserve for bias
+            param_count = 0
+            if hasattr(m, "weight") and m.weight is not None:
+                param_count += int(m.weight.numel())
+            if hasattr(m, "bias") and m.bias is not None:
+                param_count += int(m.bias.numel())
+
+            out.append(
+                BitModuleInfo(
+                    name=name,
+                    module=m,
+                    layer=layer,
+                    family=family,
+                    role=role,
+                    param_count=param_count,
+                )
+            )
+        return out
+
+    def _read_bits_detached(self, m: torch.nn.Module) -> Tuple[float, float, float]:
+        """
+        Rerurning:
+        - bit_param(Continuous, no clipping)
+        - b_cont(Continuous after clip)
+        - b_int(Discrete atfer round)
+        """
+        # Compatible to AdaptiveBitLinear/min_bits(max_bits)
+        min_bits = float(getattr(m, "min_bits", 1.0))
+        max_bits = float(getattr(m, "max_bits", 8.0))
+
+        with torch.no_grad():
+            bit_param = float(m.bit_param.detach().float().cpu().item())
+            b_cont = float(torch.clamp(m.bit_param.detach().float(), min_bits, max_bits).cpu().item())
+            b_int = float(torch.round(torch.clamp(m.bit_param.detach().float(), min_bits, max_bits)).cpu().item())
+        return bit_param, b_cont, b_int
+
+    def maybe_log(
+        self,
+        iter_num: int,
+        tokens_trained: int,
+        phase: str = "train",
+        dataset_name: Optional[str] = None,
+    ) -> None:
+        if not self.enabled:
+            return
+        if self.log_every > 0 and (iter_num % self.log_every != 0):
+            return
+
+        key = (phase, int(iter_num))
+        if key in self._logged_keys:
+            return
+        self._logged_keys.add(key)
+
+        t = time.time()
+        dataset = dataset_name or self.dataset_name
+
+        module_rows: List[Dict[str, Any]] = []
+        grad_rows: List[Dict[str, Any]] = []
+        event_rows: List[Dict[str, Any]] = []
+
+        layer_acc: Dict[int, Dict[str, float]] = {}
+        type_acc: Dict[str, Dict[str, float]] = {}
+
+        def _acc_init():
+            return {
+                "param_count": 0.0,
+                "sum_bits_int": 0.0,
+                "sum_bits_cont": 0.0,
+                "sum_abs_grad_weighted": 0.0,
+            }
+
+        for info in self.modules:
+            name = info.name
+            m = info.module
+
+            bit_param, b_cont, b_int = self._read_bits_detached(m)
+
+            g = m.bit_param.grad
+            grad = float(g.detach().float().cpu().item()) if g is not None else float("nan")
+            abs_grad = abs(grad) if g is not None else float("nan")
+
+            n = float(info.param_count)
+            total_bits_int = b_int * n
+            total_bits_cont = b_cont * n
+
+            module_rows.append(
+                {
+                    "time": t,
+                    "run_id": self.run_id,
+                    "phase": phase,
+                    "iter": int(iter_num),
+                    "tokens_trained": int(tokens_trained),
+                    "dataset": dataset,
+                    "module_name": name,
+                    "layer": -1 if info.layer is None else int(info.layer),
+                    "family": info.family,
+                    "role": info.role,
+                    "param_count": int(info.param_count),
+                    "bit_param": bit_param,
+                    "b_cont": b_cont,
+                    "b_int": b_int,
+                    "grad": grad,
+                    "abs_grad": abs_grad,
+                }
+            )
+
+            grad_rows.append(
+                {
+                    "time": t,
+                    "run_id": self.run_id,
+                    "phase": phase,
+                    "iter": int(iter_num),
+                    "tokens_trained": int(tokens_trained),
+                    "dataset": dataset,
+                    "module_name": name,
+                    "layer": -1 if info.layer is None else int(info.layer),
+                    "family": info.family,
+                    "role": info.role,
+                    "bit_param": bit_param,
+                    "b_int": b_int,
+                    "grad": grad,
+                    "abs_grad": abs_grad,
+                }
+            )
+
+            # event when b_int change
+            prev = self._prev_b_int.get(name, None)
+            if prev is None:
+                self._prev_b_int[name] = b_int
+            elif float(prev) != float(b_int):
+                event_rows.append(
+                    {
+                        "time": t,
+                        "run_id": self.run_id,
+                        "phase": phase,
+                        "iter": int(iter_num),
+                        "tokens_trained": int(tokens_trained),
+                        "dataset": dataset,
+                        "module_name": name,
+                        "layer": -1 if info.layer is None else int(info.layer),
+                        "family": info.family,
+                        "role": info.role,
+                        "old_b_int": float(prev),
+                        "new_b_int": float(b_int),
+                        "bit_param": bit_param,
+                        "b_cont": b_cont,
+                    }
+                )
+                self._prev_b_int[name] = b_int
+
+            # layer aggregate
+            if info.layer is not None:
+                if info.layer not in layer_acc:
+                    layer_acc[info.layer] = _acc_init()
+                la = layer_acc[info.layer]
+                la["param_count"] += n
+                la["sum_bits_int"] += total_bits_int
+                la["sum_bits_cont"] += total_bits_cont
+                if g is not None:
+                    la["sum_abs_grad_weighted"] += abs_grad * n
+
+            # type/family
+            fam = info.family
+            if fam not in type_acc:
+                type_acc[fam] = _acc_init()
+            ta = type_acc[fam]
+            ta["param_count"] += n
+            ta["sum_bits_int"] += total_bits_int
+            ta["sum_bits_cont"] += total_bits_cont
+            if g is not None:
+                ta["sum_abs_grad_weighted"] += abs_grad * n
+
+        layer_rows: List[Dict[str, Any]] = []
+        for layer, la in sorted(layer_acc.items(), key=lambda kv: kv[0]):
+            pc = la["param_count"]
+            avg_b_int = la["sum_bits_int"] / pc if pc > 0 else float("nan")
+            avg_b_cont = la["sum_bits_cont"] / pc if pc > 0 else float("nan")
+            avg_abs_grad = la["sum_abs_grad_weighted"] / pc if pc > 0 else float("nan")
+
+            layer_rows.append(
+                {
+                    "time": t,
+                    "run_id": self.run_id,
+                    "phase": phase,
+                    "iter": int(iter_num),
+                    "tokens_trained": int(tokens_trained),
+                    "dataset": dataset,
+                    "layer": int(layer),
+                    "avg_b_int_weighted": avg_b_int,
+                    "avg_b_cont_weighted": avg_b_cont,
+                    "avg_abs_grad_weighted": avg_abs_grad,
+                    "param_count": int(pc),
+                    "total_bits_int": la["sum_bits_int"],
+                    "total_bits_cont": la["sum_bits_cont"],
+                }
+            )
+
+        type_rows: List[Dict[str, Any]] = []
+        for fam, ta in sorted(type_acc.items(), key=lambda kv: kv[0]):
+            pc = ta["param_count"]
+            avg_b_int = ta["sum_bits_int"] / pc if pc > 0 else float("nan")
+            avg_b_cont = ta["sum_bits_cont"] / pc if pc > 0 else float("nan")
+            avg_abs_grad = ta["sum_abs_grad_weighted"] / pc if pc > 0 else float("nan")
+
+            type_rows.append(
+                {
+                    "time": t,
+                    "run_id": self.run_id,
+                    "phase": phase,
+                    "iter": int(iter_num),
+                    "tokens_trained": int(tokens_trained),
+                    "dataset": dataset,
+                    "family": fam,
+                    "avg_b_int_weighted": avg_b_int,
+                    "avg_b_cont_weighted": avg_b_cont,
+                    "avg_abs_grad_weighted": avg_abs_grad,
+                    "param_count": int(pc),
+                    "total_bits_int": ta["sum_bits_int"],
+                    "total_bits_cont": ta["sum_bits_cont"],
+                }
+            )
+
+        # Write sheets
+        _append_csv(self.paths["modules"], self.MODULE_FIELDS, module_rows)
+        _append_csv(self.paths["grads"], self.GRAD_FIELDS, grad_rows)
+        _append_csv(self.paths["layers"], self.LAYER_FIELDS, layer_rows)
+        _append_csv(self.paths["types"], self.TYPE_FIELDS, type_rows)
+        _append_csv(self.paths["events"], self.EVENT_FIELDS, event_rows)
+
+    def get_run_dir(self) -> str:
+        return self.run_dir
+
+    def list_bit_params(self) -> List[torch.nn.Parameter]:
+        return [info.module.bit_param for info in self.modules]

--- a/utils/bit_usage.py
+++ b/utils/bit_usage.py
@@ -58,8 +58,23 @@ def collect_bit_usage(module: nn.Module) -> Dict[str, torch.Tensor]:
     return usage
 
 
+def count_tracked_parameters(module: nn.Module) -> int:
+    """Count parameters covered by bit_usage modules (weight + bias if present)."""
+    total = 0
+    for child in iter_bit_usage_modules(module):
+        w = getattr(child, "weight", None)
+        b = getattr(child, "bias", None)
+        if w is not None:
+            total += w.numel()
+        if b is not None:
+            total += b.numel()
+    return total
+
+
+
 __all__ = [
     "collect_bit_usage",
     "compute_total_bit_usage",
     "iter_bit_usage_modules",
+    "count_tracked_parameters",
 ]

--- a/variations/linear_variations.py
+++ b/variations/linear_variations.py
@@ -71,7 +71,7 @@ class QuantizedLinear(nn.Linear):
             bias = dequantize(self.bias_zero_point[0], self.bias_norm, self.quantized_bias)
 
         # Uses the dequantized weights and bias to compute the output using F.linear
-        if self.bias is not none:
+        if self.bias is not None:
             out = F.linear(input, weight, bias)
         else:
             out = F.linear(input, weight)

--- a/variations/linear_variations.py
+++ b/variations/linear_variations.py
@@ -67,7 +67,7 @@ class QuantizedLinear(nn.Linear):
         weight = dequantize(self.weight_zero_point[0], self.weight_norm, self.quantized_weight)
 
         # Compute the dequantized bias
-        if self.bias is not None:
+        if self.bias:
             bias = dequantize(self.bias_zero_point[0], self.bias_norm, self.quantized_bias)
 
         # Uses the dequantized weights and bias to compute the output using F.linear
@@ -165,7 +165,7 @@ class AdaptiveBitLinear(nn.Linear):
         x = tensor.to(torch.float32)
         b = bits.to(x.dtype)
 
-        # qmax = 2^(b-1) - 1  , In this tase the gradient of B could pass back.
+        # qmax = 2^(b-1) - 1  , In this case the gradient of B could pass back.
         levels = torch.exp2(b - 1.0)
         qmax = torch.clamp(levels - 1.0, min=1.0)
         qmin = -levels
@@ -174,7 +174,7 @@ class AdaptiveBitLinear(nn.Linear):
         scale = max_val / qmax
         scale = torch.where(scale == 0, torch.ones_like(scale), scale)
 
-        # Quantizatiopn: Scale division -> Clamp -> STE-round
+        # Quantization: Scale division -> Clamp -> STE-round
         x_scaled = x / scale
         x_clipped = torch.clamp(x_scaled, qmin, qmax)
 

--- a/variations/linear_variations.py
+++ b/variations/linear_variations.py
@@ -71,7 +71,7 @@ class QuantizedLinear(nn.Linear):
             bias = dequantize(self.bias_zero_point[0], self.bias_norm, self.quantized_bias)
 
         # Uses the dequantized weights and bias to compute the output using F.linear
-        if self.bias:
+        if self.bias is not none:
             out = F.linear(input, weight, bias)
         else:
             out = F.linear(input, weight)
@@ -162,19 +162,28 @@ class AdaptiveBitLinear(nn.Linear):
 
     def _fake_quantize_tensor(self, tensor: torch.Tensor, bits: torch.Tensor) -> torch.Tensor:
         orig_dtype = tensor.dtype
-        tensor_fp32 = tensor.to(torch.float32)
-        bits_fp32 = bits.to(tensor_fp32.dtype)
+        x = tensor.to(torch.float32)
+        b = bits.to(x.dtype)
 
-        levels = torch.pow(torch.tensor(2.0, device=tensor_fp32.device), bits_fp32 - 1.0)
+        # qmax = 2^(b-1) - 1  , In this tase the gradient of B could pass back.
+        levels = torch.exp2(b - 1.0)
         qmax = torch.clamp(levels - 1.0, min=1.0)
         qmin = -levels
 
-        max_val = tensor_fp32.abs().max()
+        max_val = x.abs().max()
         scale = max_val / qmax
         scale = torch.where(scale == 0, torch.ones_like(scale), scale)
 
-        quantized = torch.clamp(torch.round(tensor_fp32 / scale), qmin, qmax) * scale
-        return (tensor_fp32 + (quantized - tensor_fp32).detach()).to(orig_dtype)
+        # Quantizatiopn: Scale division -> Clamp -> STE-round
+        x_scaled = x / scale
+        x_clipped = torch.clamp(x_scaled, qmin, qmax)
+
+        # STE for round such that gradient flows from scale → qmax → bits → bit_param
+        x_rounded = self._ste_round(x_clipped)
+
+        q = x_rounded * scale
+        return q.to(orig_dtype)
+
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         bitwidth = self.current_bitwidth()


### PR DESCRIPTION
## Train (example)

```
python train.py \
  --init_from scratch --dataset minipile --out_dir out/repro \
  --device cuda --dtype float16 \
  --n_layer 4 --n_head 4 --n_embd 256 \
  --block_size 256 --batch_size 32 --gradient_accumulation_steps 1 \
  --max_iters 30000 --eval_interval 200 --eval_iters 50 --log_interval 20 \
  --learning_rate 3e-4 \
  --loss_fn bit_balanced_cross_entropy --bit_loss_weight 2e-1 --bit_loss_normalize \
  --linear_variant_attn adaptive_bit_linear --linear_variant_mlp adaptive_bit_linear \
  --adaptive_linear_init_bits 6 --adaptive_linear_min_bits 2 --adaptive_linear_max_bits 8 \
  --adaptive_linear_activation_bits 8 --adaptive_linear_quantize_input \
  --tensorboard_log --tensorboard_log_dir runs \
  --never_save_checkpoint
```

## TensorBoard:

```bash
tensorboard --logdir runs
```

## Outputs

* `out/<run>/` training outputs.
* Bit allocation logs:
If using `utils/bit_allocation_logger.py`: `out/<run>/bit_alloc/bit_*.csv`

## Plotting

Bit allocation curves (layer-wise / type-wise):

```bash
python scripts/plot_bit_alloc.py --run_dir out/<run>
```
