### PR TITLE
Add manual induction heads 2

### DIFF
--- a/explorations/infinite_manual_induction_dim_sweep.yaml
+++ b/explorations/infinite_manual_induction_dim_sweep.yaml
@@ -1,0 +1,69 @@
+# Sweep manual-induction head dimensionality for Infinite Attention
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type (guided by explorations/default.yaml peri_ln setup)
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    named_group_settings:
+      use_rotary_embeddings: [true]
+      use_abs_pos_embeddings: [false]
+
+  # Embedding Norm
+  - named_group: "rmsnorm_wte"
+    named_group_settings:
+      norm_variant_wte: ["rmsnorm"]
+
+  # MLP Activation
+  - named_group: "squared_relu"
+    named_group_settings:
+      activation_variant: ["squared_relu"]
+
+  # Infinite Attention + manual induction heads
+  - named_group: "infinite_manual_induction"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+    # 1 induction head per layer (3 total over 3 layers)
+    n_layer: [3]
+    n_induction_head: [1]
+
+  # Sweep induction-head dimensions
+  - named_group: "ind_dim_32"
+    n_ind_head_dim: [32]
+
+  - named_group: "ind_dim_64"
+    n_ind_head_dim: [64]
+
+  - named_group: "ind_dim_128"
+    n_ind_head_dim: [128]
+
+  - named_group: "ind_dim_256"
+    n_ind_head_dim: [256]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [1000]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+
+parameter_groups:
+  - compile: [true]
+    named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "rmsnorm_wte"
+      - "squared_relu"
+      - "infinite_manual_induction"
+    named_group_alternates:
+      ["ind_dim_32", "ind_dim_64", "ind_dim_128", "ind_dim_256"]

--- a/explorations/infinite_manual_induction_dim_sweep.yaml
+++ b/explorations/infinite_manual_induction_dim_sweep.yaml
@@ -30,40 +30,75 @@ named_static_groups:
       activation_variant: ["squared_relu"]
 
   # Infinite Attention + manual induction heads
-  - named_group: "infinite_manual_induction"
+  - named_group: "infinite"
     attention_variant: ["infinite"]
     use_concat_heads: [true]
-    # 1 induction head per layer (3 total over 3 layers)
-    n_layer: [3]
-    n_induction_head: [1]
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+    n_layer: [6]
 
-  # Sweep induction-head dimensions
-  - named_group: "ind_dim_32"
-    n_ind_head_dim: [32]
 
-  - named_group: "ind_dim_64"
-    n_ind_head_dim: [64]
 
-  - named_group: "ind_dim_128"
-    n_ind_head_dim: [128]
 
-  - named_group: "ind_dim_256"
-    n_ind_head_dim: [256]
+
+# Higher Level Groupings
+named_variation_groups:
+  - named_group: "th6_head_ratios"
+    parameter_groups:
+      - n_induction_head: [1]
+        n_head: [5]
+      - n_induction_head: [2]
+        n_head: [4]
+      - n_induction_head: [3]
+        n_head: [3]
+      - n_induction_head: [4]
+        n_head: [2]
+      - n_induction_head: [5]
+        n_head: [1]
+      - n_induction_head: [6]
+        n_head: [0]
+  - named_group: "th3_head_ratios"
+    parameter_groups:
+      - n_induction_head: [1]
+        n_head: [2]
+      - n_induction_head: [2]
+        n_head: [1]
+      - n_induction_head: [3]
+        n_head: [0]
+  - named_group: "ind_dim_sizes"
+    parameter_groups:
+      - n_ind_head_dim: [32]
+      - n_ind_head_dim: [64]
+      - n_ind_head_dim: [128]
+      - n_ind_head_dim: [256]
+      - n_ind_head_dim: [384]
 
 common_group:
   dataset: ["minipile"]
   eval_interval: [1000]
   max_iters: [10000]
   never_save_checkpoint: [true]
+  compile: [true]
 
 parameter_groups:
-  - compile: [true]
-    named_group_static:
+  # Induction Head Variations
+  - named_group_static:
       - "qk_norm"
       - "peri_ln"
       - "rotary"
       - "rmsnorm_wte"
       - "squared_relu"
-      - "infinite_manual_induction"
+      - "infinite"
+    named_group_variations:
+      - "ind_dim_sizes"
     named_group_alternates:
-      ["ind_dim_32", "ind_dim_64", "ind_dim_128", "ind_dim_256"]
+      ["th6_head_ratios", "th3_head_ratios"]
+  # Baseline without induction heads
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "rmsnorm_wte"
+      - "squared_relu"
+      - "infinite"
+    n_head: [3,6]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -86,6 +86,8 @@ class GPTConfig:
     n_v_head_dim: int = None
     n_cproj: int = None
     use_concat_heads: bool = False
+    n_induction_head: int = 0
+    n_ind_head_dim: int = None
 
     # Softcapping params
     attn_logit_softcapping: float | None = None

--- a/train_args.py
+++ b/train_args.py
@@ -906,6 +906,10 @@ def parse_args():
     model_group.add_argument('--n_qk_head_dim', default=None, type=int)
     model_group.add_argument('--n_v_head_dim', default=None, type=int)
     model_group.add_argument('--n_cproj', default=None, type=int)
+    model_group.add_argument('--n_induction_head', default=0, type=int,
+                             help="Additional tied-Wk manual induction heads for Infinite Attention")
+    model_group.add_argument('--n_ind_head_dim', default=None, type=int,
+                             help="Head dim for additional manual induction heads in Infinite Attention")
     model_group.add_argument('--attn_cproj_scale', default=1.0, type=float,
                              help="Scale attention outputs before c_proj (Infinite Attention)")
     model_group.add_argument('--attn_post_act_l2_norm', default=False, action=argparse.BooleanOptionalAction,

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -1020,6 +1020,11 @@ class InfiniteHeadAttention(nn.Module):
         self.n_qk_head_dim = config.n_qk_head_dim
         self.n_v_head_dim = config.n_v_head_dim
 
+        self.n_induction_head = getattr(config, "n_induction_head", 0)
+        self.n_ind_head_dim = getattr(config, "n_ind_head_dim", None)
+        self.use_manual_induction = self.n_induction_head > 0
+        if self.use_manual_induction and (self.n_ind_head_dim is None):
+            raise ValueError("n_ind_head_dim must be set when n_induction_head > 0")
 
         # Concat Heads
         self.use_concat_heads = config.use_concat_heads
@@ -1069,6 +1074,13 @@ class InfiniteHeadAttention(nn.Module):
         self.c_attn_q = self.linear_variant_q(self.n_embd, self.n_head * self.n_qk_head_dim, config, bias=config.bias)
         self.c_attn_k = self.linear_variant_k(self.n_embd, self.n_kv_group * self.n_qk_head_dim, config, bias=config.bias)
         self.c_attn_v = self.linear_variant_v(self.n_embd, self.n_kv_group * self.n_v_head_dim, config, bias=config.bias)
+
+        if self.use_manual_induction:
+            # "Manual induction" heads tie Q and K to a shared Wk projection.
+            ind_total_dim = self.n_induction_head * self.n_ind_head_dim
+            self.c_attn_k_ind = self.linear_variant_k(self.n_embd, ind_total_dim, config, bias=config.bias)
+            self.c_attn_v_ind = self.linear_variant_v(self.n_embd, ind_total_dim, config, bias=config.bias)
+            self.c_proj_ind = self.linear_variant_attn_proj(ind_total_dim, self.n_embd, config, bias=config.bias)
 
         self.q_norm_dim = 1 if self.l2_norm_attn_q_dim == "embed" else 0
         self.k_norm_dim = 1 if self.l2_norm_attn_k_dim == "embed" else 0
@@ -1180,9 +1192,30 @@ class InfiniteHeadAttention(nn.Module):
         else:
             v = self.c_attn_v(x)
 
+        if self.use_manual_induction:
+            if self.l2_norm_attn_k:
+                k_ind_weight = F.normalize(self.c_attn_k_ind.weight, p=2, dim=self.k_norm_dim)
+                k_ind = F.linear(x, k_ind_weight, self.c_attn_k_ind.bias)
+            else:
+                k_ind = self.c_attn_k_ind(x)
+
+            if self.l2_norm_attn_v:
+                v_ind_weight = F.normalize(self.c_attn_v_ind.weight, p=2, dim=self.v_norm_dim)
+                v_ind = F.linear(x, v_ind_weight, self.c_attn_v_ind.bias)
+            else:
+                v_ind = self.c_attn_v_ind(x)
+
+            # Tied-Wk induction heads: q_ind uses the same projected features as k_ind.
+            q_ind = k_ind
+
         q = q.view(B, T, self.n_head, self.n_qk_head_dim).transpose(1, 2) # (B, n_h, T, hs)
         k = k.view(B, T, self.n_kv_group, self.n_qk_head_dim).transpose(1, 2) # (B, n_kv, T, hs)
         v = v.view(B, T, self.n_kv_group, self.n_v_head_dim).transpose(1, 2) # (B, n_kv, T, hs)
+
+        if self.use_manual_induction:
+            q_ind = q_ind.view(B, T, self.n_induction_head, self.n_ind_head_dim).transpose(1, 2)
+            k_ind = k_ind.view(B, T, self.n_induction_head, self.n_ind_head_dim).transpose(1, 2)
+            v_ind = v_ind.view(B, T, self.n_induction_head, self.n_ind_head_dim).transpose(1, 2)
 
         # Apply Rotary Position Encodings
         if (self.rotary_emb_q is not None) and (self.rotary_emb_k is not None):
@@ -1239,6 +1272,15 @@ class InfiniteHeadAttention(nn.Module):
                 is_causal=True,
             )
 
+            if self.use_manual_induction:
+                y_ind = torch.nn.functional.scaled_dot_product_attention(
+                    q_ind,
+                    k_ind,
+                    v_ind,
+                    dropout_p=self.dropout if self.training else 0,
+                    is_causal=True,
+                )
+
         else:
             # Manual implementation of attention
 
@@ -1267,6 +1309,14 @@ class InfiniteHeadAttention(nn.Module):
             att = self.attn_dropout(att)
 
             y = att @ v_attn # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+
+            if self.use_manual_induction:
+                att_ind = (q_ind @ k_ind.transpose(-2, -1))
+                att_ind = att_ind / math.sqrt(self.n_ind_head_dim)
+                att_ind = att_ind.masked_fill(self.bias[:, :, :T, :T].to(x.device) == 0, float('-inf'))
+                att_ind = F.softmax(att_ind, dim=-1)
+                att_ind = self.attn_dropout(att_ind)
+                y_ind = att_ind @ v_ind
 
         if self.post_act_l2_norm:
             y = y / y.norm(dim=-1, keepdim=True).clamp_min(1e-6)
@@ -1305,6 +1355,15 @@ class InfiniteHeadAttention(nn.Module):
             else:
                 proj_outputs = [proj(y_sum) for proj in self.c_proj_list]
             y = torch.stack(proj_outputs, dim=0).sum(dim=0)
+
+        if self.use_manual_induction:
+            y_ind = y_ind.transpose(1, 2).contiguous().view(B, T, self.n_induction_head * self.n_ind_head_dim)
+            if self.l2_norm_attn_cproj:
+                cproj_ind_weight = F.normalize(self.c_proj_ind.weight, p=2, dim=self.cproj_norm_dim)
+                y_ind = F.linear(y_ind, cproj_ind_weight, self.c_proj_ind.bias)
+            else:
+                y_ind = self.c_proj_ind(y_ind)
+            y = y + y_ind
 
         # output projection
         y = self.resid_dropout(y)


### PR DESCRIPTION
This pull request adds support for "manual induction" heads to the Infinite Attention mechanism, allowing for explicit control over the number and dimensionality of induction heads as a sweepable hyperparameter. The changes introduce new configuration options, update argument parsing, and implement the new attention logic in the model code, including parameter initialization and forward pass computations.

**Manual Induction Head Support for Infinite Attention**

*Configuration and Argument Parsing:*
- Added `n_induction_head` and `n_ind_head_dim` as new configuration parameters in `GPTConfig` and as command-line arguments in `train_args.py` to specify the number and dimensionality of manual induction heads. [[1]](diffhunk://#diff-114e7747956438292f72cb8316c075c30638fe5c68dab6a7ac466f33639df288R89-R90) [[2]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R909-R912)
- Introduced a new YAML sweep file `infinite_manual_induction_dim_sweep.yaml` to enable systematic exploration of different induction head settings and ratios.

*Model Implementation:*
- Updated the Infinite Attention class in `variations/attention_variations.py` to initialize additional projection layers for manual induction heads when enabled, and validate that `n_ind_head_dim` is set if `n_induction_head > 0`. [[1]](diffhunk://#diff-75be494a11b65088f2ca2deb4db8946fb085bde330a7aa50daf23030ee8bffceR1023-R1027) [[2]](diffhunk://#diff-75be494a11b65088f2ca2deb4db8946fb085bde330a7aa50daf23030ee8bffceR1078-R1084)
- Modified the forward pass to compute and integrate the outputs from manual induction heads, including their own Q/K/V projections, attention computations, and output projections, which are then added to the main attention output. [[1]](diffhunk://#diff-75be494a11b65088f2ca2deb4db8946fb085bde330a7aa50daf23030ee8bffceR1195-R1219) [[2]](diffhunk://#diff-75be494a11b65088f2ca2deb4db8946fb085bde330a7aa50daf23030ee8bffceR1275-R1283) [[3]](diffhunk://#diff-75be494a11b65088f2ca2deb4db8946fb085bde330a7aa50daf23030ee8bffceR1313-R1320) [[4]](diffhunk://#diff-75be494a11b65088f2ca2deb4db8946fb085bde330a7aa50daf23030ee8bffceR1359-R1367)