### PR TITLE
Add scheduled gaussian noise

### DIFF
--- a/explorations/embedding_gaussian_noise_schedule.yaml
+++ b/explorations/embedding_gaussian_noise_schedule.yaml
@@ -1,0 +1,41 @@
+# explorations/embedding_gaussian_noise_schedule.yaml
+---
+# Demonstrates the scheduled embedding Gaussian-noise options:
+# - start/end iteration window
+# - start/end noise magnitude
+# - eval-time noise gating (kept disabled for clean validation/sample behavior)
+
+common_group:
+  dataset: ["shakespeare_char"]
+  n_layer: [6]
+  n_head: [6]
+  n_embd: [384]
+  block_size: [256]
+  batch_size: [64]
+  max_iters: [3000]
+  device: ["cuda"]
+  dtype: ["bfloat16"]
+  eval_interval: [200]
+  never_save_checkpoint: [true]
+
+parameter_groups:
+  # Baseline: no embedding noise
+  - embedding_gaussian_noise_std: [0.0, 0.01, 0.02, 0.05]
+
+  # Scheduled decay: stronger early regularization, weaker later
+  - embedding_gaussian_noise_std: [0.05]
+    embedding_gaussian_noise_start_iter: [0]
+    embedding_gaussian_noise_end_iter: [3000]
+    embedding_gaussian_noise_start_std: [0.12]
+    embedding_gaussian_noise_end_std: [0.01]
+
+  # Scheduled warmup: introduce noise after early stabilization
+  - embedding_gaussian_noise_std: [0.05]
+    embedding_gaussian_noise_start_iter: [1000]
+    embedding_gaussian_noise_end_iter: [4000]
+    embedding_gaussian_noise_start_std: [0.0]
+    embedding_gaussian_noise_end_std: [0.08]
+
+# Keep noise off during model.eval() so validation loss and sample.py are unaffected.
+embedding_gaussian_noise_in_eval: [false]
+

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -340,6 +340,11 @@ class GPTConfig:
     embedding_mean_init: float= 0.0
     embedding_std_init: float= 0.02
     embedding_gaussian_noise_std: float = 0.0
+    embedding_gaussian_noise_start_iter: int = 0
+    embedding_gaussian_noise_end_iter: int | None = None
+    embedding_gaussian_noise_start_std: float | None = None
+    embedding_gaussian_noise_end_std: float | None = None
+    embedding_gaussian_noise_in_eval: bool = False
 
     ## FIRE Options (Functional Interpolation for Relative Positional Encoding)
     fire_log_bias: float = 1.0

--- a/model.py
+++ b/model.py
@@ -352,11 +352,36 @@ class GPT(nn.Module):
         np.savez(file_path, scale_up=scale_up_matrix, scale_down=scale_down_matrix)
         print(f"Scale matrices saved to {file_path}")
 
-    def add_embedding_gaussian_noise(self, embeddings):
-        if self.config.embedding_gaussian_noise_std and self.config.embedding_gaussian_noise_std > 0:
+    def get_embedding_gaussian_noise_std(self, iter_num=None):
+        if not self.config.embedding_gaussian_noise_in_eval and not self.training:
+            return 0.0
+
+        base_std = float(self.config.embedding_gaussian_noise_std or 0.0)
+        start_std = self.config.embedding_gaussian_noise_start_std
+        end_std = self.config.embedding_gaussian_noise_end_std
+        start_std = base_std if start_std is None else float(start_std)
+        end_std = base_std if end_std is None else float(end_std)
+
+        end_iter = self.config.embedding_gaussian_noise_end_iter
+        if end_iter is None or iter_num is None:
+            return max(0.0, end_std)
+
+        start_iter = int(self.config.embedding_gaussian_noise_start_iter or 0)
+        end_iter = int(end_iter)
+        if end_iter <= start_iter:
+            return max(0.0, end_std)
+
+        progress = (float(iter_num) - start_iter) / float(end_iter - start_iter)
+        progress = min(max(progress, 0.0), 1.0)
+        current_std = start_std + progress * (end_std - start_std)
+        return max(0.0, current_std)
+
+    def add_embedding_gaussian_noise(self, embeddings, iter_num=None):
+        noise_std = self.get_embedding_gaussian_noise_std(iter_num=iter_num)
+        if noise_std > 0:
             noise = torch.randn_like(embeddings)
             noise = noise / (noise.norm(dim=-1, keepdim=True) + 1e-6)
-            noise = noise * self.config.embedding_gaussian_noise_std
+            noise = noise * noise_std
             embeddings = embeddings / (embeddings.norm(dim=-1, keepdim=True) + 1e-6)
             return embeddings + noise
         return embeddings
@@ -387,7 +412,7 @@ class GPT(nn.Module):
                 else:
                     token_repr = self.transformer[f'wte_{i}'](tokens)
 
-                token_repr = self.add_embedding_gaussian_noise(token_repr)
+                token_repr = self.add_embedding_gaussian_noise(token_repr, iter_num=iter_num)
                 x = token_repr if x is None else x + token_repr
 
             if self.config.norm_variant_wte is not None:
@@ -513,7 +538,7 @@ class GPT(nn.Module):
                 tok_emb = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
             x = None
 
-            tok_emb = self.add_embedding_gaussian_noise(tok_emb)
+            tok_emb = self.add_embedding_gaussian_noise(tok_emb, iter_num=iter_num)
             if self.n_embd_wte:
                 tok_emb = self.transformer.scale_up(tok_emb)
 
@@ -620,7 +645,7 @@ class GPT(nn.Module):
         else:
             tok_emb = self.transformer.wte(idx)
 
-        tok_emb = self.add_embedding_gaussian_noise(tok_emb)
+        tok_emb = self.add_embedding_gaussian_noise(tok_emb, iter_num=None)
 
         if self.n_embd_wte:
             tok_emb = self.transformer.scale_up(tok_emb)

--- a/train_args.py
+++ b/train_args.py
@@ -1158,6 +1158,36 @@ def parse_args():
         default=0.0,
         help="Scale for L2-normalized Gaussian noise added to token embeddings after lookup.",
     )
+    model_group.add_argument(
+        "--embedding_gaussian_noise_start_iter",
+        type=int,
+        default=0,
+        help="Iteration where embedding Gaussian-noise scheduling begins.",
+    )
+    model_group.add_argument(
+        "--embedding_gaussian_noise_end_iter",
+        type=int,
+        default=None,
+        help="Iteration where embedding Gaussian-noise scheduling reaches its end magnitude.",
+    )
+    model_group.add_argument(
+        "--embedding_gaussian_noise_start_std",
+        type=float,
+        default=None,
+        help="Noise magnitude at --embedding_gaussian_noise_start_iter (defaults to --embedding_gaussian_noise_std).",
+    )
+    model_group.add_argument(
+        "--embedding_gaussian_noise_end_std",
+        type=float,
+        default=None,
+        help="Noise magnitude at --embedding_gaussian_noise_end_iter (defaults to --embedding_gaussian_noise_std).",
+    )
+    model_group.add_argument(
+        "--embedding_gaussian_noise_in_eval",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="Allow embedding Gaussian-noise injection during model.eval() (disabled by default).",
+    )
 
     ## FIRE Options (Functional Interpolation for Relative Positional Encoding)
     model_group.add_argument( "--fire_log_bias", type=float, default=1.0, help="bias in the function psi(x) = log(cx + bias)")


### PR DESCRIPTION
This pull request introduces a flexible and configurable schedule for applying Gaussian noise to token embeddings during training. The changes allow users to specify when and how much noise to inject, including ramp-up and ramp-down schedules, as well as whether to apply noise during evaluation. The implementation supports both static and scheduled noise magnitudes, improving the regularization options for model training.

**Configurable embedding Gaussian noise scheduling:**

* Added new configuration options to `GPTConfig` and command-line arguments to control the start/end iteration, start/end noise magnitude, and whether noise is applied during evaluation (`gpt_conf.py`, `train_args.py`). [[1]](diffhunk://#diff-114e7747956438292f72cb8316c075c30638fe5c68dab6a7ac466f33639df288R343-R347) [[2]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R1161-R1190)
* Implemented a new method `get_embedding_gaussian_noise_std` in `model.py` to compute the current noise standard deviation based on the schedule and training progress.

**Integration of scheduled noise into model forward pass:**

* Updated all calls to `add_embedding_gaussian_noise` in `model.py` to use the scheduled noise magnitude, passing the current iteration number where available. [[1]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L390-R415) [[2]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L516-R541) [[3]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L623-R648)

**Documentation and experiment configuration:**

* Added a new YAML exploration file demonstrating various noise scheduling options for experiments (`explorations/embedding_gaussian_noise_schedule.yaml`).