### PR TITLE
Add argmax ste

### DIFF
--- a/explorations/ste_argmax_softmax_comparison.yaml
+++ b/explorations/ste_argmax_softmax_comparison.yaml
@@ -1,0 +1,63 @@
+# Compare STE argmax-softmax vs baseline softmax using default_inf.yaml settings
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Embedding Norm
+  - named_group: "rmsnorm_wte"
+    norm_variant_wte: ["rmsnorm"]
+
+  # MLP Activation
+  - named_group: "squared_relu"
+    activation_variant: ["squared_relu"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "infinite"
+      - "mqa"
+      - "squared_relu"
+      - "rmsnorm_wte"
+      - "hd_100"
+    n_head: [3]
+    softmax_variant_attn: ["softmax", "ste_argmax_softmax"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -225,8 +225,8 @@ class GPTConfig:
     shared_attn_seq: int = 1
 
     # Softmax Alternatives and Options
-    softmax_variant_attn: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
-    softmax_variant_output: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
+    softmax_variant_attn: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax" "ste_argmax_softmax"
+    softmax_variant_output: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax" "ste_argmax_softmax"
 
 
     ## General Options

--- a/train_args.py
+++ b/train_args.py
@@ -1206,7 +1206,6 @@ def parse_args():
         "squareplus",
         "softshrink",
         "gelumax",
-        "exppolymax",
         "pfla_softmax",
         "ste_argmax_softmax",
         ]

--- a/train_args.py
+++ b/train_args.py
@@ -1208,6 +1208,7 @@ def parse_args():
         "gelumax",
         "exppolymax",
         "pfla_softmax",
+        "ste_argmax_softmax",
         ]
 
     ## Selection of softmax variation for attention and output layers

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -820,6 +820,42 @@ class PFLASoftmax(nn.Module):
 
 
 
+# STE Softmax-Argmax: argmax (one-hot) in forward, softmax gradients in backward
+class STEArgmaxSoftmax_func(torch.autograd.Function):
+    """Straight-Through Estimator: argmax in forward, softmax in backward."""
+    @staticmethod
+    def forward(ctx, x, dim):
+        softmax_out = torch.softmax(x, dim=dim)
+        ctx.save_for_backward(softmax_out)
+        ctx.dim = dim
+        # One-hot argmax
+        idx = x.argmax(dim=dim, keepdim=True)
+        one_hot = torch.zeros_like(x).scatter_(dim, idx, 1.0)
+        return one_hot
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        softmax_out, = ctx.saved_tensors
+        # Softmax Jacobian: diag(s) - s s^T applied to grad_output
+        grad_input = softmax_out * (grad_output - (grad_output * softmax_out).sum(dim=ctx.dim, keepdim=True))
+        return grad_input, None
+
+class STEArgmaxSoftmax(nn.Module):
+    """STE softmax variant: uses argmax (one-hot) in forward pass,
+    softmax gradients in backward pass."""
+    def __init__(self, config, dim=-1):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x):
+        if self.training:
+            return STEArgmaxSoftmax_func.apply(x, self.dim)
+        else:
+            # At inference, use argmax directly
+            idx = x.argmax(dim=self.dim, keepdim=True)
+            return torch.zeros_like(x).scatter_(self.dim, idx, 1.0)
+
+
 # Note: we use the built in library for regular softmax
 softmax_dictionary = {
     "consmax": ConSmax,
@@ -841,4 +877,5 @@ softmax_dictionary = {
     "softplus2max": Softplus2Max,
     "squareplus": Squareplus,
     "pfla_softmax": PFLASoftmax,
+    "ste_argmax_softmax": STEArgmaxSoftmax,
 }


### PR DESCRIPTION
This pull request introduces a new softmax variant called "STE argmax-softmax" and integrates it into the model configuration and training pipeline. The main goal is to enable experiments comparing the standard softmax attention mechanism with a straight-through estimator (STE) version that uses argmax in the forward pass and softmax gradients in the backward pass. The changes include the implementation of the new variant, updates to configuration options, and the addition of an example exploration YAML for experimentation.

**Implementation of STE argmax-softmax:**

* Added `STEArgmaxSoftmax_func` and `STEArgmaxSoftmax` classes to `variations/softmax_variations.py`, implementing a straight-through estimator that outputs a one-hot argmax in the forward pass and uses softmax gradients in the backward pass. The new variant is registered in the `softmax_dictionary` for use in the model. [[1]](diffhunk://#diff-124ed71dc807fa5e0f9f186f15a0070a81d25884798d9e05bbf5092a45a81c0bR823-R858) [[2]](diffhunk://#diff-124ed71dc807fa5e0f9f186f15a0070a81d25884798d9e05bbf5092a45a81c0bR880)

**Configuration and CLI integration:**

* Updated the `softmax_variant_attn` and `softmax_variant_output` configuration options in `gpt_conf.py` to include "ste_argmax_softmax" as a valid choice.
* Added "ste_argmax_softmax" to the list of valid command-line arguments for softmax variants in `train_args.py`.

**Experiment setup:**

* Added a new YAML configuration file `explorations/ste_argmax_softmax_comparison.yaml` to facilitate experiments comparing the baseline softmax with the STE argmax-softmax variant using the default settings.