### PR TITLE
Add demo for hanzi decomposition

### DIFF
--- a/data/han_decomp/v0/build_from_scratch.sh
+++ b/data/han_decomp/v0/build_from_scratch.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+DATA_DIR="$ROOT_DIR/data"
+INPUT_FILE=""
+DATASET_FILE=""
+MAP_FILE=""
+SYMBOLIC_FILE=""
+RECOVERED_FILE=""
+SERIALIZED_VIEW_FILE=""
+COMPARE_REPORT_FILE=""
+DECOMP_SOURCE="cjkvi"
+NORMALIZATION="conservative"
+SERIALIZATION_MODE="decomp-normalized"
+FORCE_DOWNLOAD=0
+FORCE_REBUILD_DATASET=0
+FORCE_REBUILD_MAP=0
+FORCE_REBUILD_SYMBOLIC=0
+FORCE_RECOVER=0
+RUN_SELF_TESTS=1
+CLEAN=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bash build_from_scratch.sh [options]
+
+Build the full Han decomposition + readable symbolic round-trip pipeline in the
+current folder.
+
+Default paths:
+  data/input.txt            input text (falls back to data/text_zho_Hans.txt)
+  data/han_main_block.jsonl built Han dataset
+  data/mapped.json          detailed reversible token map
+  data/input.readable.hsym  readable symbolic compact form
+  data/recovered_input.txt  exact recovered original bytes
+  data/serialized_view.txt  readable serialized/decomposition view
+  data/readable_compare_report.json  compare report
+
+Options:
+  --input PATH                    Input text file.
+  --data-dir PATH                 Data directory. Default: ./data
+  --dataset PATH                  Dataset output path.
+  --map PATH                      Mapped JSON output path.
+  --symbolic PATH                 Readable symbolic output path.
+  --recovered PATH                Recovered original output path.
+  --serialized-view PATH          Serialized text view output path.
+  --compare-report PATH           Compare report JSON path.
+  --decomp-source NAME            cjkvi | chise | cjk-decomp. Default: cjkvi
+  --normalization NAME            conservative | aggressive. Default: conservative
+  --mode NAME                     Symbolic serialization mode. Default: decomp-normalized
+  --force-download                Re-download source data.
+  --force-rebuild-dataset         Rebuild han_main_block.jsonl.
+  --force-rebuild-map             Rebuild mapped.json.
+  --force-rebuild-symbolic        Rebuild input.readable.hsym.
+  --force-recover                 Re-run recovery even if outputs are up to date.
+  --clean                         Remove generated outputs before rebuilding.
+  --no-self-tests                 Skip Python script self-tests.
+  --help                          Show this help.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 2
+}
+
+note() {
+  printf '[build] %s\n' "$*" >&2
+}
+
+run() {
+  printf '+ ' >&2
+  printf '%q ' "$@" >&2
+  printf '\n' >&2
+  "$@"
+}
+
+require_file() {
+  local path="$1"
+  local hint="${2:-}"
+  [[ -f "$path" ]] || die "Missing required file: $path${hint:+ ($hint)}"
+}
+
+resolve_input_file() {
+  if [[ -n "$INPUT_FILE" ]]; then
+    [[ -f "$INPUT_FILE" ]] || die "Input file not found: $INPUT_FILE"
+    return 0
+  fi
+  if [[ -f "$DATA_DIR/input.txt" ]]; then
+    INPUT_FILE="$DATA_DIR/input.txt"
+    return 0
+  fi
+  if [[ -f "$DATA_DIR/text_zho_Hans.txt" ]]; then
+    INPUT_FILE="$DATA_DIR/text_zho_Hans.txt"
+    return 0
+  fi
+  die "Could not find an input text file. Expected data/input.txt or data/text_zho_Hans.txt, or pass --input."
+}
+
+needs_rebuild() {
+  local target="$1"
+  shift || true
+  [[ ! -f "$target" ]] && return 0
+  local dep
+  for dep in "$@"; do
+    [[ -e "$dep" ]] || continue
+    [[ "$dep" -nt "$target" ]] && return 0
+  done
+  return 1
+}
+
+missing_downloads() {
+  local downloads_dir="$1"
+  local decomp_source="$2"
+  local decomp_name=""
+  case "$decomp_source" in
+    cjkvi) decomp_name="ids.txt" ;;
+    chise) decomp_name="IDS-UCS-Basic.txt" ;;
+    cjk-decomp) decomp_name="cjk-decomp.txt" ;;
+    *) die "Unsupported --decomp-source: $decomp_source" ;;
+  esac
+  local needed=(
+    "$downloads_dir/UnicodeData.txt"
+    "$downloads_dir/Unihan.zip"
+    "$downloads_dir/CJKRadicals.txt"
+    "$downloads_dir/EquivalentUnifiedIdeograph.txt"
+    "$downloads_dir/$decomp_name"
+  )
+  local f
+  for f in "${needed[@]}"; do
+    [[ -f "$f" ]] || return 0
+  done
+  return 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input)
+      [[ $# -ge 2 ]] || die "--input requires a value"
+      INPUT_FILE="$2"
+      shift 2
+      ;;
+    --data-dir)
+      [[ $# -ge 2 ]] || die "--data-dir requires a value"
+      DATA_DIR="$2"
+      shift 2
+      ;;
+    --dataset)
+      [[ $# -ge 2 ]] || die "--dataset requires a value"
+      DATASET_FILE="$2"
+      shift 2
+      ;;
+    --map)
+      [[ $# -ge 2 ]] || die "--map requires a value"
+      MAP_FILE="$2"
+      shift 2
+      ;;
+    --symbolic)
+      [[ $# -ge 2 ]] || die "--symbolic requires a value"
+      SYMBOLIC_FILE="$2"
+      shift 2
+      ;;
+    --recovered)
+      [[ $# -ge 2 ]] || die "--recovered requires a value"
+      RECOVERED_FILE="$2"
+      shift 2
+      ;;
+    --serialized-view)
+      [[ $# -ge 2 ]] || die "--serialized-view requires a value"
+      SERIALIZED_VIEW_FILE="$2"
+      shift 2
+      ;;
+    --compare-report)
+      [[ $# -ge 2 ]] || die "--compare-report requires a value"
+      COMPARE_REPORT_FILE="$2"
+      shift 2
+      ;;
+    --decomp-source)
+      [[ $# -ge 2 ]] || die "--decomp-source requires a value"
+      DECOMP_SOURCE="$2"
+      shift 2
+      ;;
+    --normalization)
+      [[ $# -ge 2 ]] || die "--normalization requires a value"
+      NORMALIZATION="$2"
+      shift 2
+      ;;
+    --mode)
+      [[ $# -ge 2 ]] || die "--mode requires a value"
+      SERIALIZATION_MODE="$2"
+      shift 2
+      ;;
+    --force-download)
+      FORCE_DOWNLOAD=1
+      shift
+      ;;
+    --force-rebuild-dataset)
+      FORCE_REBUILD_DATASET=1
+      shift
+      ;;
+    --force-rebuild-map)
+      FORCE_REBUILD_MAP=1
+      shift
+      ;;
+    --force-rebuild-symbolic)
+      FORCE_REBUILD_SYMBOLIC=1
+      shift
+      ;;
+    --force-recover)
+      FORCE_RECOVER=1
+      shift
+      ;;
+    --clean)
+      CLEAN=1
+      shift
+      ;;
+    --no-self-tests)
+      RUN_SELF_TESTS=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+mkdir -p "$DATA_DIR"
+resolve_input_file
+
+DATASET_FILE="${DATASET_FILE:-$DATA_DIR/han_main_block.jsonl}"
+MAP_FILE="${MAP_FILE:-$DATA_DIR/mapped.json}"
+SYMBOLIC_FILE="${SYMBOLIC_FILE:-$DATA_DIR/input.readable.hsym}"
+RECOVERED_FILE="${RECOVERED_FILE:-$DATA_DIR/recovered_input.txt}"
+SERIALIZED_VIEW_FILE="${SERIALIZED_VIEW_FILE:-$DATA_DIR/serialized_view.txt}"
+COMPARE_REPORT_FILE="${COMPARE_REPORT_FILE:-$DATA_DIR/readable_compare_report.json}"
+DOWNLOADS_DIR="$DATA_DIR/downloads"
+
+# Normalize to absolute paths when possible.
+DATA_DIR="$(cd "$DATA_DIR" && pwd)"
+INPUT_FILE="$(cd "$(dirname "$INPUT_FILE")" && pwd)/$(basename "$INPUT_FILE")"
+DATASET_FILE="$(mkdir -p "$(dirname "$DATASET_FILE")" && cd "$(dirname "$DATASET_FILE")" && pwd)/$(basename "$DATASET_FILE")"
+MAP_FILE="$(mkdir -p "$(dirname "$MAP_FILE")" && cd "$(dirname "$MAP_FILE")" && pwd)/$(basename "$MAP_FILE")"
+SYMBOLIC_FILE="$(mkdir -p "$(dirname "$SYMBOLIC_FILE")" && cd "$(dirname "$SYMBOLIC_FILE")" && pwd)/$(basename "$SYMBOLIC_FILE")"
+RECOVERED_FILE="$(mkdir -p "$(dirname "$RECOVERED_FILE")" && cd "$(dirname "$RECOVERED_FILE")" && pwd)/$(basename "$RECOVERED_FILE")"
+SERIALIZED_VIEW_FILE="$(mkdir -p "$(dirname "$SERIALIZED_VIEW_FILE")" && cd "$(dirname "$SERIALIZED_VIEW_FILE")" && pwd)/$(basename "$SERIALIZED_VIEW_FILE")"
+COMPARE_REPORT_FILE="$(mkdir -p "$(dirname "$COMPARE_REPORT_FILE")" && cd "$(dirname "$COMPARE_REPORT_FILE")" && pwd)/$(basename "$COMPARE_REPORT_FILE")"
+DOWNLOADS_DIR="$DATA_DIR/downloads"
+
+require_file "$ROOT_DIR/han_file_decomp_map_common.py"
+require_file "$ROOT_DIR/han_file_decomp_map_transform.py"
+require_file "$ROOT_DIR/han_file_symbolic_common.py"
+require_file "$ROOT_DIR/han_file_symbolic_serialize.py"
+require_file "$ROOT_DIR/han_file_symbolic_reverse.py"
+
+if (( CLEAN )); then
+  note "Removing generated outputs."
+  rm -f "$DATASET_FILE" "$MAP_FILE" "$SYMBOLIC_FILE" "$RECOVERED_FILE" "$SERIALIZED_VIEW_FILE" "$COMPARE_REPORT_FILE"
+fi
+
+if (( RUN_SELF_TESTS )); then
+  if [[ -f "$ROOT_DIR/han_main_block_decomp.py" ]]; then
+    note "Running han_main_block_decomp.py self-test"
+    run "$PYTHON_BIN" "$ROOT_DIR/han_main_block_decomp.py" self-test
+  fi
+  note "Running han_file_symbolic_serialize.py self-test"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_serialize.py" self-test
+fi
+
+if (( FORCE_DOWNLOAD )); then
+  require_file "$ROOT_DIR/han_main_block_decomp.py" "required to download source data"
+  note "Force-downloading source data into $DOWNLOADS_DIR"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_main_block_decomp.py" download \
+    --data-dir "$DATA_DIR" \
+    --decomp-source "$DECOMP_SOURCE" \
+    --force
+fi
+
+if (( FORCE_REBUILD_DATASET )) || [[ ! -f "$DATASET_FILE" ]]; then
+  require_file "$ROOT_DIR/han_main_block_decomp.py" "required to build $DATASET_FILE from scratch"
+  if missing_downloads "$DOWNLOADS_DIR" "$DECOMP_SOURCE"; then
+    note "Ensuring source data downloads exist in $DOWNLOADS_DIR"
+    run "$PYTHON_BIN" "$ROOT_DIR/han_main_block_decomp.py" download \
+      --data-dir "$DATA_DIR" \
+      --decomp-source "$DECOMP_SOURCE"
+  else
+    note "Reusing existing source downloads in $DOWNLOADS_DIR"
+  fi
+  note "Building main-block Han decomposition dataset"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_main_block_decomp.py" build \
+    --data-dir "$DATA_DIR" \
+    --decomp-source "$DECOMP_SOURCE" \
+    --download-missing \
+    --normalization "$NORMALIZATION" \
+    --output "$DATASET_FILE"
+else
+  note "Reusing existing dataset: $DATASET_FILE"
+fi
+
+if (( FORCE_REBUILD_MAP )) || needs_rebuild "$MAP_FILE" "$INPUT_FILE" "$DATASET_FILE" "$ROOT_DIR/han_file_decomp_map_transform.py" "$ROOT_DIR/han_file_decomp_map_common.py"; then
+  note "Building reversible mapped JSON"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_file_decomp_map_transform.py" build \
+    --input "$INPUT_FILE" \
+    --dataset "$DATASET_FILE" \
+    --output "$MAP_FILE"
+else
+  note "Reusing existing mapped file: $MAP_FILE"
+fi
+
+if (( FORCE_REBUILD_SYMBOLIC )) || needs_rebuild "$SYMBOLIC_FILE" "$MAP_FILE" "$ROOT_DIR/han_file_symbolic_serialize.py" "$ROOT_DIR/han_file_symbolic_common.py"; then
+  note "Building readable symbolic compact file"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_serialize.py" from-map \
+    --map "$MAP_FILE" \
+    --output "$SYMBOLIC_FILE" \
+    --mode "$SERIALIZATION_MODE" \
+    --include-han-metadata
+else
+  note "Reusing existing symbolic file: $SYMBOLIC_FILE"
+fi
+
+if (( FORCE_RECOVER )) || needs_rebuild "$RECOVERED_FILE" "$SYMBOLIC_FILE" "$ROOT_DIR/han_file_symbolic_reverse.py"; then
+  note "Recovering exact original bytes"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_reverse.py" recover \
+    --symbolic "$SYMBOLIC_FILE" \
+    --mode original-bytes \
+    --output "$RECOVERED_FILE"
+else
+  note "Reusing existing recovered file: $RECOVERED_FILE"
+fi
+
+if (( FORCE_RECOVER )) || needs_rebuild "$SERIALIZED_VIEW_FILE" "$SYMBOLIC_FILE" "$ROOT_DIR/han_file_symbolic_reverse.py"; then
+  note "Recovering serialized text view"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_reverse.py" recover \
+    --symbolic "$SYMBOLIC_FILE" \
+    --mode serialized-text \
+    --output "$SERIALIZED_VIEW_FILE"
+else
+  note "Reusing existing serialized view: $SERIALIZED_VIEW_FILE"
+fi
+
+note "Comparing recovered original bytes against the input"
+run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_reverse.py" compare \
+  --symbolic "$SYMBOLIC_FILE" \
+  --mode original-bytes \
+  --compare-to "$INPUT_FILE" \
+  --report-json "$COMPARE_REPORT_FILE"
+
+if cmp -s "$INPUT_FILE" "$RECOVERED_FILE"; then
+  note "Round trip confirmed: recovered file matches input byte-for-byte."
+else
+  die "Recovered file does not match the original input. See $COMPARE_REPORT_FILE"
+fi
+
+note "Done. Outputs:"
+printf '  input           %s\n' "$INPUT_FILE"
+printf '  dataset         %s\n' "$DATASET_FILE"
+printf '  mapped          %s\n' "$MAP_FILE"
+printf '  symbolic        %s\n' "$SYMBOLIC_FILE"
+printf '  recovered       %s\n' "$RECOVERED_FILE"
+printf '  serialized view %s\n' "$SERIALIZED_VIEW_FILE"
+printf '  compare report  %s\n' "$COMPARE_REPORT_FILE"

--- a/data/han_decomp/v0/demo.sh
+++ b/data/han_decomp/v0/demo.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+DATA_DIR="$ROOT_DIR/data"
+INPUT_FILE=""
+DECOMP_SOURCE="cjkvi"
+NORMALIZATION="conservative"
+SERIALIZATION_MODE="decomp-normalized"
+CLEAN=0
+SKIP_SELF_TESTS=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bash demo.sh [options]
+
+Walk through the full pipeline step by step:
+  1) optional self-tests
+  2) download Unicode/Unihan/IDS source files
+  3) build data/han_main_block.jsonl
+  4) build data/mapped.json
+  5) build data/input.readable.hsym
+  6) inspect the symbolic file
+  7) recover data/recovered_input.txt
+  8) compare recovered output against the original input
+  9) recover data/serialized_view.txt
+
+Options:
+  --input PATH            Input file. Default: data/input.txt, then data/text_zho_Hans.txt
+  --data-dir PATH         Data directory. Default: ./data
+  --decomp-source NAME    cjkvi | chise | cjk-decomp. Default: cjkvi
+  --normalization NAME    conservative | aggressive. Default: conservative
+  --mode NAME             Symbolic serialization mode. Default: decomp-normalized
+  --clean                 Remove generated outputs first.
+  --skip-self-tests       Skip self-tests.
+  --help                  Show this help.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 2
+}
+
+step() {
+  local msg="$1"
+  printf '\n========== %s ==========' "$msg"
+  printf '\n'
+}
+
+run() {
+  printf '+ ' >&2
+  printf '%q ' "$@" >&2
+  printf '\n' >&2
+  "$@"
+}
+
+resolve_input_file() {
+  if [[ -n "$INPUT_FILE" ]]; then
+    [[ -f "$INPUT_FILE" ]] || die "Input file not found: $INPUT_FILE"
+    return 0
+  fi
+  if [[ -f "$DATA_DIR/input.txt" ]]; then
+    INPUT_FILE="$DATA_DIR/input.txt"
+    return 0
+  fi
+  if [[ -f "$DATA_DIR/text_zho_Hans.txt" ]]; then
+    INPUT_FILE="$DATA_DIR/text_zho_Hans.txt"
+    return 0
+  fi
+  die "Could not find an input file. Expected data/input.txt or data/text_zho_Hans.txt, or pass --input."
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input)
+      [[ $# -ge 2 ]] || die "--input requires a value"
+      INPUT_FILE="$2"
+      shift 2
+      ;;
+    --data-dir)
+      [[ $# -ge 2 ]] || die "--data-dir requires a value"
+      DATA_DIR="$2"
+      shift 2
+      ;;
+    --decomp-source)
+      [[ $# -ge 2 ]] || die "--decomp-source requires a value"
+      DECOMP_SOURCE="$2"
+      shift 2
+      ;;
+    --normalization)
+      [[ $# -ge 2 ]] || die "--normalization requires a value"
+      NORMALIZATION="$2"
+      shift 2
+      ;;
+    --mode)
+      [[ $# -ge 2 ]] || die "--mode requires a value"
+      SERIALIZATION_MODE="$2"
+      shift 2
+      ;;
+    --clean)
+      CLEAN=1
+      shift
+      ;;
+    --skip-self-tests)
+      SKIP_SELF_TESTS=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+mkdir -p "$DATA_DIR"
+resolve_input_file
+
+DATASET_FILE="$DATA_DIR/han_main_block.jsonl"
+MAP_FILE="$DATA_DIR/mapped.json"
+SYMBOLIC_FILE="$DATA_DIR/input.readable.hsym"
+RECOVERED_FILE="$DATA_DIR/recovered_input.txt"
+SERIALIZED_VIEW_FILE="$DATA_DIR/serialized_view.txt"
+COMPARE_REPORT_FILE="$DATA_DIR/readable_compare_report.json"
+
+BUILDER_PRESENT=0
+if [[ -f "$ROOT_DIR/han_main_block_decomp.py" ]]; then
+  BUILDER_PRESENT=1
+fi
+[[ -f "$ROOT_DIR/han_file_decomp_map_transform.py" ]] || die "Missing $ROOT_DIR/han_file_decomp_map_transform.py"
+[[ -f "$ROOT_DIR/han_file_symbolic_serialize.py" ]] || die "Missing $ROOT_DIR/han_file_symbolic_serialize.py"
+[[ -f "$ROOT_DIR/han_file_symbolic_reverse.py" ]] || die "Missing $ROOT_DIR/han_file_symbolic_reverse.py"
+
+if (( CLEAN )); then
+  step "Cleaning previous generated outputs"
+  rm -f "$DATASET_FILE" "$MAP_FILE" "$SYMBOLIC_FILE" "$RECOVERED_FILE" "$SERIALIZED_VIEW_FILE" "$COMPARE_REPORT_FILE"
+  find "$DATA_DIR" -maxdepth 1 -type f -print | sort || true
+fi
+
+step "Environment"
+printf 'folder:      %s\n' "$ROOT_DIR"
+printf 'python:      %s\n' "$PYTHON_BIN"
+printf 'data dir:    %s\n' "$DATA_DIR"
+printf 'input file:  %s\n' "$INPUT_FILE"
+printf 'decomp src:  %s\n' "$DECOMP_SOURCE"
+printf 'normalize:   %s\n' "$NORMALIZATION"
+printf 'mode:        %s\n' "$SERIALIZATION_MODE"
+
+if (( ! SKIP_SELF_TESTS )); then
+  step "Step 1: run self-tests"
+  if (( BUILDER_PRESENT )); then
+    run "$PYTHON_BIN" "$ROOT_DIR/han_main_block_decomp.py" self-test
+  else
+    printf 'Skipping han_main_block_decomp.py self-test because that file is not present in this folder.\n'
+  fi
+  run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_serialize.py" self-test
+fi
+
+if (( BUILDER_PRESENT )); then
+  step "Step 2: download Unicode / Unihan / IDS sources (only if missing)"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_main_block_decomp.py" download \
+    --data-dir "$DATA_DIR" \
+    --decomp-source "$DECOMP_SOURCE"
+
+  step "Step 3: build the main-block Han dataset"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_main_block_decomp.py" build \
+    --data-dir "$DATA_DIR" \
+    --decomp-source "$DECOMP_SOURCE" \
+    --download-missing \
+    --normalization "$NORMALIZATION" \
+    --output "$DATASET_FILE"
+
+  step "Step 4: show dataset stats"
+  run "$PYTHON_BIN" "$ROOT_DIR/han_main_block_decomp.py" stats \
+    --dataset "$DATASET_FILE"
+else
+  [[ -f "$DATASET_FILE" ]] || die "han_main_block_decomp.py is missing and $DATASET_FILE does not exist, so the dataset cannot be built from scratch."
+  step "Steps 2-4: reuse the existing dataset"
+  printf 'han_main_block_decomp.py is not present, so this demo is reusing:\n  %s\n' "$DATASET_FILE"
+fi
+
+step "Step 5: build the detailed reversible token map"
+run "$PYTHON_BIN" "$ROOT_DIR/han_file_decomp_map_transform.py" build \
+  --input "$INPUT_FILE" \
+  --dataset "$DATASET_FILE" \
+  --output "$MAP_FILE"
+
+step "Step 6: build the readable symbolic compact file from mapped.json"
+run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_serialize.py" from-map \
+  --map "$MAP_FILE" \
+  --output "$SYMBOLIC_FILE" \
+  --mode "$SERIALIZATION_MODE" \
+  --include-han-metadata
+
+step "Step 7: inspect the symbolic file"
+run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_reverse.py" inspect \
+  --symbolic "$SYMBOLIC_FILE" \
+  --include-previews \
+  --preview-chars 240
+
+step "Step 8: preview the first lines of the symbolic file"
+sed -n '1,40p' "$SYMBOLIC_FILE"
+
+step "Step 9: recover the exact original input bytes"
+run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_reverse.py" recover \
+  --symbolic "$SYMBOLIC_FILE" \
+  --mode original-bytes \
+  --output "$RECOVERED_FILE"
+
+step "Step 10: compare the recovered bytes to the original input"
+run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_reverse.py" compare \
+  --symbolic "$SYMBOLIC_FILE" \
+  --mode original-bytes \
+  --compare-to "$INPUT_FILE" \
+  --report-json "$COMPARE_REPORT_FILE"
+
+if cmp -s "$INPUT_FILE" "$RECOVERED_FILE"; then
+  printf 'Exact byte-for-byte round trip confirmed.\n'
+else
+  die "Recovered file differs from the original. Inspect $COMPARE_REPORT_FILE"
+fi
+
+step "Step 11: also recover the serialized/decomposed text view"
+run "$PYTHON_BIN" "$ROOT_DIR/han_file_symbolic_reverse.py" recover \
+  --symbolic "$SYMBOLIC_FILE" \
+  --mode serialized-text \
+  --output "$SERIALIZED_VIEW_FILE"
+
+step "Step 12: generated outputs"
+ls -lh "$DATASET_FILE" "$MAP_FILE" "$SYMBOLIC_FILE" "$RECOVERED_FILE" "$SERIALIZED_VIEW_FILE" "$COMPARE_REPORT_FILE"
+
+printf '\nDemo complete.\n'

--- a/data/han_decomp/v0/han_file_decomp_map_common.py
+++ b/data/han_decomp/v0/han_file_decomp_map_common.py
@@ -1,0 +1,816 @@
+#!/usr/bin/env python3
+"""
+Shared helpers for reversible Han decomposition file maps.
+
+The map format is intentionally self-contained:
+  * exact original file bytes can be embedded once at the document level;
+  * each token preserves its original source span and editable current text;
+  * Han-main-block tokens optionally link to a full character inventory entry
+    plus a compact per-token decomposition summary.
+
+The implementation is scoped to UTF encodings because the caller explicitly
+asked for UTF text and because exact per-token byte-span recovery is far more
+reliable for UTF-8/16/32 than for stateful legacy encodings.
+"""
+from __future__ import annotations
+
+import base64
+import bisect
+import copy
+import dataclasses
+import datetime as _dt
+import hashlib
+import json
+import sys
+import unicodedata
+import zlib
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+
+SCHEMA_VERSION = "han-file-map/v1"
+MAIN_BLOCK_START = 0x4E00
+MAIN_BLOCK_END = 0x9FFF
+MAIN_BLOCK_NAME = "CJK Unified Ideographs"
+DEFAULT_COMPONENT_SEPARATOR = " "
+DEFAULT_TOKEN_SEPARATOR = ""
+DEFAULT_PAYLOAD_CODEC = "zlib+base64"
+SUPPORTED_MAP_FORMATS = {"json", "jsonl"}
+SUPPORTED_PAYLOAD_CODECS = {"base64", "zlib+base64"}
+SUPPORTED_UTF_ENCODINGS = {
+    "utf-8",
+    "utf8",
+    "utf-8-sig",
+    "utf8-sig",
+    "utf-16",
+    "utf16",
+    "utf-16-le",
+    "utf16le",
+    "utf-16-be",
+    "utf16be",
+    "utf-32",
+    "utf32",
+    "utf-32-le",
+    "utf32le",
+    "utf-32-be",
+    "utf32be",
+}
+UTF8_BOM = b"\xef\xbb\xbf"
+UTF16_LE_BOM = b"\xff\xfe"
+UTF16_BE_BOM = b"\xfe\xff"
+UTF32_LE_BOM = b"\xff\xfe\x00\x00"
+UTF32_BE_BOM = b"\x00\x00\xfe\xff"
+
+
+class HanFileMapError(Exception):
+    """Base exception for reversible file-map helpers."""
+
+
+@dataclasses.dataclass(frozen=True)
+class UTFEncodingPlan:
+    requested_encoding: str
+    normalized_requested_encoding: str
+    decode_encoding: str
+    encode_encoding: str
+    errors: str
+    bom_bytes: bytes
+
+    def to_dict(self) -> dict:
+        return {
+            "requested_encoding": self.requested_encoding,
+            "normalized_requested_encoding": self.normalized_requested_encoding,
+            "decode_encoding": self.decode_encoding,
+            "encode_encoding": self.encode_encoding,
+            "errors": self.errors,
+            "bom_bytes_b64": b64encode_bytes(self.bom_bytes),
+            "bom_length": len(self.bom_bytes),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "UTFEncodingPlan":
+        try:
+            return cls(
+                requested_encoding=data["requested_encoding"],
+                normalized_requested_encoding=data["normalized_requested_encoding"],
+                decode_encoding=data["decode_encoding"],
+                encode_encoding=data["encode_encoding"],
+                errors=data.get("errors", "strict"),
+                bom_bytes=b64decode_bytes(data.get("bom_bytes_b64", "")),
+            )
+        except KeyError as exc:
+            raise HanFileMapError(f"Malformed encoding plan in map: missing {exc}") from exc
+
+
+@dataclasses.dataclass(frozen=True)
+class Position:
+    line: int
+    column: int
+
+
+def stderr(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def b64encode_bytes(data: bytes) -> str:
+    if not data:
+        return ""
+    return base64.b64encode(data).decode("ascii")
+
+
+def b64decode_bytes(data: str) -> bytes:
+    if not data:
+        return b""
+    return base64.b64decode(data.encode("ascii"))
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_text_utf8(text: str) -> str:
+    return sha256_bytes(text.encode("utf-8"))
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def iso_utc_now() -> str:
+    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def normalize_encoding_label(label: str) -> str:
+    return label.strip().lower().replace("_", "-")
+
+
+def is_main_block_char(ch: str) -> bool:
+    return len(ch) == 1 and MAIN_BLOCK_START <= ord(ch) <= MAIN_BLOCK_END
+
+
+def cp_to_uplus(cp: int) -> str:
+    if cp <= 0xFFFF:
+        return f"U+{cp:04X}"
+    return f"U+{cp:06X}"
+
+
+def char_codepoints(text: str) -> List[str]:
+    return [cp_to_uplus(ord(ch)) for ch in text]
+
+
+def detect_utf_plan(raw_bytes: bytes, encoding: str, errors: str) -> UTFEncodingPlan:
+    norm = normalize_encoding_label(encoding)
+    if norm not in SUPPORTED_UTF_ENCODINGS:
+        raise HanFileMapError(
+            "This mapper only supports UTF encodings for exact reversible byte spans. "
+            f"Got: {encoding!r}. Use UTF-8/16/32 or transcode first."
+        )
+
+    if norm in {"utf-8", "utf8"}:
+        return UTFEncodingPlan(encoding, norm, "utf-8", "utf-8", errors, b"")
+
+    if norm in {"utf-8-sig", "utf8-sig"}:
+        bom = UTF8_BOM if raw_bytes.startswith(UTF8_BOM) else b""
+        return UTFEncodingPlan(encoding, norm, "utf-8-sig", "utf-8", errors, bom)
+
+    if norm in {"utf-16", "utf16"}:
+        if raw_bytes.startswith(UTF16_LE_BOM):
+            return UTFEncodingPlan(encoding, norm, "utf-16", "utf-16-le", errors, UTF16_LE_BOM)
+        if raw_bytes.startswith(UTF16_BE_BOM):
+            return UTFEncodingPlan(encoding, norm, "utf-16", "utf-16-be", errors, UTF16_BE_BOM)
+        endian = "utf-16-le" if sys.byteorder == "little" else "utf-16-be"
+        return UTFEncodingPlan(encoding, norm, "utf-16", endian, errors, b"")
+
+    if norm in {"utf-16-le", "utf16le"}:
+        return UTFEncodingPlan(encoding, norm, "utf-16-le", "utf-16-le", errors, b"")
+    if norm in {"utf-16-be", "utf16be"}:
+        return UTFEncodingPlan(encoding, norm, "utf-16-be", "utf-16-be", errors, b"")
+
+    if norm in {"utf-32", "utf32"}:
+        if raw_bytes.startswith(UTF32_LE_BOM):
+            return UTFEncodingPlan(encoding, norm, "utf-32", "utf-32-le", errors, UTF32_LE_BOM)
+        if raw_bytes.startswith(UTF32_BE_BOM):
+            return UTFEncodingPlan(encoding, norm, "utf-32", "utf-32-be", errors, UTF32_BE_BOM)
+        endian = "utf-32-le" if sys.byteorder == "little" else "utf-32-be"
+        return UTFEncodingPlan(encoding, norm, "utf-32", endian, errors, b"")
+
+    if norm in {"utf-32-le", "utf32le"}:
+        return UTFEncodingPlan(encoding, norm, "utf-32-le", "utf-32-le", errors, b"")
+    if norm in {"utf-32-be", "utf32be"}:
+        return UTFEncodingPlan(encoding, norm, "utf-32-be", "utf-32-be", errors, b"")
+
+    raise HanFileMapError(f"Unsupported UTF encoding plan: {encoding!r}")
+
+
+def decode_text(raw_bytes: bytes, plan: UTFEncodingPlan) -> str:
+    try:
+        return raw_bytes.decode(plan.decode_encoding, plan.errors)
+    except UnicodeError as exc:
+        raise HanFileMapError(
+            f"Failed to decode input bytes using {plan.decode_encoding!r} with errors={plan.errors!r}: {exc}"
+        ) from exc
+
+
+def encode_text(text: str, plan: UTFEncodingPlan, *, preserve_bom: bool = True, errors: Optional[str] = None) -> bytes:
+    err = plan.errors if errors is None else errors
+    try:
+        encoded = text.encode(plan.encode_encoding, err)
+    except UnicodeError as exc:
+        raise HanFileMapError(
+            f"Failed to encode text using {plan.encode_encoding!r} with errors={err!r}: {exc}"
+        ) from exc
+    if preserve_bom and plan.bom_bytes:
+        return plan.bom_bytes + encoded
+    return encoded
+
+
+def encode_payload(raw_bytes: bytes, codec: str) -> dict:
+    if codec not in SUPPORTED_PAYLOAD_CODECS:
+        raise HanFileMapError(f"Unsupported payload codec: {codec}")
+    if codec == "base64":
+        stored = raw_bytes
+    else:
+        stored = zlib.compress(raw_bytes, level=9)
+    return {
+        "codec": codec,
+        "size_bytes": len(raw_bytes),
+        "sha256_bytes": sha256_bytes(raw_bytes),
+        "data_b64": b64encode_bytes(stored),
+    }
+
+
+def decode_payload(payload: Optional[dict]) -> Optional[bytes]:
+    if payload is None:
+        return None
+    codec = payload.get("codec")
+    data_b64 = payload.get("data_b64")
+    if codec is None or data_b64 is None:
+        raise HanFileMapError("Malformed payload block in mapped file")
+    data = b64decode_bytes(data_b64)
+    if codec == "base64":
+        raw = data
+    elif codec == "zlib+base64":
+        try:
+            raw = zlib.decompress(data)
+        except zlib.error as exc:
+            raise HanFileMapError(f"Failed to decompress payload: {exc}") from exc
+    else:
+        raise HanFileMapError(f"Unsupported payload codec in map: {codec}")
+    expected_hash = payload.get("sha256_bytes")
+    if expected_hash and sha256_bytes(raw) != expected_hash:
+        raise HanFileMapError("Embedded original payload hash mismatch")
+    return raw
+
+
+def count_newline_kinds(text: str) -> Dict[str, int]:
+    counts = {"CRLF": 0, "LF": 0, "CR": 0}
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "\r":
+            if i + 1 < len(text) and text[i + 1] == "\n":
+                counts["CRLF"] += 1
+                i += 2
+                continue
+            counts["CR"] += 1
+        elif ch == "\n":
+            counts["LF"] += 1
+        i += 1
+    return counts
+
+
+def build_line_start_offsets(text: str) -> List[int]:
+    starts = [0]
+    offset = 0
+    if not text:
+        return starts
+    for segment in text.splitlines(keepends=True):
+        offset += len(segment)
+        starts.append(offset)
+    if starts[-1] != len(text):
+        starts.append(len(text))
+    return starts
+
+
+def offset_to_line_col(offset: int, line_starts: Sequence[int]) -> Position:
+    if offset < 0:
+        raise HanFileMapError(f"Negative text offset: {offset}")
+    idx = bisect.bisect_right(line_starts, offset) - 1
+    if idx < 0:
+        idx = 0
+    if idx >= len(line_starts):
+        idx = len(line_starts) - 1
+    return Position(line=idx + 1, column=(offset - line_starts[idx]) + 1)
+
+
+def classify_char(ch: str) -> str:
+    if ch in {"\r", "\n"}:
+        return "newline"
+    if is_main_block_char(ch):
+        return "han_main_block"
+    if ch.isspace():
+        return "whitespace"
+    return "other"
+
+
+def unicode_name_safe(ch: str) -> Optional[str]:
+    try:
+        return unicodedata.name(ch)
+    except ValueError:
+        return None
+
+
+def deep_copy_jsonable(value):
+    return copy.deepcopy(value)
+
+
+def iter_decomposition_records(dataset_path: Path) -> Iterator[dict]:
+    suffix = dataset_path.suffix.lower()
+    if suffix == ".jsonl":
+        with dataset_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                if line.strip():
+                    yield json.loads(line)
+        return
+    if suffix == ".json":
+        with dataset_path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, list):
+            raise HanFileMapError(f"Expected top-level list in decomposition dataset: {dataset_path}")
+        for item in data:
+            yield item
+        return
+    raise HanFileMapError(f"Unsupported decomposition dataset format: {dataset_path}")
+
+
+def load_decomposition_subset(dataset_path: Path, wanted_chars: Iterable[str]) -> Dict[str, dict]:
+    wanted = set(wanted_chars)
+    out: Dict[str, dict] = {}
+    if not wanted:
+        return out
+    for record in iter_decomposition_records(dataset_path):
+        ch = record.get("char")
+        if ch in wanted and ch not in out:
+            out[ch] = record
+            if len(out) == len(wanted):
+                break
+    return out
+
+
+def build_decomposition_summary(char_record: Optional[dict], component_separator: str) -> Optional[dict]:
+    if not char_record:
+        return None
+    decomp = char_record.get("decomposition") or {}
+    unihan = char_record.get("unihan") or {}
+    raw_leaf = list(decomp.get("leaf_components_raw") or [])
+    normalized_leaf = list(decomp.get("leaf_radicals_normalized") or [])
+    return {
+        "available": True,
+        "primary_raw": decomp.get("primary_raw"),
+        "immediate_components": list(decomp.get("immediate_components") or []),
+        "leaf_components_raw": raw_leaf,
+        "leaf_radicals_normalized": normalized_leaf,
+        "leaf_components_raw_unique": list(decomp.get("leaf_components_raw_unique") or []),
+        "leaf_radicals_normalized_unique": list(decomp.get("leaf_radicals_normalized_unique") or []),
+        "unresolved_tokens": list(decomp.get("unresolved_tokens") or []),
+        "expanded_tree": deep_copy_jsonable(decomp.get("expanded_tree")),
+        "render_raw_default": component_separator.join(raw_leaf),
+        "render_normalized_default": component_separator.join(normalized_leaf),
+        "kRSUnicode": deep_copy_jsonable(unihan.get("kRSUnicode")),
+        "kTotalStrokes": deep_copy_jsonable(unihan.get("kTotalStrokes")),
+        "kDefinition": unihan.get("kDefinition"),
+    }
+
+
+def make_inventory(
+    chars_in_order: Sequence[str],
+    occurrence_counts: Dict[str, int],
+    record_lookup: Dict[str, dict],
+) -> Tuple[List[dict], Dict[str, int]]:
+    inventory: List[dict] = []
+    index_by_char: Dict[str, int] = {}
+    for ch in chars_in_order:
+        if ch in index_by_char:
+            continue
+        idx = len(inventory)
+        index_by_char[ch] = idx
+        inventory.append(
+            {
+                "inventory_index": idx,
+                "char": ch,
+                "occurrence_count": occurrence_counts.get(ch, 0),
+                "record_available": ch in record_lookup,
+                "char_record": deep_copy_jsonable(record_lookup.get(ch)),
+            }
+        )
+    return inventory, index_by_char
+
+
+def dedupe_preserve_order(items: Iterable[str]) -> List[str]:
+    seen = set()
+    out: List[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def build_token_records(
+    text: str,
+    plan: UTFEncodingPlan,
+    record_lookup: Dict[str, dict],
+    component_separator: str,
+) -> Tuple[List[dict], List[dict], Dict[str, int]]:
+    line_starts = build_line_start_offsets(text)
+    han_chars_in_text = [ch for ch in text if is_main_block_char(ch)]
+    unique_han_first_order = dedupe_preserve_order(han_chars_in_text)
+    occurrence_counts: Dict[str, int] = {}
+    for ch in han_chars_in_text:
+        occurrence_counts[ch] = occurrence_counts.get(ch, 0) + 1
+    inventory, inventory_index = make_inventory(unique_han_first_order, occurrence_counts, record_lookup)
+
+    tokens: List[dict] = []
+    byte_offset = len(plan.bom_bytes)
+    for token_id, ch in enumerate(text):
+        char_start = token_id
+        char_end = token_id + 1
+        encoded = ch.encode(plan.encode_encoding, plan.errors)
+        byte_start = byte_offset
+        byte_end = byte_start + len(encoded)
+        byte_offset = byte_end
+        start_pos = offset_to_line_col(char_start, line_starts)
+        end_pos = offset_to_line_col(char_end, line_starts)
+        kind = classify_char(ch)
+        inv_idx = inventory_index.get(ch) if is_main_block_char(ch) else None
+        char_record = record_lookup.get(ch) if is_main_block_char(ch) else None
+        token = {
+            "token_id": token_id,
+            "kind": kind,
+            "text_original": ch,
+            "text_current": ch,
+            "original_length_codepoints": len(ch),
+            "codepoints": char_codepoints(ch),
+            "codepoint_ints": [ord(cp) for cp in ch],
+            "unicode_name": unicode_name_safe(ch),
+            "general_category": unicodedata.category(ch),
+            "inventory_index": inv_idx,
+            "positions": {
+                "char_start": char_start,
+                "char_end": char_end,
+                "byte_start": byte_start,
+                "byte_end": byte_end,
+                "line_start": start_pos.line,
+                "column_start": start_pos.column,
+                "line_end": end_pos.line,
+                "column_end": end_pos.column,
+            },
+            "decomposition": build_decomposition_summary(char_record, component_separator) if inv_idx is not None else None,
+            "annotations": {},
+        }
+        tokens.append(token)
+    return tokens, inventory, inventory_index
+
+
+def reconstruct_token_text(
+    token: dict,
+    *,
+    mode: str,
+    component_separator: str,
+    preserve_non_han: bool = True,
+    missing_han_fallback: str = "current",
+) -> str:
+    if mode == "original-text":
+        return token.get("text_original", "")
+    if mode == "current-text":
+        return token.get("text_current", token.get("text_original", ""))
+
+    if mode not in {"decomp-raw", "decomp-normalized"}:
+        raise HanFileMapError(f"Unsupported reconstruction mode: {mode}")
+
+    if token.get("kind") != "han_main_block":
+        if preserve_non_han:
+            return token.get("text_current", token.get("text_original", ""))
+        return ""
+
+    decomp = token.get("decomposition") or {}
+    if mode == "decomp-raw":
+        seq = list(decomp.get("leaf_components_raw") or [])
+    else:
+        seq = list(decomp.get("leaf_radicals_normalized") or [])
+
+    if seq:
+        return component_separator.join(seq)
+
+    if missing_han_fallback == "current":
+        return token.get("text_current", token.get("text_original", ""))
+    if missing_han_fallback == "original":
+        return token.get("text_original", "")
+    if missing_han_fallback == "empty":
+        return ""
+    raise HanFileMapError(f"Unsupported missing Han fallback: {missing_han_fallback}")
+
+
+def reconstruct_text_from_tokens(
+    tokens: Sequence[dict],
+    *,
+    mode: str,
+    component_separator: str,
+    token_separator: str = DEFAULT_TOKEN_SEPARATOR,
+    preserve_non_han: bool = True,
+    missing_han_fallback: str = "current",
+) -> str:
+    rendered = [
+        reconstruct_token_text(
+            token,
+            mode=mode,
+            component_separator=component_separator,
+            preserve_non_han=preserve_non_han,
+            missing_han_fallback=missing_han_fallback,
+        )
+        for token in tokens
+    ]
+    return token_separator.join(rendered)
+
+
+def first_difference(a: bytes, b: bytes) -> Optional[dict]:
+    limit = min(len(a), len(b))
+    for idx in range(limit):
+        if a[idx] != b[idx]:
+            return {
+                "offset": idx,
+                "a_byte_hex": f"{a[idx]:02X}",
+                "b_byte_hex": f"{b[idx]:02X}",
+            }
+    if len(a) != len(b):
+        return {
+            "offset": limit,
+            "a_byte_hex": f"{a[limit]:02X}" if len(a) > limit else None,
+            "b_byte_hex": f"{b[limit]:02X}" if len(b) > limit else None,
+        }
+    return None
+
+
+def changed_tokens_for_mode(
+    tokens: Sequence[dict],
+    *,
+    mode: str,
+    component_separator: str,
+    preserve_non_han: bool = True,
+    missing_han_fallback: str = "current",
+) -> List[dict]:
+    out: List[dict] = []
+    for token in tokens:
+        original = token.get("text_original", "")
+        rendered = reconstruct_token_text(
+            token,
+            mode=mode,
+            component_separator=component_separator,
+            preserve_non_han=preserve_non_han,
+            missing_han_fallback=missing_han_fallback,
+        )
+        if rendered != original:
+            out.append(
+                {
+                    "token_id": token.get("token_id"),
+                    "kind": token.get("kind"),
+                    "positions": deep_copy_jsonable(token.get("positions")),
+                    "text_original": original,
+                    "rendered_text": rendered,
+                    "text_current": token.get("text_current", original),
+                    "inventory_index": token.get("inventory_index"),
+                    "codepoints": list(token.get("codepoints") or []),
+                }
+            )
+    return out
+
+
+def current_text_edits(tokens: Sequence[dict]) -> List[dict]:
+    edits: List[dict] = []
+    for token in tokens:
+        original = token.get("text_original", "")
+        current = token.get("text_current", original)
+        if current != original:
+            edits.append(
+                {
+                    "token_id": token.get("token_id"),
+                    "kind": token.get("kind"),
+                    "positions": deep_copy_jsonable(token.get("positions")),
+                    "text_original": original,
+                    "text_current": current,
+                    "inventory_index": token.get("inventory_index"),
+                    "codepoints": list(token.get("codepoints") or []),
+                }
+            )
+    return edits
+
+
+def write_map_document(document: dict, output_path: Path, output_format: str) -> None:
+    if output_format not in SUPPORTED_MAP_FORMATS:
+        raise HanFileMapError(f"Unsupported map output format: {output_format}")
+    ensure_parent_dir(output_path)
+    if output_format == "json":
+        with output_path.open("w", encoding="utf-8") as fh:
+            json.dump(document, fh, ensure_ascii=False, indent=2)
+            fh.write("\n")
+        return
+
+    doc_header = {k: v for k, v in document.items() if k not in {"inventory", "tokens"}}
+    with output_path.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"record_type": "document", **doc_header}, ensure_ascii=False))
+        fh.write("\n")
+        for inv in document.get("inventory", []):
+            fh.write(json.dumps({"record_type": "inventory", **inv}, ensure_ascii=False))
+            fh.write("\n")
+        for token in document.get("tokens", []):
+            fh.write(json.dumps({"record_type": "token", **token}, ensure_ascii=False))
+            fh.write("\n")
+
+
+def load_map_document(path: Path) -> dict:
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        with path.open("r", encoding="utf-8") as fh:
+            doc = json.load(fh)
+        validate_map_document(doc)
+        return doc
+
+    if suffix == ".jsonl":
+        header = None
+        inventory: List[dict] = []
+        tokens: List[dict] = []
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                record = json.loads(line)
+                rtype = record.pop("record_type", None)
+                if rtype == "document":
+                    header = record
+                elif rtype == "inventory":
+                    inventory.append(record)
+                elif rtype == "token":
+                    tokens.append(record)
+                else:
+                    raise HanFileMapError(f"Unknown JSONL map record_type: {rtype}")
+        if header is None:
+            raise HanFileMapError(f"Missing document header in JSONL map: {path}")
+        doc = dict(header)
+        doc["inventory"] = inventory
+        doc["tokens"] = tokens
+        validate_map_document(doc)
+        return doc
+
+    raise HanFileMapError(f"Unsupported mapped file format: {path}")
+
+
+def validate_map_document(document: dict) -> None:
+    schema = document.get("schema_version")
+    if schema != SCHEMA_VERSION:
+        raise HanFileMapError(f"Unsupported or missing schema_version: {schema!r}")
+    if not isinstance(document.get("tokens"), list):
+        raise HanFileMapError("Mapped document missing token list")
+    if not isinstance(document.get("inventory"), list):
+        raise HanFileMapError("Mapped document missing inventory list")
+    source_document = document.get("source_document") or {}
+    if "encoding_plan" not in source_document:
+        raise HanFileMapError("Mapped document missing source_document.encoding_plan")
+
+    inventory_len = len(document["inventory"])
+    prev_char_end = 0
+    prev_byte_end = None
+    for expected_id, token in enumerate(document["tokens"]):
+        token_id = token.get("token_id")
+        if token_id != expected_id:
+            raise HanFileMapError(f"Token IDs must be contiguous and ordered; expected {expected_id}, got {token_id}")
+        positions = token.get("positions") or {}
+        char_start = positions.get("char_start")
+        char_end = positions.get("char_end")
+        byte_start = positions.get("byte_start")
+        byte_end = positions.get("byte_end")
+        if None in {char_start, char_end, byte_start, byte_end}:
+            raise HanFileMapError(f"Token {token_id} is missing position fields")
+        if char_start != prev_char_end:
+            raise HanFileMapError(f"Non-contiguous char spans at token {token_id}")
+        if char_end < char_start:
+            raise HanFileMapError(f"Invalid char span at token {token_id}")
+        if prev_byte_end is not None and byte_start != prev_byte_end:
+            raise HanFileMapError(f"Non-contiguous byte spans at token {token_id}")
+        if byte_end < byte_start:
+            raise HanFileMapError(f"Invalid byte span at token {token_id}")
+        prev_char_end = char_end
+        prev_byte_end = byte_end
+        inv_idx = token.get("inventory_index")
+        if inv_idx is not None and not (0 <= inv_idx < inventory_len):
+            raise HanFileMapError(f"Token {token_id} inventory_index out of range: {inv_idx}")
+
+
+def map_original_bytes(document: dict) -> Optional[bytes]:
+    payload = document.get("original_payload")
+    if payload is None:
+        return None
+    return decode_payload(payload)
+
+
+def map_encoding_plan(document: dict) -> UTFEncodingPlan:
+    src = document.get("source_document") or {}
+    return UTFEncodingPlan.from_dict(src["encoding_plan"])
+
+
+def reconstruct_original_bytes(document: dict) -> bytes:
+    raw = map_original_bytes(document)
+    if raw is not None:
+        return raw
+    plan = map_encoding_plan(document)
+    text = reconstruct_text_from_tokens(
+        document["tokens"],
+        mode="original-text",
+        component_separator=document.get("tokenization", {}).get("component_separator_default", DEFAULT_COMPONENT_SEPARATOR),
+    )
+    return encode_text(text, plan, preserve_bom=True)
+
+
+def diff_lines(a_text: str, b_text: str, *, fromfile: str, tofile: str, context: int) -> List[str]:
+    import difflib
+
+    return list(
+        difflib.unified_diff(
+            a_text.splitlines(keepends=True),
+            b_text.splitlines(keepends=True),
+            fromfile=fromfile,
+            tofile=tofile,
+            n=context,
+        )
+    )
+
+
+def document_text_from_original_bytes(document: dict) -> str:
+    raw = reconstruct_original_bytes(document)
+    plan = map_encoding_plan(document)
+    return decode_text(raw, plan)
+
+
+def source_slice_bytes(document: dict, token: dict) -> bytes:
+    raw = reconstruct_original_bytes(document)
+    pos = token["positions"]
+    return raw[pos["byte_start"] : pos["byte_end"]]
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "MAIN_BLOCK_NAME",
+    "DEFAULT_COMPONENT_SEPARATOR",
+    "DEFAULT_TOKEN_SEPARATOR",
+    "DEFAULT_PAYLOAD_CODEC",
+    "HanFileMapError",
+    "UTFEncodingPlan",
+    "stderr",
+    "ensure_parent_dir",
+    "b64encode_bytes",
+    "b64decode_bytes",
+    "sha256_bytes",
+    "sha256_text_utf8",
+    "sha256_file",
+    "iso_utc_now",
+    "normalize_encoding_label",
+    "is_main_block_char",
+    "cp_to_uplus",
+    "char_codepoints",
+    "detect_utf_plan",
+    "decode_text",
+    "encode_text",
+    "encode_payload",
+    "decode_payload",
+    "count_newline_kinds",
+    "build_line_start_offsets",
+    "offset_to_line_col",
+    "classify_char",
+    "unicode_name_safe",
+    "deep_copy_jsonable",
+    "iter_decomposition_records",
+    "load_decomposition_subset",
+    "build_decomposition_summary",
+    "make_inventory",
+    "dedupe_preserve_order",
+    "build_token_records",
+    "reconstruct_token_text",
+    "reconstruct_text_from_tokens",
+    "first_difference",
+    "changed_tokens_for_mode",
+    "current_text_edits",
+    "write_map_document",
+    "load_map_document",
+    "validate_map_document",
+    "map_original_bytes",
+    "map_encoding_plan",
+    "reconstruct_original_bytes",
+    "diff_lines",
+    "document_text_from_original_bytes",
+    "source_slice_bytes",
+]

--- a/data/han_decomp/v0/han_file_decomp_map_transform.py
+++ b/data/han_decomp/v0/han_file_decomp_map_transform.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+Transform a UTF text file into a self-contained reversible token map enriched
+with Han main-block decomposition metadata.
+
+Typical flow:
+  1. Build the character dataset with han_main_block_decomp.py.
+  2. Run this script on a UTF text file.
+  3. Optionally edit token[...]["text_current"] or consume token-level
+     decomposition features downstream.
+  4. Use han_file_decomp_map_reverse.py to recover, diff, and validate.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Optional, Sequence
+
+from han_file_decomp_map_common import (
+    SCHEMA_VERSION,
+    DEFAULT_COMPONENT_SEPARATOR,
+    DEFAULT_PAYLOAD_CODEC,
+    HanFileMapError,
+    build_token_records,
+    count_newline_kinds,
+    decode_text,
+    dedupe_preserve_order,
+    detect_utf_plan,
+    encode_payload,
+    encode_text,
+    iso_utc_now,
+    is_main_block_char,
+    load_decomposition_subset,
+    sha256_bytes,
+    sha256_file,
+    sha256_text_utf8,
+    stderr,
+    write_map_document,
+    load_map_document,
+)
+
+SCRIPT_NAME = "han_file_decomp_map_transform.py"
+SCRIPT_VERSION = "1.0.0"
+
+
+def infer_output_format(output_path: Path, explicit: Optional[str]) -> str:
+    if explicit:
+        return explicit
+    suffix = output_path.suffix.lower()
+    if suffix in {".json", ".jsonl"}:
+        return suffix[1:]
+    return "json"
+
+
+def build_mapped_document(
+    *,
+    input_path: Path,
+    dataset_path: Path,
+    encoding: str,
+    errors: str,
+    component_separator: str,
+    payload_codec: str,
+    embed_original_bytes: bool,
+) -> dict:
+    raw_bytes = input_path.read_bytes()
+    plan = detect_utf_plan(raw_bytes, encoding, errors)
+    text = decode_text(raw_bytes, plan)
+
+    # Fail early if the decoded text cannot be losslessly re-encoded under the
+    # chosen UTF plan. Exact byte recovery is part of the design contract.
+    roundtrip = encode_text(text, plan, preserve_bom=True)
+    if roundtrip != raw_bytes:
+        raise HanFileMapError(
+            "Input file did not round-trip exactly under the chosen UTF encoding plan. "
+            "Use the correct UTF encoding and error handler so the reversible map "
+            "can preserve exact bytes."
+        )
+
+    wanted_han_chars = dedupe_preserve_order(ch for ch in text if is_main_block_char(ch))
+    record_lookup = load_decomposition_subset(dataset_path, wanted_han_chars)
+    tokens, inventory, _inventory_index = build_token_records(text, plan, record_lookup, component_separator)
+
+    expected_final_byte = len(raw_bytes)
+    actual_final_byte = tokens[-1]["positions"]["byte_end"] if tokens else len(plan.bom_bytes)
+    if actual_final_byte != expected_final_byte:
+        raise HanFileMapError(
+            f"Token byte spans do not cover the original file exactly: {actual_final_byte} != {expected_final_byte}"
+        )
+
+    missing_han = [
+        {
+            "char": ch,
+            "codepoint": f"U+{ord(ch):04X}",
+        }
+        for ch in wanted_han_chars
+        if ch not in record_lookup
+    ]
+
+    line_count = text.count("\n") + text.count("\r") - count_newline_kinds(text)["CRLF"] + 1 if text else 1
+    document = {
+        "schema_version": SCHEMA_VERSION,
+        "generator": {
+            "script": SCRIPT_NAME,
+            "version": SCRIPT_VERSION,
+            "created_at_utc": iso_utc_now(),
+        },
+        "source_document": {
+            "path": str(input_path),
+            "filename": input_path.name,
+            "byte_length": len(raw_bytes),
+            "sha256_bytes": sha256_bytes(raw_bytes),
+            "text_length_codepoints": len(text),
+            "text_sha256_utf8": sha256_text_utf8(text),
+            "line_count": line_count,
+            "newline_counts": count_newline_kinds(text),
+            "encoding_plan": plan.to_dict(),
+        },
+        "original_payload": encode_payload(raw_bytes, payload_codec) if embed_original_bytes else None,
+        "decomposition_dataset": {
+            "path": str(dataset_path),
+            "filename": dataset_path.name,
+            "sha256_bytes": sha256_file(dataset_path),
+            "matched_char_count": len(record_lookup),
+            "requested_han_char_count": len(wanted_han_chars),
+            "missing_han_characters": missing_han,
+        },
+        "tokenization": {
+            "mode": "codepoint",
+            "char_offsets_are_half_open": True,
+            "byte_offsets_are_half_open": True,
+            "byte_offsets_are_absolute": True,
+            "component_separator_default": component_separator,
+            "token_separator_default": "",
+            "non_han_tokens_are_preserved": True,
+        },
+        "inventory": inventory,
+        "tokens": tokens,
+    }
+    return document
+
+
+def cmd_build(args: argparse.Namespace) -> int:
+    input_path = Path(args.input)
+    dataset_path = Path(args.dataset)
+    output_path = Path(args.output)
+    output_format = infer_output_format(output_path, args.output_format)
+
+    document = build_mapped_document(
+        input_path=input_path,
+        dataset_path=dataset_path,
+        encoding=args.encoding,
+        errors=args.errors,
+        component_separator=args.component_separator,
+        payload_codec=args.payload_codec,
+        embed_original_bytes=not args.no_embed_original_bytes,
+    )
+    write_map_document(document, output_path, output_format)
+    stderr("Mapped file written.")
+    stderr(
+        json.dumps(
+            {
+                "output": str(output_path),
+                "output_format": output_format,
+                "token_count": len(document["tokens"]),
+                "inventory_count": len(document["inventory"]),
+                "matched_han_char_count": document["decomposition_dataset"]["matched_char_count"],
+                "missing_han_char_count": len(document["decomposition_dataset"]["missing_han_characters"]),
+                "embedded_original_payload": document["original_payload"] is not None,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def run_self_tests() -> None:
+    sample_dataset = [
+        {
+            "char": "河",
+            "codepoint": "U+6CB3",
+            "unihan": {
+                "kRSUnicode": [{"raw": "85.5", "radical_number": 85}],
+                "kTotalStrokes": [8],
+                "kDefinition": "river",
+            },
+            "decomposition": {
+                "primary_raw": "⿰氵可",
+                "immediate_components": ["氵", "可"],
+                "leaf_components_raw": ["氵", "丁", "口"],
+                "leaf_components_raw_unique": ["氵", "丁", "口"],
+                "leaf_radicals_normalized": ["水", "丁", "口"],
+                "leaf_radicals_normalized_unique": ["水", "丁", "口"],
+                "unresolved_tokens": [],
+                "expanded_tree": {
+                    "kind": "op",
+                    "value": "⿰",
+                    "scheme": "ids",
+                    "children": [
+                        {"kind": "leaf", "value": "氵", "scheme": "ids"},
+                        {
+                            "kind": "op",
+                            "value": "⿱",
+                            "scheme": "ids",
+                            "children": [
+                                {"kind": "leaf", "value": "丁", "scheme": "ids"},
+                                {"kind": "leaf", "value": "口", "scheme": "ids"},
+                            ],
+                        },
+                    ],
+                },
+            },
+        },
+        {
+            "char": "語",
+            "codepoint": "U+8A9E",
+            "unihan": {
+                "kRSUnicode": [{"raw": "149.7", "radical_number": 149}],
+                "kTotalStrokes": [14],
+                "kDefinition": "language",
+            },
+            "decomposition": {
+                "primary_raw": "⿰言吾",
+                "immediate_components": ["言", "吾"],
+                "leaf_components_raw": ["言", "五", "口"],
+                "leaf_components_raw_unique": ["言", "五", "口"],
+                "leaf_radicals_normalized": ["言", "五", "口"],
+                "leaf_radicals_normalized_unique": ["言", "五", "口"],
+                "unresolved_tokens": [],
+                "expanded_tree": {
+                    "kind": "op",
+                    "value": "⿰",
+                    "scheme": "ids",
+                    "children": [
+                        {"kind": "leaf", "value": "言", "scheme": "ids"},
+                        {
+                            "kind": "op",
+                            "value": "⿱",
+                            "scheme": "ids",
+                            "children": [
+                                {"kind": "leaf", "value": "五", "scheme": "ids"},
+                                {"kind": "leaf", "value": "口", "scheme": "ids"},
+                            ],
+                        },
+                    ],
+                },
+            },
+        },
+    ]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        dataset_path = tmp / "dataset.jsonl"
+        with dataset_path.open("w", encoding="utf-8") as fh:
+            for record in sample_dataset:
+                fh.write(json.dumps(record, ensure_ascii=False))
+                fh.write("\n")
+
+        input_path = tmp / "sample.txt"
+        raw = ("\ufeff河A語\n").encode("utf-8")
+        input_path.write_bytes(raw)
+
+        doc = build_mapped_document(
+            input_path=input_path,
+            dataset_path=dataset_path,
+            encoding="utf-8-sig",
+            errors="strict",
+            component_separator=" ",
+            payload_codec="zlib+base64",
+            embed_original_bytes=True,
+        )
+        assert doc["source_document"]["sha256_bytes"] == sha256_bytes(raw)
+        assert len(doc["tokens"]) == 4
+        assert doc["tokens"][0]["text_original"] == "河"
+        assert doc["tokens"][0]["inventory_index"] == 0
+        assert doc["tokens"][0]["decomposition"]["render_normalized_default"] == "水 丁 口"
+        assert doc["tokens"][1]["text_original"] == "A"
+        assert doc["tokens"][1]["decomposition"] is None
+        assert doc["tokens"][2]["text_original"] == "語"
+        assert doc["tokens"][3]["kind"] == "newline"
+        assert doc["tokens"][0]["positions"]["byte_start"] == 3  # after UTF-8 BOM
+
+        map_path = tmp / "mapped.json"
+        write_map_document(doc, map_path, "json")
+        loaded = load_map_document(map_path)
+        assert loaded["source_document"]["encoding_plan"]["bom_length"] == 3
+        assert loaded["inventory"][0]["char"] == "河"
+
+    stderr("All self-tests passed.")
+
+
+def cmd_self_test(args: argparse.Namespace) -> int:
+    run_self_tests()
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Transform a UTF text file into a reversible Han decomposition token map."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_build = subparsers.add_parser("build", help="Build a reversible mapped file from a UTF text input.")
+    p_build.add_argument("--input", required=True, help="Path to the input UTF text file.")
+    p_build.add_argument("--dataset", required=True, help="Path to the decomposition dataset from han_main_block_decomp.py.")
+    p_build.add_argument("--output", required=True, help="Output mapped file (.json or .jsonl).")
+    p_build.add_argument(
+        "--output-format",
+        default=None,
+        choices=("json", "jsonl"),
+        help="Serialization format. If omitted, inferred from the output suffix, otherwise defaults to json.",
+    )
+    p_build.add_argument("--encoding", default="utf-8", help="Input file encoding. Exact reversible mapping is supported for UTF-8/16/32 variants.")
+    p_build.add_argument("--errors", default="strict", help="Unicode decode/encode error handler. Use strict unless you know you need another UTF-safe mode.")
+    p_build.add_argument(
+        "--component-separator",
+        default=DEFAULT_COMPONENT_SEPARATOR,
+        help="Separator used for default token-level decomposition renderings.",
+    )
+    p_build.add_argument(
+        "--payload-codec",
+        default=DEFAULT_PAYLOAD_CODEC,
+        choices=("base64", "zlib+base64"),
+        help="How to embed the exact original file bytes in the mapped file.",
+    )
+    p_build.add_argument(
+        "--no-embed-original-bytes",
+        action="store_true",
+        help="Do not embed the original raw bytes. The map will still contain token spans, but exact original-byte recovery will then require the source file.",
+    )
+    p_build.set_defaults(func=cmd_build)
+
+    p_self = subparsers.add_parser("self-test", help="Run internal mapper self-tests.")
+    p_self.set_defaults(func=cmd_self_test)
+
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except HanFileMapError as exc:
+        stderr(f"ERROR: {exc}")
+        return 2
+    except KeyboardInterrupt:
+        stderr("Interrupted.")
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/han_decomp/v0/han_file_symbolic_README.md
+++ b/data/han_decomp/v0/han_file_symbolic_README.md
@@ -1,0 +1,136 @@
+# Readable symbolic compact format for reversible Han files
+
+This format is the human-readable sibling of the earlier compact container.
+
+It is designed to be:
+
+- **reversible**: you can recover the exact original `input.txt` bytes
+- **readable**: the file stays line-oriented text with a legend and a visible body
+- **compact-ish**: repeated Han characters become short symbol IDs instead of full JSON token records
+
+## What the format looks like
+
+A file starts with metadata, then a legend, then a wrapped symbol body:
+
+```text
+HAN-READABLE-SYMBOLIC/v1
+meta	{"schema_version":"han-readable-symbolic/v1",...}
+stats	{"token_count":1234,...}
+legend_begin
+symbol	{"symbol_id":"←","original_text":"河","serialized_text":"水 丁 口",...}
+symbol	{"symbol_id":"↑","original_text":"語","serialized_text":"言 五 口",...}
+legend_end
+body_begin
+|¤←¤↑A ¤←¤~n¤↑
+```
+
+Interpretation:
+
+- `¤←` means “token mapped by symbol ID `←`”
+- the legend tells you that `←` maps back to original `河`
+- `serialized_text` shows the transformed/decomposition rendering for that symbol
+- `¤~n`, `¤~r`, `¤~t`, and `¤~s` are visible escapes for newline, carriage return, tab, and the sentinel itself
+
+## Files
+
+- `han_file_symbolic_serialize.py` — forward transform into the readable symbolic format
+- `han_file_symbolic_reverse.py` — reverse recovery, inspection, and compare
+- `han_file_symbolic_common.py` — shared format/parsing helpers
+
+## Typical workflow
+
+### 1) Build the Han decomposition dataset
+
+```bash
+python3 han_main_block_decomp.py build \
+  --data-dir data \
+  --download-missing \
+  --decomp-source cjkvi \
+  --normalization conservative \
+  --output data/han_main_block.jsonl
+```
+
+### 2) Create the readable symbolic file directly from `input.txt`
+
+```bash
+python3 han_file_symbolic_serialize.py build \
+  --input data/input.txt \
+  --dataset data/han_main_block.jsonl \
+  --output data/input.readable.hsym
+```
+
+Useful options:
+
+```bash
+python3 han_file_symbolic_serialize.py build \
+  --input data/input.txt \
+  --dataset data/han_main_block.jsonl \
+  --output data/input.readable.hsym \
+  --mode decomp-normalized \
+  --component-separator " " \
+  --sentinel "¤" \
+  --wrap-width 120
+```
+
+### 3) Or create it from an existing mapped file
+
+```bash
+python3 han_file_symbolic_serialize.py from-map \
+  --map data/mapped.json \
+  --output data/input.readable.hsym
+```
+
+### 4) Recover the exact original file
+
+```bash
+python3 han_file_symbolic_reverse.py recover \
+  --symbolic data/input.readable.hsym \
+  --mode original-bytes \
+  --output data/recovered_input.txt
+```
+
+### 5) Compare recovered output against the original
+
+```bash
+python3 han_file_symbolic_reverse.py compare \
+  --symbolic data/input.readable.hsym \
+  --mode original-bytes \
+  --compare-to data/input.txt \
+  --report-json data/readable_compare_report.json
+```
+
+## Recovery modes
+
+`han_file_symbolic_reverse.py recover` supports:
+
+- `original-bytes` — exact original file bytes
+- `original-text` — reconstructed original Unicode text
+- `serialized-text` — the transformed/decomposition text view
+- `symbolic-body` — the raw visible symbol stream stored in the container
+
+Examples:
+
+```bash
+python3 han_file_symbolic_reverse.py recover \
+  --symbolic data/input.readable.hsym \
+  --mode serialized-text \
+  --output data/serialized_view.txt
+
+python3 han_file_symbolic_reverse.py inspect \
+  --symbolic data/input.readable.hsym \
+  --include-previews
+```
+
+## Notes
+
+- By default, **Han main-block tokens are symbolized**, while safe non-Han literals stay inline for readability.
+- If needed, you can also symbolize non-Han tokens with `--symbolize-non-han`.
+- The format stores the source UTF encoding plan, so the original byte stream can be reconstructed exactly.
+- If you build from a pre-edited mapped file, any token whose serialized/current text differs from the original is automatically moved into the legend so reversibility is preserved.
+
+## Quick validation
+
+```bash
+python3 han_file_symbolic_serialize.py self-test
+python3 han_file_symbolic_reverse.py self-test
+```

--- a/data/han_decomp/v0/han_file_symbolic_common.py
+++ b/data/han_decomp/v0/han_file_symbolic_common.py
@@ -1,0 +1,736 @@
+#!/usr/bin/env python3
+"""
+Shared helpers for a readable symbolic compact serialization of the reversible
+Han decomposition file map.
+
+This format is designed to stay text-friendly while remaining exactly
+reversible back to the original UTF input:
+
+  * Han tokens (and optionally other tokens) are replaced with short visible
+    symbol IDs in the body stream.
+  * A readable legend maps each symbol ID back to the original token text and
+    its serialized/transformed text.
+  * Non-symbolized literal text is preserved directly in the body whenever that
+    remains reversible; control characters and the sentinel itself are emitted
+    through visible escape sequences.
+
+The on-disk container is line-oriented and easy to diff:
+
+    HAN-READABLE-SYMBOLIC/v1
+    meta\t{...json...}
+    stats\t{...json...}
+    legend_begin
+    symbol\t{...json...}
+    ...
+    legend_end
+    body_begin
+    |...wrapped body chunk...
+    |...wrapped body chunk...
+
+All lines after ``body_begin`` belong to the wrapped body payload. The leading
+``|`` on each body line is a framing character and is stripped during load.
+"""
+from __future__ import annotations
+
+import json
+import unicodedata
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+
+from han_file_decomp_map_common import (
+    DEFAULT_COMPONENT_SEPARATOR,
+    HanFileMapError,
+    UTFEncodingPlan,
+    cp_to_uplus,
+    encode_text,
+    iso_utc_now,
+    reconstruct_token_text,
+    sha256_bytes,
+    sha256_text_utf8,
+)
+
+READABLE_SYMBOLIC_SCHEMA_VERSION = "han-readable-symbolic/v1"
+READABLE_SYMBOLIC_MAGIC = "HAN-READABLE-SYMBOLIC/v1"
+DEFAULT_SYMBOLIC_WRAP_WIDTH = 120
+DEFAULT_SYMBOLIC_SENTINEL = "¤"
+DEFAULT_SYMBOL_ALPHABET_PROFILE = "default"
+VALID_SERIALIZATION_MODES = {"original-text", "current-text", "decomp-raw", "decomp-normalized"}
+
+# Ordered, curated ranges with lots of visible single-codepoint symbols.
+# The resulting default alphabet contains well over 1,000 code points, which
+# means width=1 works for many files and width=2 covers millions of symbols.
+_DEFAULT_SYMBOL_RANGES: Sequence[Tuple[int, int]] = (
+    (0x2190, 0x21FF),  # Arrows
+    (0x2300, 0x23FF),  # Misc Technical
+    (0x2460, 0x24FF),  # Enclosed Alphanumerics / numbers
+    (0x2500, 0x257F),  # Box Drawing
+    (0x2580, 0x259F),  # Block Elements
+    (0x25A0, 0x25FF),  # Geometric Shapes
+    (0x2600, 0x26FF),  # Misc Symbols
+    (0x2700, 0x27BF),  # Dingbats
+    (0x27F0, 0x27FF),  # Supplemental Arrows-A
+    (0x2900, 0x297F),  # Supplemental Arrows-B
+    (0x2B00, 0x2BFF),  # Misc Symbols and Arrows
+)
+
+
+class HanReadableSymbolicError(HanFileMapError):
+    """Readable symbolic serialization specific error."""
+
+
+def _iter_default_symbol_alphabet() -> Iterator[str]:
+    seen = set()
+    for start, end in _DEFAULT_SYMBOL_RANGES:
+        for cp in range(start, end + 1):
+            ch = chr(cp)
+            if ch in seen:
+                continue
+            seen.add(ch)
+            cat = unicodedata.category(ch)
+            if cat.startswith("C") or cat.startswith("M"):
+                continue
+            if ch.isspace():
+                continue
+            yield ch
+
+
+def get_symbol_alphabet(profile: str = DEFAULT_SYMBOL_ALPHABET_PROFILE) -> List[str]:
+    if profile != DEFAULT_SYMBOL_ALPHABET_PROFILE:
+        raise HanReadableSymbolicError(f"Unsupported symbol alphabet profile: {profile}")
+    return list(_iter_default_symbol_alphabet())
+
+
+def _symbol_entry_from_token(
+    token: dict,
+    *,
+    serialized_text: str,
+    include_han_metadata: bool,
+    source_inventory: Sequence[dict],
+) -> dict:
+    inv_idx = token.get("inventory_index")
+    entry = {
+        "kind": token.get("kind"),
+        "original_text": token.get("text_original", ""),
+        "serialized_text": serialized_text,
+        "source_inventory_index": inv_idx,
+    }
+
+    if inv_idx is not None and 0 <= inv_idx < len(source_inventory):
+        inv = source_inventory[inv_idx]
+        entry["source_char"] = inv.get("char")
+        entry["source_record_available"] = bool(inv.get("record_available"))
+    else:
+        entry["source_char"] = None
+        entry["source_record_available"] = False
+
+    if include_han_metadata and token.get("kind") == "han_main_block":
+        decomp = token.get("decomposition") or {}
+        entry["han"] = {
+            "primary_raw": decomp.get("primary_raw"),
+            "render_raw_default": decomp.get("render_raw_default"),
+            "render_normalized_default": decomp.get("render_normalized_default"),
+            "kRSUnicode": decomp.get("kRSUnicode"),
+            "kTotalStrokes": decomp.get("kTotalStrokes"),
+            "kDefinition": decomp.get("kDefinition"),
+        }
+    return entry
+
+
+def _symbol_key_from_entry(entry: dict) -> Tuple[object, ...]:
+    return (
+        entry.get("kind"),
+        entry.get("original_text"),
+        entry.get("serialized_text"),
+        entry.get("source_inventory_index"),
+        json.dumps(entry.get("han"), ensure_ascii=False, sort_keys=True) if "han" in entry else None,
+    )
+
+
+def _required_symbol_id_width(symbol_count: int, alphabet_size: int) -> int:
+    if alphabet_size <= 1:
+        raise HanReadableSymbolicError("Symbol alphabet must contain at least two symbols")
+    width = 1
+    capacity = alphabet_size
+    while symbol_count > capacity:
+        width += 1
+        capacity *= alphabet_size
+    return width
+
+
+def _int_to_symbol_id(index: int, alphabet: Sequence[str], width: int) -> str:
+    if index < 0:
+        raise HanReadableSymbolicError(f"Negative symbol index is invalid: {index}")
+    base = len(alphabet)
+    max_supported = base ** width
+    if index >= max_supported:
+        raise HanReadableSymbolicError(
+            f"symbol_id width={width} cannot encode index={index}; capacity is {max_supported}"
+        )
+    digits = [alphabet[0]] * width
+    value = index
+    pos = width - 1
+    while pos >= 0:
+        digits[pos] = alphabet[value % base]
+        value //= base
+        pos -= 1
+    return "".join(digits)
+
+
+def _iter_escape_text(text: str, *, sentinel: str) -> Iterator[str]:
+    for ch in text:
+        cp = ord(ch)
+        if ch == sentinel:
+            yield sentinel + "~s"
+        elif ch == "\n":
+            yield sentinel + "~n"
+        elif ch == "\r":
+            yield sentinel + "~r"
+        elif ch == "\t":
+            yield sentinel + "~t"
+        elif cp < 0x20 or cp == 0x7F or ch in {"\u2028", "\u2029"}:
+            width = 4 if cp <= 0xFFFF else 6
+            yield f"{sentinel}~x{cp:0{width}X};"
+        else:
+            yield ch
+
+
+def escape_body_literal(text: str, *, sentinel: str) -> str:
+    return "".join(_iter_escape_text(text, sentinel=sentinel))
+
+
+def _parse_escape(body: str, start: int, *, sentinel: str) -> Tuple[str, int]:
+    # body[start] == sentinel and body[start+1] == "~"
+    if start + 2 >= len(body):
+        raise HanReadableSymbolicError("Truncated symbolic escape at end of body")
+    code = body[start + 2]
+    if code == "s":
+        return sentinel, start + 3
+    if code == "n":
+        return "\n", start + 3
+    if code == "r":
+        return "\r", start + 3
+    if code == "t":
+        return "\t", start + 3
+    if code == "x":
+        end = body.find(";", start + 3)
+        if end == -1:
+            raise HanReadableSymbolicError("Unterminated hex escape in symbolic body")
+        hex_part = body[start + 3 : end]
+        if not hex_part or any(ch not in "0123456789ABCDEFabcdef" for ch in hex_part):
+            raise HanReadableSymbolicError(f"Invalid hex escape in symbolic body: {hex_part!r}")
+        cp = int(hex_part, 16)
+        try:
+            return chr(cp), end + 1
+        except ValueError as exc:
+            raise HanReadableSymbolicError(f"Invalid code point in symbolic body escape: U+{cp:04X}") from exc
+    raise HanReadableSymbolicError(f"Unknown symbolic escape code: ~{code}")
+
+
+def _should_symbolize_token(
+    token: dict,
+    *,
+    serialized_text: str,
+    symbolize_non_han: bool,
+) -> bool:
+    if token.get("kind") == "han_main_block":
+        return True
+    if symbolize_non_han:
+        return True
+    # If the transformed/current rendering would differ from the original token,
+    # keep the token in the legend so the container stays reversible.
+    return serialized_text != token.get("text_original", "")
+
+
+def build_readable_symbolic_document_from_map(
+    mapped_document: dict,
+    *,
+    mode: str = "decomp-normalized",
+    component_separator: str = DEFAULT_COMPONENT_SEPARATOR,
+    preserve_non_han: bool = True,
+    missing_han_fallback: str = "current",
+    include_han_metadata: bool = False,
+    symbolize_non_han: bool = False,
+    sentinel: str = DEFAULT_SYMBOLIC_SENTINEL,
+    symbol_alphabet_profile: str = DEFAULT_SYMBOL_ALPHABET_PROFILE,
+    symbol_id_width: Optional[int] = None,
+) -> dict:
+    if mode not in VALID_SERIALIZATION_MODES:
+        raise HanReadableSymbolicError(f"Unsupported serialization mode: {mode}")
+    if len(sentinel) != 1:
+        raise HanReadableSymbolicError("Sentinel must be exactly one Unicode code point")
+
+    source_document = mapped_document.get("source_document") or {}
+    tokens = mapped_document.get("tokens") or []
+    inventory = mapped_document.get("inventory") or []
+
+    alphabet = get_symbol_alphabet(symbol_alphabet_profile)
+    if sentinel in alphabet:
+        alphabet = [ch for ch in alphabet if ch != sentinel]
+    if not alphabet:
+        raise HanReadableSymbolicError("Resolved symbol alphabet is empty after removing the sentinel")
+
+    symbol_entries: List[dict] = []
+    symbol_index: Dict[Tuple[object, ...], int] = {}
+    symbol_occurrence_counts: Dict[int, int] = {}
+    token_symbol_refs: List[Optional[int]] = []
+    token_serialized_texts: List[str] = []
+
+    for token in tokens:
+        serialized_text = reconstruct_token_text(
+            token,
+            mode=mode,
+            component_separator=component_separator,
+            preserve_non_han=preserve_non_han,
+            missing_han_fallback=missing_han_fallback,
+        )
+        token_serialized_texts.append(serialized_text)
+        should_symbolize = _should_symbolize_token(
+            token,
+            serialized_text=serialized_text,
+            symbolize_non_han=symbolize_non_han,
+        )
+        if not should_symbolize:
+            token_symbol_refs.append(None)
+            continue
+
+        entry = _symbol_entry_from_token(
+            token,
+            serialized_text=serialized_text,
+            include_han_metadata=include_han_metadata,
+            source_inventory=inventory,
+        )
+        key = _symbol_key_from_entry(entry)
+        sid = symbol_index.get(key)
+        if sid is None:
+            sid = len(symbol_entries)
+            symbol_index[key] = sid
+            symbol_entries.append(entry)
+        symbol_occurrence_counts[sid] = symbol_occurrence_counts.get(sid, 0) + 1
+        token_symbol_refs.append(sid)
+
+    if symbol_id_width is None:
+        symbol_id_width = max(1, _required_symbol_id_width(len(symbol_entries) or 1, len(alphabet)))
+    else:
+        symbol_id_width = int(symbol_id_width)
+        if symbol_id_width <= 0:
+            raise HanReadableSymbolicError("symbol_id_width must be a positive integer")
+        max_capacity = len(alphabet) ** symbol_id_width
+        if len(symbol_entries) > max_capacity:
+            raise HanReadableSymbolicError(
+                f"symbol_id_width={symbol_id_width} cannot encode {len(symbol_entries)} symbols; "
+                f"capacity is {max_capacity}"
+            )
+
+    symbol_lookup_by_index: Dict[int, dict] = {}
+    for sid, entry in enumerate(symbol_entries):
+        symbol_id = _int_to_symbol_id(sid, alphabet, symbol_id_width)
+        entry["symbol_index"] = sid
+        entry["symbol_id"] = symbol_id
+        entry["occurrence_count"] = symbol_occurrence_counts.get(sid, 0)
+        entry["original_codepoints"] = [cp_to_uplus(ord(ch)) for ch in entry["original_text"]]
+        entry["serialized_codepoints"] = [cp_to_uplus(ord(ch)) for ch in entry["serialized_text"]]
+        symbol_lookup_by_index[sid] = entry
+
+    body_parts: List[str] = []
+    for token, sid, serialized_text in zip(tokens, token_symbol_refs, token_serialized_texts):
+        if sid is not None:
+            body_parts.append(sentinel)
+            body_parts.append(symbol_lookup_by_index[sid]["symbol_id"])
+            continue
+        # Raw literals are emitted only when they already match the serialized
+        # view. They still need escaping for the body container grammar.
+        original_text = token.get("text_original", "")
+        if serialized_text != original_text:
+            raise HanReadableSymbolicError(
+                "Encountered a non-symbolized token whose serialized text does not match the original; "
+                "this would break reversibility."
+            )
+        body_parts.append(escape_body_literal(original_text, sentinel=sentinel))
+    body = "".join(body_parts)
+
+    symbolic_document = {
+        "schema_version": READABLE_SYMBOLIC_SCHEMA_VERSION,
+        "generator": {
+            "script": "han_file_symbolic_serialize.py",
+            "version": "1.0.0",
+            "created_at_utc": iso_utc_now(),
+        },
+        "source_document": {
+            "path": source_document.get("path"),
+            "filename": source_document.get("filename"),
+            "byte_length": source_document.get("byte_length"),
+            "sha256_bytes": source_document.get("sha256_bytes"),
+            "text_length_codepoints": source_document.get("text_length_codepoints"),
+            "text_sha256_utf8": source_document.get("text_sha256_utf8"),
+            "line_count": source_document.get("line_count"),
+            "newline_counts": source_document.get("newline_counts"),
+            "encoding_plan": source_document.get("encoding_plan"),
+        },
+        "source_map": {
+            "schema_version": mapped_document.get("schema_version"),
+            "generator": mapped_document.get("generator"),
+            "decomposition_dataset": mapped_document.get("decomposition_dataset"),
+            "inventory_count": len(inventory),
+            "token_count": len(tokens),
+        },
+        "serialization": {
+            "mode": mode,
+            "component_separator": component_separator,
+            "preserve_non_han": preserve_non_han,
+            "missing_han_fallback": missing_han_fallback,
+            "include_han_metadata": include_han_metadata,
+            "symbolize_non_han": symbolize_non_han,
+            "sentinel": sentinel,
+            "symbol_alphabet_profile": symbol_alphabet_profile,
+            "symbol_id_width": symbol_id_width,
+        },
+        "stats": {
+            "token_count": len(tokens),
+            "symbol_entry_count": len(symbol_entries),
+            "symbolized_token_count": sum(1 for sid in token_symbol_refs if sid is not None),
+            "han_symbol_entry_count": sum(1 for entry in symbol_entries if entry.get("kind") == "han_main_block"),
+            "han_symbolized_token_count": sum(
+                entry.get("occurrence_count", 0)
+                for entry in symbol_entries
+                if entry.get("kind") == "han_main_block"
+            ),
+            "body_length_codepoints": len(body),
+            "body_sha256_utf8": sha256_text_utf8(body),
+            "original_text_length_codepoints": sum(len(token.get("text_original", "")) for token in tokens),
+            "symbol_id_width": symbol_id_width,
+        },
+        "symbol_table": symbol_entries,
+        "body": body,
+    }
+    validate_readable_symbolic_document(symbolic_document)
+    return symbolic_document
+
+
+def symbolic_encoding_plan(document: dict) -> UTFEncodingPlan:
+    src = document.get("source_document") or {}
+    plan = src.get("encoding_plan")
+    if not isinstance(plan, dict):
+        raise HanReadableSymbolicError("Symbolic document missing source_document.encoding_plan")
+    return UTFEncodingPlan.from_dict(plan)
+
+
+def _symbol_lookup(document: dict) -> Dict[str, dict]:
+    return {entry["symbol_id"]: entry for entry in document.get("symbol_table", [])}
+
+
+def iter_decoded_body_units(document: dict) -> Iterator[Tuple[str, str]]:
+    """
+    Yield pairs ``(kind, value)`` where kind is either ``literal`` or ``symbol``.
+
+    For ``literal`` units, value is the literal character to append.
+    For ``symbol`` units, value is the symbol_id string.
+    """
+    validate_readable_symbolic_document(document)
+    serialization = document.get("serialization") or {}
+    sentinel = serialization["sentinel"]
+    id_width = serialization["symbol_id_width"]
+    body = document.get("body", "")
+    symbol_lookup = _symbol_lookup(document)
+
+    i = 0
+    while i < len(body):
+        ch = body[i]
+        if ch != sentinel:
+            yield "literal", ch
+            i += 1
+            continue
+
+        if i + 1 >= len(body):
+            raise HanReadableSymbolicError("Trailing sentinel at end of symbolic body")
+        if body[i + 1] == "~":
+            literal, i = _parse_escape(body, i, sentinel=sentinel)
+            yield "literal", literal
+            continue
+
+        end = i + 1 + id_width
+        symbol_id = body[i + 1 : end]
+        if len(symbol_id) != id_width:
+            raise HanReadableSymbolicError("Truncated symbol ID at end of symbolic body")
+        if symbol_id not in symbol_lookup:
+            raise HanReadableSymbolicError(f"Unknown symbol ID in symbolic body: {symbol_id!r}")
+        yield "symbol", symbol_id
+        i = end
+
+
+def reconstruct_original_text(document: dict) -> str:
+    symbol_lookup = _symbol_lookup(document)
+    parts: List[str] = []
+    for kind, value in iter_decoded_body_units(document):
+        if kind == "literal":
+            parts.append(value)
+        else:
+            parts.append(symbol_lookup[value].get("original_text", ""))
+    return "".join(parts)
+
+
+def reconstruct_serialized_text(document: dict) -> str:
+    symbol_lookup = _symbol_lookup(document)
+    parts: List[str] = []
+    for kind, value in iter_decoded_body_units(document):
+        if kind == "literal":
+            parts.append(value)
+        else:
+            parts.append(symbol_lookup[value].get("serialized_text", ""))
+    return "".join(parts)
+
+
+def reconstruct_original_bytes(document: dict, *, errors: Optional[str] = None) -> bytes:
+    plan = symbolic_encoding_plan(document)
+    text = reconstruct_original_text(document)
+    return encode_text(text, plan, preserve_bom=True, errors=errors)
+
+
+def readable_symbolic_compare_original_hash(document: dict, *, errors: Optional[str] = None) -> dict:
+    recovered = reconstruct_original_bytes(document, errors=errors)
+    recovered_hash = sha256_bytes(recovered)
+    source_hash = (document.get("source_document") or {}).get("sha256_bytes")
+    return {
+        "bytes_equal_to_stored_hash": (source_hash == recovered_hash) if source_hash else None,
+        "recovered_sha256_bytes": recovered_hash,
+        "stored_sha256_bytes": source_hash,
+        "recovered_byte_length": len(recovered),
+        "stored_byte_length": (document.get("source_document") or {}).get("byte_length"),
+    }
+
+
+def validate_readable_symbolic_document(document: dict) -> None:
+    schema = document.get("schema_version")
+    if schema != READABLE_SYMBOLIC_SCHEMA_VERSION:
+        raise HanReadableSymbolicError(f"Unsupported or missing schema_version: {schema!r}")
+
+    serialization = document.get("serialization")
+    if not isinstance(serialization, dict):
+        raise HanReadableSymbolicError("Symbolic document missing serialization block")
+    if serialization.get("mode") not in VALID_SERIALIZATION_MODES:
+        raise HanReadableSymbolicError("Symbolic document has unsupported serialization mode")
+    sentinel = serialization.get("sentinel")
+    if not isinstance(sentinel, str) or len(sentinel) != 1:
+        raise HanReadableSymbolicError("Symbolic document sentinel must be a single code point")
+    id_width = serialization.get("symbol_id_width")
+    if not isinstance(id_width, int) or id_width <= 0:
+        raise HanReadableSymbolicError("Symbolic document missing a valid symbol_id_width")
+
+    symbol_table = document.get("symbol_table")
+    if not isinstance(symbol_table, list):
+        raise HanReadableSymbolicError("Symbolic document missing symbol_table list")
+    seen_ids = set()
+    for idx, entry in enumerate(symbol_table):
+        symbol_id = entry.get("symbol_id")
+        if not isinstance(symbol_id, str) or len(symbol_id) != id_width:
+            raise HanReadableSymbolicError(
+                f"symbol_table entry {idx} has invalid symbol_id width: {symbol_id!r}"
+            )
+        if symbol_id in seen_ids:
+            raise HanReadableSymbolicError(f"Duplicate symbol_id in symbol_table: {symbol_id!r}")
+        seen_ids.add(symbol_id)
+        if "original_text" not in entry or "serialized_text" not in entry:
+            raise HanReadableSymbolicError(f"symbol_table entry {idx} missing required text fields")
+
+    if not isinstance(document.get("body"), str):
+        raise HanReadableSymbolicError("Symbolic document missing body string")
+
+    source_document = document.get("source_document") or {}
+    if "encoding_plan" not in source_document:
+        raise HanReadableSymbolicError("Symbolic document missing source_document.encoding_plan")
+
+    # Parse once to verify the body is structurally valid and to check token count.
+    token_count = 0
+    for _kind, _value in iter_decoded_body_units_no_validate(document, symbol_table=symbol_table):
+        token_count += 1
+    expected = (document.get("stats") or {}).get("token_count")
+    if expected is not None and expected != token_count:
+        raise HanReadableSymbolicError(
+            f"Symbolic body token count mismatch: expected {expected}, decoded {token_count}"
+        )
+
+
+def iter_decoded_body_units_no_validate(
+    document: dict,
+    *,
+    symbol_table: Optional[Sequence[dict]] = None,
+) -> Iterator[Tuple[str, str]]:
+    serialization = document.get("serialization") or {}
+    sentinel = serialization["sentinel"]
+    id_width = serialization["symbol_id_width"]
+    body = document.get("body", "")
+    if symbol_table is None:
+        symbol_table = document.get("symbol_table", [])
+    symbol_lookup = {entry["symbol_id"]: entry for entry in symbol_table}
+
+    i = 0
+    while i < len(body):
+        ch = body[i]
+        if ch != sentinel:
+            yield "literal", ch
+            i += 1
+            continue
+        if i + 1 >= len(body):
+            raise HanReadableSymbolicError("Trailing sentinel at end of symbolic body")
+        if body[i + 1] == "~":
+            literal, i = _parse_escape(body, i, sentinel=sentinel)
+            yield "literal", literal
+            continue
+        end = i + 1 + id_width
+        symbol_id = body[i + 1 : end]
+        if len(symbol_id) != id_width:
+            raise HanReadableSymbolicError("Truncated symbol ID at end of symbolic body")
+        if symbol_id not in symbol_lookup:
+            raise HanReadableSymbolicError(f"Unknown symbol ID in symbolic body: {symbol_id!r}")
+        yield "symbol", symbol_id
+        i = end
+
+
+def _wrap_text(text: str, width: int) -> List[str]:
+    if width <= 0:
+        return [text] if text else []
+    return [text[i : i + width] for i in range(0, len(text), width)]
+
+
+def write_readable_symbolic_document(
+    document: dict,
+    output_path: Path,
+    *,
+    wrap_width: int = DEFAULT_SYMBOLIC_WRAP_WIDTH,
+) -> None:
+    validate_readable_symbolic_document(document)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    meta = {
+        "schema_version": document.get("schema_version"),
+        "generator": document.get("generator"),
+        "source_document": document.get("source_document"),
+        "source_map": document.get("source_map"),
+        "serialization": document.get("serialization"),
+    }
+    stats = document.get("stats") or {}
+
+    with output_path.open("w", encoding="utf-8", newline="\n") as fh:
+        fh.write(READABLE_SYMBOLIC_MAGIC + "\n")
+        fh.write("meta\t")
+        fh.write(json.dumps(meta, ensure_ascii=False, separators=(",", ":")))
+        fh.write("\n")
+        fh.write("stats\t")
+        fh.write(json.dumps(stats, ensure_ascii=False, separators=(",", ":")))
+        fh.write("\n")
+        fh.write("legend_begin\n")
+        for entry in document.get("symbol_table", []):
+            fh.write("symbol\t")
+            fh.write(json.dumps(entry, ensure_ascii=False, separators=(",", ":")))
+            fh.write("\n")
+        fh.write("legend_end\n")
+        fh.write("body_begin\n")
+        body = document.get("body", "")
+        for chunk in _wrap_text(body, wrap_width):
+            fh.write("|")
+            fh.write(chunk)
+            fh.write("\n")
+        if body == "":
+            # Represent the empty body explicitly for readability and stable load.
+            fh.write("|\n")
+
+
+def load_readable_symbolic_document(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        lines = [line.rstrip("\n") for line in fh]
+    if not lines or lines[0] != READABLE_SYMBOLIC_MAGIC:
+        raise HanReadableSymbolicError(f"Missing or invalid symbolic container magic in {path}")
+
+    meta = None
+    stats = None
+    symbol_table: List[dict] = []
+    body_chunks: List[str] = []
+    i = 1
+    in_legend = False
+    in_body = False
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        if in_body:
+            if not line.startswith("|"):
+                raise HanReadableSymbolicError(
+                    f"Malformed body chunk line in {path}; expected leading '|': {line!r}"
+                )
+            body_chunks.append(line[1:])
+            continue
+        if in_legend:
+            if line == "legend_end":
+                in_legend = False
+                continue
+            if not line.startswith("symbol\t"):
+                raise HanReadableSymbolicError(f"Malformed legend line in {path}: {line!r}")
+            try:
+                entry = json.loads(line.split("\t", 1)[1])
+            except Exception as exc:
+                raise HanReadableSymbolicError(f"Failed to parse legend entry JSON: {exc}") from exc
+            symbol_table.append(entry)
+            continue
+
+        if line.startswith("meta\t"):
+            try:
+                meta = json.loads(line.split("\t", 1)[1])
+            except Exception as exc:
+                raise HanReadableSymbolicError(f"Failed to parse meta JSON: {exc}") from exc
+            continue
+        if line.startswith("stats\t"):
+            try:
+                stats = json.loads(line.split("\t", 1)[1])
+            except Exception as exc:
+                raise HanReadableSymbolicError(f"Failed to parse stats JSON: {exc}") from exc
+            continue
+        if line == "legend_begin":
+            in_legend = True
+            continue
+        if line == "body_begin":
+            in_body = True
+            continue
+        if line == "":
+            continue
+        raise HanReadableSymbolicError(f"Unexpected line in symbolic container: {line!r}")
+
+    if meta is None:
+        raise HanReadableSymbolicError(f"Symbolic container missing meta block: {path}")
+    if stats is None:
+        raise HanReadableSymbolicError(f"Symbolic container missing stats block: {path}")
+    if not in_body:
+        raise HanReadableSymbolicError(f"Symbolic container missing body_begin: {path}")
+
+    document = {
+        "schema_version": meta.get("schema_version"),
+        "generator": meta.get("generator"),
+        "source_document": meta.get("source_document"),
+        "source_map": meta.get("source_map"),
+        "serialization": meta.get("serialization"),
+        "stats": stats,
+        "symbol_table": symbol_table,
+        "body": "".join(body_chunks) if body_chunks != [""] else "",
+    }
+    validate_readable_symbolic_document(document)
+    return document
+
+
+__all__ = [
+    "READABLE_SYMBOLIC_SCHEMA_VERSION",
+    "READABLE_SYMBOLIC_MAGIC",
+    "DEFAULT_SYMBOLIC_WRAP_WIDTH",
+    "DEFAULT_SYMBOLIC_SENTINEL",
+    "DEFAULT_SYMBOL_ALPHABET_PROFILE",
+    "VALID_SERIALIZATION_MODES",
+    "HanReadableSymbolicError",
+    "get_symbol_alphabet",
+    "escape_body_literal",
+    "build_readable_symbolic_document_from_map",
+    "symbolic_encoding_plan",
+    "validate_readable_symbolic_document",
+    "iter_decoded_body_units",
+    "reconstruct_original_text",
+    "reconstruct_serialized_text",
+    "reconstruct_original_bytes",
+    "readable_symbolic_compare_original_hash",
+    "write_readable_symbolic_document",
+    "load_readable_symbolic_document",
+]

--- a/data/han_decomp/v0/han_file_symbolic_reverse.py
+++ b/data/han_decomp/v0/han_file_symbolic_reverse.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Recover and compare outputs from the readable symbolic Han serialization format.
+
+Primary use:
+  * recover the exact original input.txt bytes from the symbolic text file
+  * optionally render the original text, serialized/transformed text, or the
+    symbolic body itself
+  * compare recovered output against the original file or stored hashes
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Optional, Sequence
+
+from han_file_decomp_map_common import (
+    diff_lines,
+    first_difference,
+    sha256_bytes,
+    sha256_text_utf8,
+    stderr,
+)
+from han_file_symbolic_common import (
+    HanReadableSymbolicError,
+    load_readable_symbolic_document,
+    readable_symbolic_compare_original_hash,
+    reconstruct_original_bytes,
+    reconstruct_original_text,
+    reconstruct_serialized_text,
+)
+from han_file_symbolic_serialize import run_self_tests as run_serialize_self_tests
+
+SCRIPT_NAME = "han_file_symbolic_reverse.py"
+SCRIPT_VERSION = "1.0.0"
+TEXT_MODES = {"original-text", "serialized-text", "symbolic-body"}
+ALL_MODES = {"original-bytes", *TEXT_MODES}
+
+
+
+def recover_output(
+    document: dict,
+    *,
+    mode: str,
+    text_output_encoding: str,
+    text_output_errors: str,
+) -> bytes:
+    if mode == "original-bytes":
+        return reconstruct_original_bytes(document, errors=text_output_errors)
+    if mode == "original-text":
+        return reconstruct_original_text(document).encode(text_output_encoding, text_output_errors)
+    if mode == "serialized-text":
+        return reconstruct_serialized_text(document).encode(text_output_encoding, text_output_errors)
+    if mode == "symbolic-body":
+        return (document.get("body") or "").encode(text_output_encoding, text_output_errors)
+    raise HanReadableSymbolicError(f"Unsupported recover mode: {mode}")
+
+
+
+def _decode_for_diff(data: bytes, encoding: str, errors: str) -> str:
+    return data.decode(encoding, errors)
+
+
+
+def cmd_recover(args: argparse.Namespace) -> int:
+    document = load_readable_symbolic_document(Path(args.symbolic))
+    recovered = recover_output(
+        document,
+        mode=args.mode,
+        text_output_encoding=args.text_output_encoding,
+        text_output_errors=args.text_output_errors,
+    )
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(recovered)
+
+    report = {
+        "output": str(output_path),
+        "mode": args.mode,
+        "byte_length": len(recovered),
+        "sha256": sha256_bytes(recovered),
+    }
+    if args.mode == "original-bytes":
+        report["stored_hash_check"] = readable_symbolic_compare_original_hash(
+            document,
+            errors=args.text_output_errors,
+        )
+    stderr(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    document = load_readable_symbolic_document(Path(args.symbolic))
+    recovered = recover_output(
+        document,
+        mode=args.mode,
+        text_output_encoding=args.text_output_encoding,
+        text_output_errors=args.text_output_errors,
+    )
+
+    if args.compare_to:
+        other_bytes = Path(args.compare_to).read_bytes()
+        compare_target_label = str(Path(args.compare_to))
+    else:
+        if args.mode != "original-bytes":
+            raise HanReadableSymbolicError("--compare-to is required for non-original-bytes compare mode")
+        stored = readable_symbolic_compare_original_hash(document, errors=args.text_output_errors)
+        report = {
+            "mode": args.mode,
+            "compare_to": "stored_source_hash",
+            **stored,
+        }
+        if args.report_json:
+            path = Path(args.report_json)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        return 0 if stored["bytes_equal_to_stored_hash"] else 1
+
+    equal = recovered == other_bytes
+    report = {
+        "mode": args.mode,
+        "compare_to": compare_target_label,
+        "equal": equal,
+        "recovered_byte_length": len(recovered),
+        "compare_to_byte_length": len(other_bytes),
+        "recovered_sha256": sha256_bytes(recovered),
+        "compare_to_sha256": sha256_bytes(other_bytes),
+        "first_difference": None if equal else first_difference(recovered, other_bytes),
+    }
+
+    if args.mode in TEXT_MODES or args.decode_compare_as_text:
+        recovered_text = _decode_for_diff(recovered, args.text_output_encoding, args.text_output_errors)
+        other_text = _decode_for_diff(other_bytes, args.text_output_encoding, args.text_output_errors)
+        report["recovered_text_sha256_utf8"] = sha256_text_utf8(recovered_text)
+        report["compare_to_text_sha256_utf8"] = sha256_text_utf8(other_text)
+        if not equal:
+            diff = diff_lines(
+                other_text,
+                recovered_text,
+                fromfile=compare_target_label,
+                tofile=f"recovered:{args.mode}",
+                context=args.diff_context,
+            )
+            report["unified_diff_sample"] = diff[: args.diff_lines_limit]
+
+    if args.report_json:
+        path = Path(args.report_json)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if equal else 1
+
+
+
+def cmd_inspect(args: argparse.Namespace) -> int:
+    document = load_readable_symbolic_document(Path(args.symbolic))
+    report = {
+        "schema_version": document.get("schema_version"),
+        "generator": document.get("generator"),
+        "source_document": document.get("source_document"),
+        "source_map": document.get("source_map"),
+        "serialization": document.get("serialization"),
+        "stats": document.get("stats"),
+        "stored_hash_check": readable_symbolic_compare_original_hash(document, errors=args.text_output_errors),
+    }
+    if args.include_previews:
+        report["preview_original_text"] = reconstruct_original_text(document)[: args.preview_chars]
+        report["preview_serialized_text"] = reconstruct_serialized_text(document)[: args.preview_chars]
+        report["preview_body"] = (document.get("body") or "")[: args.preview_chars]
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_recover = sub.add_parser("recover", help="Recover output from a readable symbolic file")
+    p_recover.add_argument("--symbolic", required=True)
+    p_recover.add_argument("--mode", choices=sorted(ALL_MODES), default="original-bytes")
+    p_recover.add_argument("--output", required=True)
+    p_recover.add_argument("--text-output-encoding", default="utf-8")
+    p_recover.add_argument("--text-output-errors", default="strict")
+    p_recover.set_defaults(func=cmd_recover)
+
+    p_compare = sub.add_parser("compare", help="Compare recovered output to a file or stored hash")
+    p_compare.add_argument("--symbolic", required=True)
+    p_compare.add_argument("--mode", choices=sorted(ALL_MODES), default="original-bytes")
+    p_compare.add_argument("--compare-to")
+    p_compare.add_argument("--text-output-encoding", default="utf-8")
+    p_compare.add_argument("--text-output-errors", default="strict")
+    p_compare.add_argument("--decode-compare-as-text", action="store_true")
+    p_compare.add_argument("--diff-context", type=int, default=3)
+    p_compare.add_argument("--diff-lines-limit", type=int, default=60)
+    p_compare.add_argument("--report-json")
+    p_compare.set_defaults(func=cmd_compare)
+
+    p_inspect = sub.add_parser("inspect", help="Inspect a readable symbolic file")
+    p_inspect.add_argument("--symbolic", required=True)
+    p_inspect.add_argument("--text-output-errors", default="strict")
+    p_inspect.add_argument("--include-previews", action="store_true")
+    p_inspect.add_argument("--preview-chars", type=int, default=240)
+    p_inspect.set_defaults(func=cmd_inspect)
+
+    p_self = sub.add_parser("self-test", help="Run internal self-tests")
+    p_self.set_defaults(func=lambda args: (run_serialize_self_tests(), print("self-test: ok"), 0)[-1])
+
+    return parser
+
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except HanReadableSymbolicError as exc:
+        stderr(f"error: {exc}")
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/data/han_decomp/v0/han_file_symbolic_serialize.py
+++ b/data/han_decomp/v0/han_file_symbolic_serialize.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""
+Create a readable symbolic compact serialization of a transformed Han file map.
+
+Two entry paths are supported:
+  * build     : start from input.txt + the Han decomposition dataset
+  * from-map  : start from an existing mapped JSON/JSONL document
+
+The resulting file stays human-readable:
+  * a legend maps short symbol IDs back to original tokens and their serialized
+    decomposition/current-text view;
+  * the body is a wrapped symbol stream with visible escapes for control chars;
+  * the original UTF file can be recovered exactly from the legend + body.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Optional, Sequence
+
+from han_file_decomp_map_common import (
+    DEFAULT_COMPONENT_SEPARATOR,
+    HanFileMapError,
+    load_map_document,
+    sha256_bytes,
+    stderr,
+)
+from han_file_decomp_map_transform import build_mapped_document
+from han_file_symbolic_common import (
+    DEFAULT_SYMBOLIC_SENTINEL,
+    DEFAULT_SYMBOLIC_WRAP_WIDTH,
+    DEFAULT_SYMBOL_ALPHABET_PROFILE,
+    HanReadableSymbolicError,
+    VALID_SERIALIZATION_MODES,
+    build_readable_symbolic_document_from_map,
+    load_readable_symbolic_document,
+    readable_symbolic_compare_original_hash,
+    reconstruct_original_bytes,
+    reconstruct_original_text,
+    reconstruct_serialized_text,
+    write_readable_symbolic_document,
+)
+
+SCRIPT_NAME = "han_file_symbolic_serialize.py"
+SCRIPT_VERSION = "1.0.0"
+
+
+def _summarize_document(document: dict) -> dict:
+    stats = document.get("stats") or {}
+    source = document.get("source_document") or {}
+    serialization = document.get("serialization") or {}
+    return {
+        "source_filename": source.get("filename"),
+        "source_byte_length": source.get("byte_length"),
+        "source_sha256_bytes": source.get("sha256_bytes"),
+        "token_count": stats.get("token_count"),
+        "symbol_entry_count": stats.get("symbol_entry_count"),
+        "symbolized_token_count": stats.get("symbolized_token_count"),
+        "han_symbol_entry_count": stats.get("han_symbol_entry_count"),
+        "han_symbolized_token_count": stats.get("han_symbolized_token_count"),
+        "body_length_codepoints": stats.get("body_length_codepoints"),
+        "body_sha256_utf8": stats.get("body_sha256_utf8"),
+        "mode": serialization.get("mode"),
+        "sentinel": serialization.get("sentinel"),
+        "symbol_id_width": serialization.get("symbol_id_width"),
+        "symbolize_non_han": serialization.get("symbolize_non_han"),
+    }
+
+
+
+def build_symbolic_from_map_document(args: argparse.Namespace, mapped_document: dict) -> dict:
+    return build_readable_symbolic_document_from_map(
+        mapped_document,
+        mode=args.mode,
+        component_separator=args.component_separator,
+        preserve_non_han=not args.drop_non_han,
+        missing_han_fallback=args.missing_han_fallback,
+        include_han_metadata=args.include_han_metadata,
+        symbolize_non_han=args.symbolize_non_han,
+        sentinel=args.sentinel,
+        symbol_alphabet_profile=args.alphabet_profile,
+        symbol_id_width=args.symbol_id_width,
+    )
+
+
+
+def cmd_build(args: argparse.Namespace) -> int:
+    mapped_document = build_mapped_document(
+        input_path=Path(args.input),
+        dataset_path=Path(args.dataset),
+        encoding=args.encoding,
+        errors=args.errors,
+        component_separator=args.component_separator,
+        payload_codec="zlib+base64",
+        embed_original_bytes=False,
+    )
+    symbolic_document = build_symbolic_from_map_document(args, mapped_document)
+    output_path = Path(args.output)
+    write_readable_symbolic_document(symbolic_document, output_path, wrap_width=args.wrap_width)
+
+    recovered = reconstruct_original_bytes(symbolic_document, errors=args.errors)
+    source_hash = (symbolic_document.get("source_document") or {}).get("sha256_bytes")
+    summary = _summarize_document(symbolic_document)
+    summary.update(
+        {
+            "output": str(output_path),
+            "output_size_bytes": output_path.stat().st_size,
+            "recovered_sha256_bytes": sha256_bytes(recovered),
+            "matches_stored_source_hash": sha256_bytes(recovered) == source_hash,
+        }
+    )
+    stderr("Readable symbolic file written.")
+    stderr(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+
+def cmd_from_map(args: argparse.Namespace) -> int:
+    map_path = Path(args.map)
+    mapped_document = load_map_document(map_path)
+    symbolic_document = build_symbolic_from_map_document(args, mapped_document)
+    output_path = Path(args.output)
+    write_readable_symbolic_document(symbolic_document, output_path, wrap_width=args.wrap_width)
+
+    summary = _summarize_document(symbolic_document)
+    summary.update(
+        {
+            "input_map": str(map_path),
+            "input_map_size_bytes": map_path.stat().st_size,
+            "output": str(output_path),
+            "output_size_bytes": output_path.stat().st_size,
+            "symbolic_vs_map_size_ratio": (
+                output_path.stat().st_size / map_path.stat().st_size if map_path.stat().st_size else None
+            ),
+        }
+    )
+    stderr("Readable symbolic file written from map.")
+    stderr(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+
+def cmd_inspect(args: argparse.Namespace) -> int:
+    document = load_readable_symbolic_document(Path(args.symbolic))
+    report = _summarize_document(document)
+    report["compare_to_stored_hash"] = readable_symbolic_compare_original_hash(document, errors=args.errors)
+    if args.include_previews:
+        report["preview_original_text"] = reconstruct_original_text(document)[: args.preview_chars]
+        report["preview_serialized_text"] = reconstruct_serialized_text(document)[: args.preview_chars]
+        report["preview_body"] = (document.get("body") or "")[: args.preview_chars]
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+
+def run_self_tests() -> None:
+    sample_dataset = [
+        {
+            "char": "河",
+            "codepoint": "U+6CB3",
+            "unihan": {
+                "kRSUnicode": [{"raw": "85.5", "radical_number": 85}],
+                "kTotalStrokes": [8],
+                "kDefinition": "river",
+            },
+            "decomposition": {
+                "primary_raw": "⿰氵可",
+                "immediate_components": ["氵", "可"],
+                "leaf_components_raw": ["氵", "丁", "口"],
+                "leaf_components_raw_unique": ["氵", "丁", "口"],
+                "leaf_radicals_normalized": ["水", "丁", "口"],
+                "leaf_radicals_normalized_unique": ["水", "丁", "口"],
+                "unresolved_tokens": [],
+                "expanded_tree": None,
+            },
+        },
+        {
+            "char": "語",
+            "codepoint": "U+8A9E",
+            "unihan": {
+                "kRSUnicode": [{"raw": "149.7", "radical_number": 149}],
+                "kTotalStrokes": [14],
+                "kDefinition": "language",
+            },
+            "decomposition": {
+                "primary_raw": "⿰言吾",
+                "immediate_components": ["言", "吾"],
+                "leaf_components_raw": ["言", "五", "口"],
+                "leaf_components_raw_unique": ["言", "五", "口"],
+                "leaf_radicals_normalized": ["言", "五", "口"],
+                "leaf_radicals_normalized_unique": ["言", "五", "口"],
+                "unresolved_tokens": [],
+                "expanded_tree": None,
+            },
+        },
+    ]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        dataset_path = tmp / "dataset.jsonl"
+        with dataset_path.open("w", encoding="utf-8") as fh:
+            for record in sample_dataset:
+                fh.write(json.dumps(record, ensure_ascii=False))
+                fh.write("\n")
+
+        input_path = tmp / "input.txt"
+        raw_text = "河語A 河\n語¤\t\r"
+        input_path.write_text(raw_text, encoding="utf-8")
+
+        mapped = build_mapped_document(
+            input_path=input_path,
+            dataset_path=dataset_path,
+            encoding="utf-8",
+            errors="strict",
+            component_separator=" ",
+            payload_codec="zlib+base64",
+            embed_original_bytes=False,
+        )
+        symbolic = build_readable_symbolic_document_from_map(
+            mapped,
+            mode="decomp-normalized",
+            component_separator=" ",
+            preserve_non_han=True,
+            missing_han_fallback="current",
+            include_han_metadata=True,
+            symbolize_non_han=False,
+            sentinel="¤",
+            symbol_id_width=1,
+        )
+
+        original_text = reconstruct_original_text(symbolic)
+        serialized_text = reconstruct_serialized_text(symbolic)
+        original_bytes = reconstruct_original_bytes(symbolic, errors="strict")
+        assert original_text == raw_text
+        assert original_bytes == input_path.read_bytes()
+        assert serialized_text.startswith("水 丁 口言 五 口A ")
+        assert "¤~n" in symbolic["body"]
+        assert "¤~t" in symbolic["body"]
+        assert "¤~r" in symbolic["body"]
+        assert "¤~s" in symbolic["body"]
+
+        path = tmp / "sample.hsym"
+        write_readable_symbolic_document(symbolic, path, wrap_width=10)
+        loaded = load_readable_symbolic_document(path)
+        assert reconstruct_original_text(loaded) == raw_text
+        assert reconstruct_original_bytes(loaded, errors="strict") == input_path.read_bytes()
+        compare = readable_symbolic_compare_original_hash(loaded, errors="strict")
+        assert compare["bytes_equal_to_stored_hash"] is True
+
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_symbolic_options(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--mode", choices=sorted(VALID_SERIALIZATION_MODES), default="decomp-normalized")
+        p.add_argument("--component-separator", default=DEFAULT_COMPONENT_SEPARATOR)
+        p.add_argument(
+            "--missing-han-fallback",
+            choices=["current", "original", "empty"],
+            default="current",
+            help="How to serialize Han characters that are missing decomposition leaves.",
+        )
+        p.add_argument("--drop-non-han", action="store_true", help="Serialize non-Han tokens as empty strings.")
+        p.add_argument(
+            "--symbolize-non-han",
+            action="store_true",
+            help="Put non-Han tokens into the symbol legend too, instead of preserving safe literals inline.",
+        )
+        p.add_argument("--include-han-metadata", action="store_true")
+        p.add_argument("--sentinel", default=DEFAULT_SYMBOLIC_SENTINEL)
+        p.add_argument("--alphabet-profile", default=DEFAULT_SYMBOL_ALPHABET_PROFILE)
+        p.add_argument("--symbol-id-width", type=int, default=None)
+        p.add_argument("--wrap-width", type=int, default=DEFAULT_SYMBOLIC_WRAP_WIDTH)
+
+    p_build = sub.add_parser("build", help="Build a readable symbolic file from input text + dataset")
+    p_build.add_argument("--input", required=True)
+    p_build.add_argument("--dataset", required=True)
+    p_build.add_argument("--output", required=True)
+    p_build.add_argument("--encoding", default="utf-8")
+    p_build.add_argument("--errors", default="strict")
+    add_symbolic_options(p_build)
+    p_build.set_defaults(func=cmd_build)
+
+    p_from_map = sub.add_parser("from-map", help="Build a readable symbolic file from an existing mapped file")
+    p_from_map.add_argument("--map", required=True)
+    p_from_map.add_argument("--output", required=True)
+    add_symbolic_options(p_from_map)
+    p_from_map.set_defaults(func=cmd_from_map)
+
+    p_inspect = sub.add_parser("inspect", help="Inspect a readable symbolic file")
+    p_inspect.add_argument("--symbolic", required=True)
+    p_inspect.add_argument("--errors", default="strict")
+    p_inspect.add_argument("--include-previews", action="store_true")
+    p_inspect.add_argument("--preview-chars", type=int, default=240)
+    p_inspect.set_defaults(func=cmd_inspect)
+
+    p_self = sub.add_parser("self-test", help="Run internal self-tests")
+    p_self.set_defaults(func=lambda args: (run_self_tests(), print("self-test: ok"), 0)[-1])
+
+    return parser
+
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (HanReadableSymbolicError, HanFileMapError) as exc:
+        stderr(f"error: {exc}")
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/data/han_decomp/v0/han_main_block_decomp.py
+++ b/data/han_decomp/v0/han_main_block_decomp.py
@@ -1,0 +1,1374 @@
+
+#!/usr/bin/env python3
+"""
+Build recursive subcomponent decompositions for Chinese Han characters in the
+main Unicode block (U+4E00..U+9FFF).
+
+The script combines:
+  * official Unicode/UCD/Unihan metadata (UnicodeData.txt, Unihan.zip,
+    CJKRadicals.txt, EquivalentUnifiedIdeograph.txt)
+  * a decomposition source such as cjkvi-ids, CHISE, or cjk-decomp
+
+Goals
+-----
+1. keep the official radical/stroke metadata separate from structural
+   decomposition;
+2. preserve exact source decompositions;
+3. derive a second "normalized radicals" layer for downstream search/indexing.
+
+The implementation is intentionally strict about source formats, but it also
+contains enough heuristics to cope with the real-world quirks in CHISE/cjkvi
+IDS data:
+  * entity references such as &U-i003+51AC;
+  * angle-bracket tokens like <CJK RADICAL MEAT>;
+  * optional CHISE @apparent= metadata;
+  * alternative IDS strings on the same line;
+  * current Unicode IDS grammar, including unary IDCs and U+31EF.
+
+The script uses only the Python standard library.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import io
+import json
+import os
+import re
+import shutil
+import sys
+import textwrap
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+
+MAIN_BLOCK_START = 0x4E00
+MAIN_BLOCK_END = 0x9FFF
+MAIN_BLOCK_NAME = "CJK Unified Ideographs"
+
+LATEST_UCD_BASE = "https://www.unicode.org/Public/UCD/latest/ucd/"
+
+DEFAULT_URLS = {
+    "unicode_data": f"{LATEST_UCD_BASE}UnicodeData.txt",
+    "unihan_zip": f"{LATEST_UCD_BASE}Unihan.zip",
+    "cjk_radicals": f"{LATEST_UCD_BASE}CJKRadicals.txt",
+    "equivalent_unified": f"{LATEST_UCD_BASE}EquivalentUnifiedIdeograph.txt",
+    "cjkvi": "https://raw.githubusercontent.com/cjkvi/cjkvi-ids/master/ids.txt",
+    "chise": "https://raw.githubusercontent.com/osfans/chise-ids/master/IDS-UCS-Basic.txt",
+    "cjk_decomp": "https://raw.githubusercontent.com/amake/cjk-decomp/master/cjk-decomp.txt",
+}
+
+DOWNLOAD_FILENAMES = {
+    "unicode_data": "UnicodeData.txt",
+    "unihan_zip": "Unihan.zip",
+    "cjk_radicals": "CJKRadicals.txt",
+    "equivalent_unified": "EquivalentUnifiedIdeograph.txt",
+    "cjkvi": "ids.txt",
+    "chise": "IDS-UCS-Basic.txt",
+    "cjk_decomp": "cjk-decomp.txt",
+}
+
+IDS_UNARY = {"⿾", "⿿"}
+IDS_BINARY = {"⿰", "⿱", "⿴", "⿵", "⿶", "⿷", "⿸", "⿹", "⿺", "⿻", "⿼", "⿽", "㇯"}
+IDS_TRINARY = {"⿲", "⿳"}
+IDS_ARITY = {op: 1 for op in IDS_UNARY}
+IDS_ARITY.update({op: 2 for op in IDS_BINARY})
+IDS_ARITY.update({op: 3 for op in IDS_TRINARY})
+
+# Variant normalization is intentionally layered:
+# - conservative: obvious radical/component allographs and simplification forms
+# - aggressive: adds a few common component-to-radical reductions
+CONSERVATIVE_VARIANT_MAP = {
+    "亻": "人",
+    "⺅": "人",
+    "氵": "水",
+    "氺": "水",
+    "忄": "心",
+    "⺖": "心",
+    "㣺": "心",
+    "⺗": "心",
+    "扌": "手",
+    "龵": "手",
+    "犭": "犬",
+    "礻": "示",
+    "⺬": "示",
+    "衤": "衣",
+    "讠": "言",
+    "訁": "言",
+    "钅": "金",
+    "釒": "金",
+    "饣": "食",
+    "飠": "食",
+    "纟": "糸",
+    "糹": "糸",
+    "辶": "辵",
+    "⻌": "辵",
+    "⻍": "辵",
+    "攵": "攴",
+    "爫": "爪",
+    "灬": "火",
+    "⺼": "肉",
+    "艹": "艸",
+    "⺾": "艸",
+    "⺿": "艸",
+    "罒": "网",
+    "⺲": "网",
+    "罓": "网",
+    "覀": "西",
+}
+AGGRESSIVE_EXTRA_VARIANT_MAP = {
+    "刂": "刀",
+    "⺉": "刀",
+    "⺈": "刀",
+    "⺌": "小",
+    "⺍": "小",
+    "⺨": "犬",
+    "⺡": "水",
+    "⺘": "手",
+    "⺩": "玉",
+    "⻎": "辵",
+    "⻏": "邑",
+    "⻖": "阜",
+    "⻂": "衣",
+    "⻑": "長",
+    "⻒": "長",
+    "⻨": "麥",
+    "⻩": "黃",
+    "⻪": "黽",
+}
+UNRESOLVED_PREFIXES = ("&", "<", "U+", "U-")
+TRAILING_PAREN_COMMENT_RE = re.compile(r"\s+\([^)]+\)\s*$")
+INLINE_HASH_COMMENT_RE = re.compile(r"\s+#.*$")
+RS_UNICODE_RE = re.compile(r"^(?P<num>\d{1,3})(?P<marks>'{0,3})\.(?P<residual>-?\d{1,3})$")
+U_TOKEN_RE = re.compile(r"^(?:U\+([0-9A-Fa-f]{4,6})|U-([0-9A-Fa-f]{8}))$")
+U_TOKEN_ANYWHERE_RE = re.compile(r"(?:U\+([0-9A-Fa-f]{4,6})|U-([0-9A-Fa-f]{8}))")
+CHISE_LIKE_LEAD_RE = re.compile(
+    r"^(?P<cp>U\+[0-9A-Fa-f]{4,6}|U-[0-9A-Fa-f]{8})"
+    r"(?:\t+|\s+)"
+    r"(?P<char>\S)"
+    r"(?:\t+|\s+)"
+    r"(?P<rest>.+?)\s*$"
+)
+CJK_DECOMP_RE = re.compile(r"^(?P<target>[^:#\s][^:]*)\:(?P<kind>[^()]+)\((?P<parts>.*)\)\s*$")
+
+
+class HanDecompError(Exception):
+    """Base exception for this script."""
+
+
+class ParseError(HanDecompError):
+    """Raised when a decomposition cannot be parsed."""
+
+
+@dataclasses.dataclass(frozen=True)
+class IDSNode:
+    kind: str  # "leaf" | "op"
+    value: str
+    children: Tuple["IDSNode", ...] = dataclasses.field(default_factory=tuple)
+    scheme: str = "ids"
+
+    @property
+    def is_leaf(self) -> bool:
+        return self.kind == "leaf"
+
+
+@dataclasses.dataclass
+class RSUnicodeValue:
+    raw: str
+    radical_key: str
+    radical_number: int
+    simplification_marks: int
+    residual_strokes: int
+    radical_char: Optional[str]
+    radical_unified_char: Optional[str]
+
+    def to_dict(self) -> dict:
+        return {
+            "raw": self.raw,
+            "radical_key": self.radical_key,
+            "radical_number": self.radical_number,
+            "simplification_marks": self.simplification_marks,
+            "residual_strokes": self.residual_strokes,
+            "radical_char": self.radical_char,
+            "radical_unified_char": self.radical_unified_char,
+        }
+
+
+@dataclasses.dataclass
+class DecompositionEntry:
+    key: str
+    char: Optional[str]
+    source_format: str
+    primary_raw: Optional[str] = None
+    primary_tree: Optional[IDSNode] = None
+    alternative_raw: List[str] = dataclasses.field(default_factory=list)
+    apparent_raw: List[str] = dataclasses.field(default_factory=list)
+    metadata: Dict[str, List[str]] = dataclasses.field(default_factory=lambda: defaultdict(list))
+    source_lines: List[int] = dataclasses.field(default_factory=list)
+
+    def merge_from(self, other: "DecompositionEntry") -> None:
+        if self.key != other.key:
+            raise ValueError("Cannot merge entries for different keys")
+        if self.char is None and other.char is not None:
+            self.char = other.char
+        if self.primary_raw is None and other.primary_raw is not None:
+            self.primary_raw = other.primary_raw
+            self.primary_tree = other.primary_tree
+        elif other.primary_raw and other.primary_raw != self.primary_raw:
+            if other.primary_raw not in self.alternative_raw:
+                self.alternative_raw.append(other.primary_raw)
+        for item in other.alternative_raw:
+            if item not in self.alternative_raw and item != self.primary_raw:
+                self.alternative_raw.append(item)
+        for item in other.apparent_raw:
+            if item not in self.apparent_raw:
+                self.apparent_raw.append(item)
+        for key, values in other.metadata.items():
+            existing = self.metadata.setdefault(key, [])
+            for value in values:
+                if value not in existing:
+                    existing.append(value)
+        for line in other.source_lines:
+            if line not in self.source_lines:
+                self.source_lines.append(line)
+
+
+@dataclasses.dataclass(frozen=True)
+class LeafContext:
+    parent_op: Optional[str]
+    scheme: Optional[str]
+    child_index: Optional[int]
+    sibling_count: Optional[int]
+
+
+@dataclasses.dataclass
+class BuildContext:
+    assigned_main_block: Dict[int, str]
+    name_lookup: Dict[str, str]
+    radical_map: Dict[str, Tuple[Optional[str], Optional[str]]]
+    equivalent_map: Dict[str, str]
+    unihan: Dict[int, Dict[str, str]]
+    decomp_db: Dict[str, DecompositionEntry]
+    entity_map: Dict[str, str]
+    normalization: str
+    max_depth: int
+
+
+def stderr(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def normalize_ucd_name(name: str) -> str:
+    return re.sub(r"[\s\-_]+", " ", name.strip().upper())
+
+
+def parse_codepoint_token(token: str) -> Optional[int]:
+    m = U_TOKEN_RE.match(token)
+    if not m:
+        return None
+    hex_text = m.group(1) or m.group(2)
+    if hex_text is None:
+        return None
+    return int(hex_text, 16)
+
+
+def char_from_codepoint_token(token: str) -> Optional[str]:
+    cp = parse_codepoint_token(token)
+    if cp is None or cp > 0x10FFFF:
+        return None
+    return chr(cp)
+
+
+def is_main_block(cp: int) -> bool:
+    return MAIN_BLOCK_START <= cp <= MAIN_BLOCK_END
+
+
+def cp_to_uplus(cp: int) -> str:
+    if cp <= 0xFFFF:
+        return f"U+{cp:04X}"
+    return f"U+{cp:06X}"
+
+
+def serialize_node(node: IDSNode) -> dict:
+    if node.is_leaf:
+        return {"kind": "leaf", "value": node.value, "scheme": node.scheme}
+    return {
+        "kind": "op",
+        "value": node.value,
+        "scheme": node.scheme,
+        "children": [serialize_node(child) for child in node.children],
+    }
+
+
+def node_surface(node: IDSNode) -> str:
+    if node.is_leaf:
+        return node.value
+    if node.scheme == "ids":
+        return node.value + "".join(node_surface(child) for child in node.children)
+    return f"{node.value}({','.join(node_surface(child) for child in node.children)})"
+
+
+def immediate_component_surfaces(node: Optional[IDSNode]) -> List[str]:
+    if node is None or node.is_leaf:
+        return []
+    return [node_surface(child) for child in node.children]
+
+
+def collect_leaf_tokens(node: IDSNode, context: Optional[LeafContext] = None) -> List[Tuple[str, LeafContext]]:
+    if node.is_leaf:
+        if context is None:
+            context = LeafContext(None, None, None, None)
+        return [(node.value, context)]
+    out: List[Tuple[str, LeafContext]] = []
+    n = len(node.children)
+    for idx, child in enumerate(node.children):
+        child_context = LeafContext(node.value, node.scheme, idx, n)
+        out.extend(collect_leaf_tokens(child, child_context))
+    return out
+
+
+def dedupe_preserve_order(items: Iterable[str]) -> List[str]:
+    seen = set()
+    out = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def is_unresolved_token(token: str) -> bool:
+    if not token:
+        return True
+    if token.startswith(UNRESOLVED_PREFIXES):
+        return True
+    if token.isdigit():
+        return True
+    # A token can be more than one code point if it is still unresolved or if it
+    # is a CHISE/cjk-decomp synthetic identifier. Surface Unicode leaves should
+    # generally collapse to a single Unicode scalar here.
+    return len(token) != 1
+
+
+def load_json_mapping(path: Optional[Path]) -> Dict[str, str]:
+    if path is None:
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise HanDecompError(f"Entity map must be a JSON object: {path}")
+    out = {}
+    for key, value in data.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise HanDecompError("Entity map keys and values must be strings")
+        out[key] = value
+    return out
+
+
+def download_file(url: str, dest: Path, force: bool = False) -> None:
+    if dest.exists() and not force:
+        return
+    ensure_dir(dest.parent)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    stderr(f"Downloading {url} -> {dest}")
+    try:
+        with urllib.request.urlopen(url) as response, tmp.open("wb") as fh:
+            shutil.copyfileobj(response, fh)
+    except urllib.error.URLError as exc:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise HanDecompError(f"Failed to download {url}: {exc}") from exc
+    tmp.replace(dest)
+
+
+def download_required_files(
+    data_dir: Path,
+    decomp_source: str,
+    force: bool = False,
+    decomp_url: Optional[str] = None,
+) -> Dict[str, Path]:
+    downloads_dir = data_dir / "downloads"
+    ensure_dir(downloads_dir)
+    paths = {
+        "unicode_data": downloads_dir / DOWNLOAD_FILENAMES["unicode_data"],
+        "unihan_zip": downloads_dir / DOWNLOAD_FILENAMES["unihan_zip"],
+        "cjk_radicals": downloads_dir / DOWNLOAD_FILENAMES["cjk_radicals"],
+        "equivalent_unified": downloads_dir / DOWNLOAD_FILENAMES["equivalent_unified"],
+    }
+    for key in ("unicode_data", "unihan_zip", "cjk_radicals", "equivalent_unified"):
+        download_file(DEFAULT_URLS[key], paths[key], force=force)
+
+    if decomp_source != "none":
+        decomp_key = "cjkvi" if decomp_source == "auto" else decomp_source
+        if decomp_url is None:
+            if decomp_key not in DEFAULT_URLS:
+                raise HanDecompError(f"No default URL for decomposition source: {decomp_source}")
+            decomp_url = DEFAULT_URLS[decomp_key]
+        filename = DOWNLOAD_FILENAMES.get(decomp_key, Path(urllib.parse.urlparse(decomp_url).path).name or "decomp.txt")
+        paths["decomp"] = downloads_dir / filename
+        download_file(decomp_url, paths["decomp"], force=force)
+    return paths
+
+
+def parse_unicode_data(path: Path) -> Tuple[Dict[int, str], Dict[str, str]]:
+    """
+    Returns:
+      assigned_main_block: cp -> name
+      name_lookup: normalized UCD character name -> char
+    """
+    assigned: Dict[int, str] = {}
+    name_lookup: Dict[str, str] = {}
+    pending_range_start: Optional[int] = None
+    pending_range_name: Optional[str] = None
+
+    with path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.rstrip("\n")
+            if not line:
+                continue
+            fields = line.split(";")
+            if len(fields) < 2:
+                continue
+            cp = int(fields[0], 16)
+            name = fields[1]
+
+            if name and not name.startswith("<"):
+                name_lookup[normalize_ucd_name(name)] = chr(cp)
+
+            if name.endswith(", First>"):
+                pending_range_start = cp
+                pending_range_name = name
+                continue
+
+            if name.endswith(", Last>"):
+                if pending_range_start is None or pending_range_name is None:
+                    raise HanDecompError(f"Malformed UnicodeData range near {fields[0]}")
+                start = pending_range_start
+                end = cp
+                overlap_start = max(start, MAIN_BLOCK_START)
+                overlap_end = min(end, MAIN_BLOCK_END)
+                if overlap_start <= overlap_end:
+                    for current in range(overlap_start, overlap_end + 1):
+                        assigned[current] = f"CJK UNIFIED IDEOGRAPH-{current:04X}"
+                pending_range_start = None
+                pending_range_name = None
+                continue
+
+            if is_main_block(cp):
+                if name.startswith("<") and "CJK Ideograph" in name:
+                    assigned[cp] = f"CJK UNIFIED IDEOGRAPH-{cp:04X}"
+                else:
+                    assigned[cp] = name
+
+    return assigned, name_lookup
+
+
+def parse_cjk_radicals(path: Path) -> Dict[str, Tuple[Optional[str], Optional[str]]]:
+    """
+    Returns radical_key -> (radical_char, unified_char)
+    radical_key keeps apostrophes, e.g. "90'".
+    """
+    out: Dict[str, Tuple[Optional[str], Optional[str]]] = {}
+    with path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = [p.strip() for p in line.split(";")]
+            if len(parts) < 3:
+                continue
+            radical_key = parts[0]
+            radical_cp = int(parts[1], 16) if parts[1] else None
+            unified_cp = int(parts[2], 16) if parts[2] else None
+            radical_char = chr(radical_cp) if radical_cp is not None else None
+            unified_char = chr(unified_cp) if unified_cp is not None else None
+            out[radical_key] = (radical_char, unified_char)
+    return out
+
+
+def parse_equivalent_unified(path: Path) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    with path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = [p.strip() for p in line.split(";")]
+            if len(parts) < 3:
+                continue
+            try:
+                src_cp = int(parts[0], 16)
+                dst_cp = int(parts[2], 16)
+            except ValueError:
+                continue
+            out[chr(src_cp)] = chr(dst_cp)
+    return out
+
+
+def parse_unihan_zip(path: Path, needed_fields: Optional[Sequence[str]] = None) -> Dict[int, Dict[str, str]]:
+    if needed_fields is None:
+        needed_fields = ("kRSUnicode", "kTotalStrokes", "kDefinition")
+    needed = set(needed_fields)
+    out: Dict[int, Dict[str, str]] = defaultdict(dict)
+    with zipfile.ZipFile(path) as zf:
+        for name in zf.namelist():
+            if not name.endswith(".txt"):
+                continue
+            with zf.open(name) as fh:
+                for raw_line in io.TextIOWrapper(fh, encoding="utf-8"):
+                    if not raw_line or raw_line.startswith("#"):
+                        continue
+                    parts = raw_line.rstrip("\n").split("\t")
+                    if len(parts) != 3:
+                        continue
+                    cp_field, prop, value = parts
+                    if prop not in needed:
+                        continue
+                    cp = parse_codepoint_token(cp_field)
+                    if cp is None or not is_main_block(cp):
+                        continue
+                    out[cp][prop] = value
+    return out
+
+
+def parse_rs_unicode(raw_value: Optional[str], radical_map: Dict[str, Tuple[Optional[str], Optional[str]]]) -> List[RSUnicodeValue]:
+    if not raw_value:
+        return []
+    values: List[RSUnicodeValue] = []
+    for item in raw_value.split():
+        m = RS_UNICODE_RE.match(item)
+        if not m:
+            continue
+        radical_key = f"{m.group('num')}{m.group('marks')}"
+        radical_number = int(m.group("num"))
+        marks = len(m.group("marks"))
+        residual = int(m.group("residual"))
+        radical_char, radical_unified = radical_map.get(radical_key, (None, None))
+        values.append(
+            RSUnicodeValue(
+                raw=item,
+                radical_key=radical_key,
+                radical_number=radical_number,
+                simplification_marks=marks,
+                residual_strokes=residual,
+                radical_char=radical_char,
+                radical_unified_char=radical_unified,
+            )
+        )
+    return values
+
+
+def parse_total_strokes(raw_value: Optional[str]) -> List[int]:
+    if not raw_value:
+        return []
+    values: List[int] = []
+    for item in raw_value.split():
+        try:
+            values.append(int(item))
+        except ValueError:
+            continue
+    return values
+
+
+def tokenize_ids(text: str) -> List[str]:
+    tokens: List[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch == "&":
+            j = text.find(";", i + 1)
+            if j != -1:
+                tokens.append(text[i : j + 1])
+                i = j + 1
+                continue
+        if ch == "<":
+            j = text.find(">", i + 1)
+            if j != -1:
+                tokens.append(text[i : j + 1])
+                i = j + 1
+                continue
+        if text.startswith("U+", i) or text.startswith("U-", i):
+            m = U_TOKEN_ANYWHERE_RE.match(text[i:])
+            if m:
+                tok = m.group(0)
+                tokens.append(tok)
+                i += len(tok)
+                continue
+        tokens.append(ch)
+        i += 1
+    return tokens
+
+
+def parse_ids_from_tokens(tokens: Sequence[str], start: int = 0) -> Tuple[IDSNode, int]:
+    if start >= len(tokens):
+        raise ParseError("Unexpected end of IDS")
+    tok = tokens[start]
+    if tok in IDS_UNARY:
+        child, next_index = parse_ids_from_tokens(tokens, start + 1)
+        return IDSNode("op", tok, (child,), "ids"), next_index
+    if tok in IDS_BINARY:
+        left, idx = parse_ids_from_tokens(tokens, start + 1)
+        right, idx = parse_ids_from_tokens(tokens, idx)
+        return IDSNode("op", tok, (left, right), "ids"), idx
+    if tok in IDS_TRINARY:
+        first, idx = parse_ids_from_tokens(tokens, start + 1)
+        second, idx = parse_ids_from_tokens(tokens, idx)
+        third, idx = parse_ids_from_tokens(tokens, idx)
+        return IDSNode("op", tok, (first, second, third), "ids"), idx
+    return IDSNode("leaf", tok, (), "ids"), start + 1
+
+
+def extract_ids_candidates(text: str) -> List[str]:
+    cleaned = TRAILING_PAREN_COMMENT_RE.sub("", text.strip())
+    cleaned = INLINE_HASH_COMMENT_RE.sub("", cleaned).strip()
+    if not cleaned:
+        return []
+    tokens = tokenize_ids(cleaned)
+    if not tokens:
+        return []
+    candidates: List[str] = []
+    idx = 0
+    while idx < len(tokens):
+        node, next_idx = parse_ids_from_tokens(tokens, idx)
+        candidates.append(node_surface(node))
+        idx = next_idx
+    return candidates
+
+
+def parse_ids_string(text: str) -> IDSNode:
+    candidates = extract_ids_candidates(text)
+    if not candidates:
+        raise ParseError(f"Could not parse IDS: {text!r}")
+    tokens = tokenize_ids(candidates[0])
+    node, next_idx = parse_ids_from_tokens(tokens, 0)
+    if next_idx != len(tokens):
+        raise ParseError(f"Trailing tokens in IDS: {text!r}")
+    return node
+
+
+def parse_chise_like_file(path: Path, source_format: str) -> Dict[str, DecompositionEntry]:
+    """
+    Parser for CHISE-like or cjkvi-like text files.
+
+    Supported line styles:
+      U+XXXX<TAB>字<TAB>IDS
+      U+XXXX<TAB>字<TAB>IDS<TAB>@apparent=IDS
+      U+XXXX 字 IDS IDS2
+    """
+    out: Dict[str, DecompositionEntry] = {}
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw_line in enumerate(fh, 1):
+            stripped = raw_line.strip()
+            if not stripped or stripped.startswith("#") or stripped.startswith(";;"):
+                continue
+            m = CHISE_LIKE_LEAD_RE.match(raw_line.rstrip("\n"))
+            if not m:
+                # Some files contain standalone metadata or malformed lines; skip them.
+                continue
+            cp_token = m.group("cp")
+            char_field = m.group("char")
+            rest = m.group("rest")
+            char_from_cp = char_from_codepoint_token(cp_token)
+            char = char_field
+            if char_from_cp is not None and char != char_from_cp:
+                # Prefer the explicit character column unless it is suspiciously empty.
+                if len(char) != 1:
+                    char = char_from_cp
+
+            fields = raw_line.rstrip("\n").split("\t")
+            if len(fields) >= 3:
+                tail_fields = [field.strip() for field in fields[2:] if field.strip()]
+            else:
+                tail_fields = [rest]
+
+            entry = DecompositionEntry(key=char, char=char, source_format=source_format, source_lines=[lineno])
+
+            ids_candidates: List[str] = []
+            apparent_candidates: List[str] = []
+            metadata: Dict[str, List[str]] = defaultdict(list)
+
+            for field in tail_fields:
+                if not field:
+                    continue
+                if field.startswith("@apparent="):
+                    try:
+                        apparent_candidates.extend(extract_ids_candidates(field[len("@apparent=") :]))
+                    except ParseError:
+                        metadata["unparsed_apparent"].append(field[len("@apparent=") :].strip())
+                    continue
+                if field.startswith("@"):
+                    key, eq, value = field.partition("=")
+                    meta_key = key[1:] if key.startswith("@") else key
+                    metadata[meta_key].append(value if eq else "")
+                    continue
+                try:
+                    ids_candidates.extend(extract_ids_candidates(field))
+                except ParseError:
+                    metadata["unparsed_field"].append(field)
+
+            if not ids_candidates:
+                # If the tab-split path did not yield IDS candidates, try the whole tail.
+                try:
+                    ids_candidates = extract_ids_candidates(rest)
+                except ParseError:
+                    metadata["unparsed_tail"].append(rest)
+                    ids_candidates = []
+
+            if ids_candidates:
+                entry.primary_raw = ids_candidates[0]
+                entry.primary_tree = parse_ids_string(ids_candidates[0])
+                entry.alternative_raw = dedupe_preserve_order(ids_candidates[1:])
+            entry.apparent_raw = dedupe_preserve_order(apparent_candidates)
+            entry.metadata = metadata
+
+            existing = out.get(entry.key)
+            if existing is None:
+                out[entry.key] = entry
+            else:
+                existing.merge_from(entry)
+    return out
+
+
+def split_cjk_decomp_parts(parts_text: str) -> List[str]:
+    if not parts_text.strip():
+        return []
+    return [part.strip() for part in parts_text.split(",") if part.strip()]
+
+
+def parse_cjk_decomp_file(path: Path) -> Dict[str, DecompositionEntry]:
+    out: Dict[str, DecompositionEntry] = {}
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw_line in enumerate(fh, 1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            m = CJK_DECOMP_RE.match(line)
+            if not m:
+                continue
+            target = m.group("target").strip()
+            kind = m.group("kind").strip()
+            parts = split_cjk_decomp_parts(m.group("parts"))
+            char = target if len(target) == 1 else None
+
+            entry = DecompositionEntry(key=target, char=char, source_format="cjk-decomp", source_lines=[lineno])
+
+            if kind == "c" or not parts:
+                entry.primary_raw = target
+                entry.primary_tree = IDSNode("leaf", target, (), "cjk-decomp")
+            else:
+                children = tuple(IDSNode("leaf", part, (), "cjk-decomp") for part in parts)
+                entry.primary_raw = f"{kind}({','.join(parts)})"
+                entry.primary_tree = IDSNode("op", kind, children, "cjk-decomp")
+            entry.metadata = defaultdict(list, {"kind": [kind]})
+            out[target] = entry
+    return out
+
+
+def load_decomposition_db(path: Path, source_format: str) -> Dict[str, DecompositionEntry]:
+    if source_format == "auto":
+        # very small sniff: cjk-decomp uses "X:kind(...)" at line start
+        with path.open("r", encoding="utf-8") as fh:
+            for raw_line in fh:
+                line = raw_line.strip()
+                if not line or line.startswith("#") or line.startswith(";;"):
+                    continue
+                if CJK_DECOMP_RE.match(line):
+                    return parse_cjk_decomp_file(path)
+                return parse_chise_like_file(path, "auto")
+        return {}
+    if source_format == "cjk-decomp":
+        return parse_cjk_decomp_file(path)
+    return parse_chise_like_file(path, source_format)
+
+
+def resolve_token_to_lookup_key(
+    token: str,
+    name_lookup: Dict[str, str],
+    equivalent_map: Dict[str, str],
+    entity_map: Dict[str, str],
+) -> str:
+    if token in entity_map:
+        return entity_map[token]
+    body = token[1:-1] if token.startswith("&") and token.endswith(";") else token
+    if body in entity_map:
+        return entity_map[body]
+
+    cp_char = char_from_codepoint_token(token)
+    if cp_char is not None:
+        token = cp_char
+
+    if token.startswith("&") and token.endswith(";"):
+        body = token[1:-1]
+        if body in entity_map:
+            token = entity_map[body]
+        else:
+            m = U_TOKEN_ANYWHERE_RE.search(body)
+            if m:
+                cp_hex = m.group(1) or m.group(2)
+                if cp_hex is not None:
+                    cp = int(cp_hex, 16)
+                    if cp <= 0x10FFFF:
+                        token = chr(cp)
+
+    if token.startswith("<") and token.endswith(">"):
+        name_key = normalize_ucd_name(token[1:-1])
+        replacement = name_lookup.get(name_key)
+        if replacement:
+            token = replacement
+
+    token = equivalent_map.get(token, token)
+    return token
+
+
+def normalize_leaf_token(
+    token: str,
+    context: LeafContext,
+    normalization: str,
+    name_lookup: Dict[str, str],
+    equivalent_map: Dict[str, str],
+    entity_map: Dict[str, str],
+) -> str:
+    token = resolve_token_to_lookup_key(token, name_lookup, equivalent_map, entity_map)
+
+    if token == "阝":
+        if context.parent_op in {"⿰", "⿲"} and context.child_index is not None and context.sibling_count is not None:
+            if context.child_index == context.sibling_count - 1:
+                token = "邑"
+            else:
+                token = "阜"
+        elif context.scheme == "cjk-decomp" and context.parent_op is not None:
+            if context.parent_op.startswith("a") and context.child_index is not None and context.sibling_count is not None:
+                if context.child_index == context.sibling_count - 1:
+                    token = "邑"
+                else:
+                    token = "阜"
+
+    if normalization in {"conservative", "aggressive"}:
+        token = CONSERVATIVE_VARIANT_MAP.get(token, token)
+
+    if normalization == "aggressive":
+        token = AGGRESSIVE_EXTRA_VARIANT_MAP.get(token, token)
+
+    return token
+
+
+def expand_node(
+    node: IDSNode,
+    decomp_db: Dict[str, DecompositionEntry],
+    name_lookup: Dict[str, str],
+    equivalent_map: Dict[str, str],
+    entity_map: Dict[str, str],
+    max_depth: int,
+    memo: Dict[str, IDSNode],
+    visiting: Optional[set] = None,
+    depth: int = 0,
+) -> IDSNode:
+    if visiting is None:
+        visiting = set()
+
+    if depth >= max_depth:
+        return node
+
+    if node.is_leaf:
+        lookup_key = resolve_token_to_lookup_key(node.value, name_lookup, equivalent_map, entity_map)
+        if lookup_key in memo:
+            return memo[lookup_key]
+        if lookup_key in visiting:
+            return IDSNode("leaf", lookup_key, (), node.scheme)
+        entry = decomp_db.get(lookup_key)
+        if entry is None or entry.primary_tree is None:
+            return IDSNode("leaf", lookup_key, (), node.scheme)
+        if entry.primary_tree.is_leaf and resolve_token_to_lookup_key(entry.primary_tree.value, name_lookup, equivalent_map, entity_map) == lookup_key:
+            return IDSNode("leaf", lookup_key, (), node.scheme)
+
+        visiting.add(lookup_key)
+        expanded = expand_node(
+            entry.primary_tree,
+            decomp_db,
+            name_lookup,
+            equivalent_map,
+            entity_map,
+            max_depth,
+            memo,
+            visiting,
+            depth + 1,
+        )
+        visiting.remove(lookup_key)
+        memo[lookup_key] = expanded
+        return expanded
+
+    expanded_children = tuple(
+        expand_node(
+            child,
+            decomp_db,
+            name_lookup,
+            equivalent_map,
+            entity_map,
+            max_depth,
+            memo,
+            visiting,
+            depth + 1,
+        )
+        for child in node.children
+    )
+    return IDSNode("op", node.value, expanded_children, node.scheme)
+
+
+def build_record(cp: int, ctx: BuildContext) -> dict:
+    char = chr(cp)
+    name = ctx.assigned_main_block[cp]
+    unihan_props = ctx.unihan.get(cp, {})
+    rs_values = parse_rs_unicode(unihan_props.get("kRSUnicode"), ctx.radical_map)
+    total_strokes = parse_total_strokes(unihan_props.get("kTotalStrokes"))
+    definition = unihan_props.get("kDefinition")
+
+    entry = ctx.decomp_db.get(char)
+    primary_raw = entry.primary_raw if entry else None
+    primary_tree = entry.primary_tree if entry else None
+    immediate_components = immediate_component_surfaces(primary_tree) if primary_tree else []
+    alt_raw = entry.alternative_raw if entry else []
+    apparent_raw = entry.apparent_raw if entry else []
+    metadata = entry.metadata if entry else {}
+    source_lines = entry.source_lines if entry else []
+
+    expanded_tree = None
+    raw_leaf_tokens: List[str] = []
+    normalized_leaf_tokens: List[str] = []
+    unresolved_tokens: List[str] = []
+    if primary_tree is not None:
+        expanded_tree = expand_node(
+            primary_tree,
+            ctx.decomp_db,
+            ctx.name_lookup,
+            ctx.equivalent_map,
+            ctx.entity_map,
+            ctx.max_depth,
+            memo={},
+        )
+        raw_leaf_pairs = collect_leaf_tokens(expanded_tree)
+        raw_leaf_tokens = [resolve_token_to_lookup_key(tok, ctx.name_lookup, ctx.equivalent_map, ctx.entity_map) for tok, _ in raw_leaf_pairs]
+        normalized_leaf_tokens = [
+            normalize_leaf_token(
+                tok,
+                context,
+                ctx.normalization,
+                ctx.name_lookup,
+                ctx.equivalent_map,
+                ctx.entity_map,
+            )
+            for tok, context in raw_leaf_pairs
+        ]
+        unresolved_tokens = dedupe_preserve_order(
+            tok
+            for tok in normalized_leaf_tokens
+            if is_unresolved_token(tok)
+        )
+
+    record = {
+        "char": char,
+        "codepoint": cp_to_uplus(cp),
+        "codepoint_int": cp,
+        "name": name,
+        "block": MAIN_BLOCK_NAME,
+        "unihan": {
+            "kRSUnicode_raw": unihan_props.get("kRSUnicode"),
+            "kRSUnicode": [item.to_dict() for item in rs_values],
+            "kTotalStrokes_raw": unihan_props.get("kTotalStrokes"),
+            "kTotalStrokes": total_strokes,
+            "kDefinition": definition,
+        },
+        "decomposition_source": entry.source_format if entry else None,
+        "decomposition": {
+            "primary_raw": primary_raw,
+            "alternative_raw": alt_raw,
+            "apparent_raw": apparent_raw,
+            "metadata": {k: list(v) for k, v in metadata.items()},
+            "source_lines": source_lines,
+            "immediate_components": immediate_components,
+            "primary_tree": serialize_node(primary_tree) if primary_tree else None,
+            "expanded_tree": serialize_node(expanded_tree) if expanded_tree else None,
+            "leaf_components_raw": raw_leaf_tokens,
+            "leaf_components_raw_unique": dedupe_preserve_order(raw_leaf_tokens),
+            "leaf_radicals_normalized": normalized_leaf_tokens,
+            "leaf_radicals_normalized_unique": dedupe_preserve_order(normalized_leaf_tokens),
+            "unresolved_tokens": unresolved_tokens,
+        },
+    }
+    return record
+
+
+def write_records(records: Iterable[dict], output: Path, output_format: str) -> None:
+    ensure_dir(output.parent)
+    if output_format == "jsonl":
+        with output.open("w", encoding="utf-8") as fh:
+            for record in records:
+                fh.write(json.dumps(record, ensure_ascii=False, sort_keys=False))
+                fh.write("\n")
+        return
+    if output_format == "json":
+        with output.open("w", encoding="utf-8") as fh:
+            json.dump(list(records), fh, ensure_ascii=False, indent=2)
+            fh.write("\n")
+        return
+    raise HanDecompError(f"Unsupported output format: {output_format}")
+
+
+def load_records_for_lookup(dataset: Path) -> Iterator[dict]:
+    suffix = dataset.suffix.lower()
+    if suffix == ".jsonl":
+        with dataset.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                if line.strip():
+                    yield json.loads(line)
+        return
+    if suffix == ".json":
+        with dataset.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, list):
+            for item in data:
+                yield item
+            return
+    raise HanDecompError(f"Unsupported dataset format for lookup: {dataset}")
+
+
+def summarize_stats(records: Iterable[dict]) -> dict:
+    total = 0
+    with_decomp = 0
+    with_unresolved = 0
+    no_unihan = 0
+    for record in records:
+        total += 1
+        if record["decomposition"]["primary_raw"]:
+            with_decomp += 1
+        if record["decomposition"]["unresolved_tokens"]:
+            with_unresolved += 1
+        if not record["unihan"]["kRSUnicode"] and not record["unihan"]["kTotalStrokes"]:
+            no_unihan += 1
+    return {
+        "total_records": total,
+        "with_decomposition": with_decomp,
+        "with_unresolved_tokens": with_unresolved,
+        "without_unihan_radical_or_strokes": no_unihan,
+    }
+
+
+def build_dataset(
+    unicode_data_path: Path,
+    unihan_zip_path: Path,
+    cjk_radicals_path: Path,
+    equivalent_unified_path: Path,
+    decomp_path: Optional[Path],
+    decomp_source: str,
+    entity_map_path: Optional[Path],
+    normalization: str,
+    output: Path,
+    output_format: str,
+    include_unassigned: bool,
+    max_depth: int,
+) -> dict:
+    assigned, name_lookup = parse_unicode_data(unicode_data_path)
+    radical_map = parse_cjk_radicals(cjk_radicals_path)
+    equivalent_map = parse_equivalent_unified(equivalent_unified_path)
+    unihan = parse_unihan_zip(unihan_zip_path)
+    entity_map = load_json_mapping(entity_map_path)
+
+    if decomp_path is None or decomp_source == "none":
+        decomp_db: Dict[str, DecompositionEntry] = {}
+    else:
+        decomp_db = load_decomposition_db(decomp_path, decomp_source)
+
+    ctx = BuildContext(
+        assigned_main_block=assigned,
+        name_lookup=name_lookup,
+        radical_map=radical_map,
+        equivalent_map=equivalent_map,
+        unihan=unihan,
+        decomp_db=decomp_db,
+        entity_map=entity_map,
+        normalization=normalization,
+        max_depth=max_depth,
+    )
+
+    cps = range(MAIN_BLOCK_START, MAIN_BLOCK_END + 1)
+    if not include_unassigned:
+        cps = [cp for cp in cps if cp in assigned]
+
+    records = [build_record(cp, ctx) for cp in cps]
+    write_records(records, output, output_format)
+    return summarize_stats(records)
+
+
+def resolve_default_input_paths(
+    data_dir: Path,
+    decomp_source: str,
+) -> Dict[str, Path]:
+    downloads = data_dir / "downloads"
+    paths = {
+        "unicode_data": downloads / DOWNLOAD_FILENAMES["unicode_data"],
+        "unihan_zip": downloads / DOWNLOAD_FILENAMES["unihan_zip"],
+        "cjk_radicals": downloads / DOWNLOAD_FILENAMES["cjk_radicals"],
+        "equivalent_unified": downloads / DOWNLOAD_FILENAMES["equivalent_unified"],
+    }
+    if decomp_source != "none":
+        lookup_key = "cjkvi" if decomp_source == "auto" else decomp_source
+        filename = DOWNLOAD_FILENAMES.get(lookup_key)
+        if filename:
+            paths["decomp"] = downloads / filename
+    return paths
+
+
+def parse_char_or_codepoint(arg: str) -> str:
+    cp = parse_codepoint_token(arg)
+    if cp is not None:
+        return chr(cp)
+    if len(arg) == 1:
+        return arg
+    raise HanDecompError(f"Lookup key must be a single character or U+XXXX code point: {arg}")
+
+
+def cmd_download(args: argparse.Namespace) -> int:
+    download_required_files(
+        data_dir=Path(args.data_dir),
+        decomp_source=args.decomp_source,
+        force=args.force,
+        decomp_url=args.decomp_url,
+    )
+    return 0
+
+
+def cmd_build(args: argparse.Namespace) -> int:
+    data_dir = Path(args.data_dir)
+    if args.download_missing:
+        download_required_files(
+            data_dir=data_dir,
+            decomp_source=args.decomp_source,
+            force=False,
+            decomp_url=args.decomp_url,
+        )
+    default_paths = resolve_default_input_paths(data_dir, args.decomp_source)
+
+    unicode_data = Path(args.unicode_data) if args.unicode_data else default_paths["unicode_data"]
+    unihan_zip = Path(args.unihan_zip) if args.unihan_zip else default_paths["unihan_zip"]
+    cjk_radicals = Path(args.cjk_radicals) if args.cjk_radicals else default_paths["cjk_radicals"]
+    equivalent_unified = Path(args.equivalent_unified) if args.equivalent_unified else default_paths["equivalent_unified"]
+    decomp_path = None
+    if args.decomp_source != "none":
+        if args.decomp_file:
+            decomp_path = Path(args.decomp_file)
+        else:
+            decomp_path = default_paths.get("decomp")
+            if decomp_path is None:
+                raise HanDecompError("No decomposition file path available")
+
+    output = Path(args.output)
+    stats = build_dataset(
+        unicode_data_path=unicode_data,
+        unihan_zip_path=unihan_zip,
+        cjk_radicals_path=cjk_radicals,
+        equivalent_unified_path=equivalent_unified,
+        decomp_path=decomp_path,
+        decomp_source=args.decomp_source,
+        entity_map_path=Path(args.entity_map) if args.entity_map else None,
+        normalization=args.normalization,
+        output=output,
+        output_format=args.output_format,
+        include_unassigned=args.include_unassigned,
+        max_depth=args.max_depth,
+    )
+    stderr("Build complete.")
+    stderr(json.dumps(stats, ensure_ascii=False, indent=2))
+    return 0
+
+
+def cmd_lookup(args: argparse.Namespace) -> int:
+    dataset = Path(args.dataset)
+    wanted = {parse_char_or_codepoint(item) for item in args.items}
+    found = {}
+    for record in load_records_for_lookup(dataset):
+        char = record.get("char")
+        if char in wanted:
+            found[char] = record
+
+    missing = [item for item in wanted if item not in found]
+    for char in args.items:
+        normalized = parse_char_or_codepoint(char)
+        if normalized in found:
+            print(json.dumps(found[normalized], ensure_ascii=False, indent=2))
+    if missing:
+        stderr(f"Not found: {' '.join(missing)}")
+        return 1
+    return 0
+
+
+def cmd_stats(args: argparse.Namespace) -> int:
+    stats = summarize_stats(load_records_for_lookup(Path(args.dataset)))
+    print(json.dumps(stats, ensure_ascii=False, indent=2))
+    return 0
+
+
+def run_self_tests() -> None:
+    # IDS parsing
+    n = parse_ids_string("⿰氵可")
+    assert n.value == "⿰" and len(n.children) == 2 and n.children[0].value == "氵"
+
+    n = parse_ids_string("⿳艹⿰白勺口")
+    assert n.value == "⿳" and len(n.children) == 3
+
+    # Multiple IDS candidates in one field
+    cands = extract_ids_candidates("⿰言吾 ⿰言⿱五口")
+    assert cands == ["⿰言吾", "⿰言⿱五口"]
+
+    # CHISE-like parsing, including @apparent
+    sample = textwrap.dedent("""\
+        U+6CB3\t河\t⿰氵可\t@apparent=⿰水可
+        ;; comment
+        U+8A9E\t語\t⿰言吾
+    """)
+    tmp = Path("._selftest_chise.txt")
+    tmp.write_text(sample, encoding="utf-8")
+    db = parse_chise_like_file(tmp, "chise")
+    tmp.unlink()
+    assert db["河"].primary_raw == "⿰氵可"
+    assert db["河"].apparent_raw == ["⿰水可"]
+    assert db["語"].primary_tree is not None
+
+    # cjk-decomp parsing
+    sample = textwrap.dedent("""\
+        的:a(白,勺)
+        00001:c()
+    """)
+    tmp = Path("._selftest_cjkdecomp.txt")
+    tmp.write_text(sample, encoding="utf-8")
+    db = parse_cjk_decomp_file(tmp)
+    tmp.unlink()
+    assert db["的"].primary_tree is not None
+    assert db["的"].primary_tree.value == "a"
+    assert db["00001"].primary_tree is not None
+    assert db["00001"].primary_tree.is_leaf
+
+    # RS Unicode parsing
+    radicals = {"85": ("⽔", "水"), "170'": ("⻖", "阜")}
+    values = parse_rs_unicode("85.5 170'.3", radicals)
+    assert values[0].radical_number == 85
+    assert values[1].simplification_marks == 1
+
+    # Token resolution / normalization
+    name_lookup = {normalize_ucd_name("CJK RADICAL MEAT"): "⺼"}
+    equivalent = {"⺼": "肉"}
+    entity_map = {}
+    tok = normalize_leaf_token("<CJK RADICAL MEAT>", LeafContext(None, None, None, None), "conservative", name_lookup, equivalent, entity_map)
+    assert tok == "肉"
+
+    # Context-sensitive 阜/邑 resolution
+    tok = normalize_leaf_token("阝", LeafContext("⿰", "ids", 0, 2), "conservative", {}, {}, {})
+    assert tok == "阜"
+    tok = normalize_leaf_token("阝", LeafContext("⿰", "ids", 1, 2), "conservative", {}, {}, {})
+    assert tok == "邑"
+
+    # Recursive expansion with synthetic DB
+    river = DecompositionEntry(key="河", char="河", source_format="ids", primary_raw="⿰氵可", primary_tree=parse_ids_string("⿰氵可"))
+    comp = DecompositionEntry(key="可", char="可", source_format="ids", primary_raw="⿱丁口", primary_tree=parse_ids_string("⿱丁口"))
+    db = {"河": river, "可": comp}
+    expanded = expand_node(river.primary_tree, db, {}, {}, {}, 16, memo={})
+    leaves = [tok for tok, _ in collect_leaf_tokens(expanded)]
+    assert leaves == ["氵", "丁", "口"]
+
+    # Node surface for cjk-decomp
+    node = IDSNode("op", "a", (IDSNode("leaf", "白", (), "cjk-decomp"), IDSNode("leaf", "勺", (), "cjk-decomp")), "cjk-decomp")
+    assert node_surface(node) == "a(白,勺)"
+
+    stderr("All self-tests passed.")
+
+
+def cmd_self_test(args: argparse.Namespace) -> int:
+    run_self_tests()
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build recursive Han subcomponent decompositions for U+4E00..U+9FFF."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_download = subparsers.add_parser("download", help="Download the default Unicode/decomposition source files.")
+    p_download.add_argument("--data-dir", default="data", help="Directory used for cached downloads.")
+    p_download.add_argument(
+        "--decomp-source",
+        default="cjkvi",
+        choices=("cjkvi", "chise", "cjk-decomp", "none"),
+        help="Decomposition source to download.",
+    )
+    p_download.add_argument("--decomp-url", default=None, help="Override the decomposition source URL.")
+    p_download.add_argument("--force", action="store_true", help="Re-download even if files already exist.")
+    p_download.set_defaults(func=cmd_download)
+
+    p_build = subparsers.add_parser("build", help="Build the main-block dataset.")
+    p_build.add_argument("--data-dir", default="data", help="Directory used for cached downloads.")
+    p_build.add_argument(
+        "--decomp-source",
+        default="cjkvi",
+        choices=("cjkvi", "chise", "cjk-decomp", "auto", "none"),
+        help="Which decomposition parser/source style to use.",
+    )
+    p_build.add_argument("--decomp-url", default=None, help="Override the download URL used with --download-missing.")
+    p_build.add_argument("--download-missing", action="store_true", help="Auto-download missing default files.")
+    p_build.add_argument("--unicode-data", default=None, help="Path to UnicodeData.txt")
+    p_build.add_argument("--unihan-zip", default=None, help="Path to Unihan.zip")
+    p_build.add_argument("--cjk-radicals", default=None, help="Path to CJKRadicals.txt")
+    p_build.add_argument("--equivalent-unified", default=None, help="Path to EquivalentUnifiedIdeograph.txt")
+    p_build.add_argument("--decomp-file", default=None, help="Path to a decomposition file.")
+    p_build.add_argument("--entity-map", default=None, help="Optional JSON file mapping unresolved entities/tokens to Unicode.")
+    p_build.add_argument(
+        "--normalization",
+        default="conservative",
+        choices=("none", "conservative", "aggressive"),
+        help="How aggressively to normalize final leaf components into radicals.",
+    )
+    p_build.add_argument("--max-depth", type=int, default=32, help="Maximum recursive expansion depth.")
+    p_build.add_argument("--include-unassigned", action="store_true", help="Include unassigned code points in U+4E00..U+9FFF.")
+    p_build.add_argument("--output", required=True, help="Output file path.")
+    p_build.add_argument("--output-format", default="jsonl", choices=("jsonl", "json"), help="Output serialization format.")
+    p_build.set_defaults(func=cmd_build)
+
+    p_lookup = subparsers.add_parser("lookup", help="Lookup one or more characters/code points from a built dataset.")
+    p_lookup.add_argument("--dataset", required=True, help="Path to a .jsonl or .json dataset created by this script.")
+    p_lookup.add_argument("items", nargs="+", help="Characters or U+XXXX code points.")
+    p_lookup.set_defaults(func=cmd_lookup)
+
+    p_stats = subparsers.add_parser("stats", help="Summarize a built dataset.")
+    p_stats.add_argument("--dataset", required=True, help="Path to a .jsonl or .json dataset.")
+    p_stats.set_defaults(func=cmd_stats)
+
+    p_self = subparsers.add_parser("self-test", help="Run internal parser/expansion self-tests.")
+    p_self.set_defaults(func=cmd_self_test)
+
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except HanDecompError as exc:
+        stderr(f"ERROR: {exc}")
+        return 2
+    except KeyboardInterrupt:
+        stderr("Interrupted.")
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This pull request adds two new Bash scripts to the Han decomposition pipeline: a robust end-to-end build script (`build_from_scratch.sh`) and an interactive demonstration script (`demo.sh`). These scripts automate and document the process of generating, inspecting, and validating Han character decomposition data and its reversible symbolic representations.

The most important changes are:

**Pipeline Automation and Build Script:**

* Added `build_from_scratch.sh`, a comprehensive script to automate the full Han decomposition and round-trip pipeline. This script handles input resolution, dataset construction, reversible mapping, symbolic serialization, recovery, and byte-for-byte validation, with support for custom paths, build options, and cleaning outputs.
* The build script includes robust argument parsing, dependency checks, conditional rebuilding based on file timestamps, and optional self-tests to ensure pipeline integrity.

**Demonstration and Step-by-Step Walkthrough:**

* Added `demo.sh`, an interactive script that guides users through each pipeline stage, including self-tests, source data download, dataset building, mapping, symbolic serialization, inspection, recovery, and validation, with clear step-by-step output and error handling.
* The demo script is designed for clarity and educational value, making it easy to understand and verify each transformation and output in the pipeline.