### PR TITLE
Add hyperparam search fixes

### DIFF
--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -419,8 +419,6 @@ def main():
                 seed0 = int(cfg_template.get("seed", 1337))
                 if args.randomize_seed:
                     seed0 = random.randint(0, 2**31 - 1)
-                else:
-                    seed0 = int(cfg_template.get("seed", 1337))
                 seed_runs: List[Dict[str, Any]] = []
                 scores: List[float] = []
 

--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -108,7 +108,7 @@ def run_trial_inproc(cfg: Dict[str, Any]) -> TrialMetrics:
 
     loss = float(tr.best_val_loss)
     nparam = float(tr.raw_model.num_param)
-    best_iter = int(getattr(tr, "best_iter", getattr(tr, "iter_num_best_val_loss", 0)))
+    best_iter = int(getattr(tr, "best_iter", 0))
     torch_alloc_mb = float(
         getattr(tr, "peak_torch_allocated", getattr(tr, "peak_gpu_usage", 0.0))
         / (1024 ** 2)

--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -27,6 +27,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
+import random
 
 import torch
 import yaml
@@ -264,6 +265,11 @@ def main():
         default="max",
         help="Whether to maximize or minimize the selected optimization target.",
     )
+    ap.add_argument(
+        "--randomize_seed",
+        action="store_true",
+        help="Whether to random seed for each separate train.py run, and prevent overfitting via hillclimbing on one section of the target dataset",
+    )
 
     args = ap.parse_args()
 
@@ -411,6 +417,10 @@ def main():
                 nonlocal best_choice, candidates
 
                 seed0 = int(cfg_template.get("seed", 1337))
+                if args.randomize_seed:
+                    seed0 = random.randint(0, 2**31 - 1)
+                else:
+                    seed0 = int(cfg_template.get("seed", 1337))
                 seed_runs: List[Dict[str, Any]] = []
                 scores: List[float] = []
 


### PR DESCRIPTION
This pull request introduces a new feature to the `hyperparam_search.py` script that allows users to randomize the seed for each training run, which can help prevent overfitting to a specific section of the target dataset. It also makes a minor fix regarding how the best iteration is determined. The most important changes are:

**New Feature: Randomized Training Seeds**

* Added a `--randomize_seed` command-line argument to enable random seeding for each `train.py` run, aiming to reduce overfitting during hyperparameter search. (F376b9bcL265R265)
* Modified the `_evaluate` function to use a random seed if `--randomize_seed` is specified; otherwise, it falls back to the default or provided seed. (F376b9bcL417R417)
* Imported the `random` module to support randomized seed generation.

**Bug Fix / Refactor**

* Updated the logic for determining `best_iter` in `run_trial_inproc` to use only `best_iter` from the trial object, removing fallback to `iter_num_best_val_loss`. (F376b9bcL108R108)