### PR TITLE
Add abs pos variants

### DIFF
--- a/demos/multicontext_prime_demo_absolute_cyclic.sh
+++ b/demos/multicontext_prime_demo_absolute_cyclic.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Compare conventional learned absolute embeddings vs cyclic absolute embeddings
+# on the same multicontext prime setup used in multicontext_prime_demo.sh.
+
+set -euo pipefail
+
+pushd data/shakespeare_char_prime
+bash get_dataset.sh
+popd
+
+COMMON_ARGS=(
+  --training_mode multicontext
+  --multicontext
+  --multicontext_datasets
+    shakespeare_char
+    data/shakespeare_char_prime/char_mod2
+    data/shakespeare_char_prime/char_mod3
+    data/shakespeare_char_prime/char_mod7
+    data/shakespeare_char_prime/char_mod11
+    data/shakespeare_char_prime/char_mod13
+    data/shakespeare_char_prime/char_mod17
+  --max_iters 2000
+  --dropout 0.2
+  --top_k 1
+  --sample_each_eval
+  --use_qk_norm
+  --use_qk_norm_scale
+  --use_abs_pos_embeddings
+  --compile
+)
+
+# 1) Conventional learned absolute position embeddings (backwards-compatible default).
+python3 train.py \
+  "${COMMON_ARGS[@]}" \
+  --absolute_pos_embedding_variant learned \
+  --out_dir ./out_mc_shakespeare_abs_learned
+
+# 2) Cyclic absolute position embeddings with cycle sizes 2,3,5.
+python3 train.py \
+  "${COMMON_ARGS[@]}" \
+  --absolute_pos_embedding_variant cyclic \
+  --cyclic_abs_pos_cycle_lengths 2 3 5 \
+  --no-cyclic_abs_pos_randomize_starts \
+  --out_dir ./out_mc_shakespeare_abs_cyclic
+
+# Optional random-start training variant (per-cycle random phase each step).
+# python3 train.py \
+#   "${COMMON_ARGS[@]}" \
+#   --absolute_pos_embedding_variant cyclic \
+#   --cyclic_abs_pos_cycle_lengths 2 3 5 \
+#   --cyclic_abs_pos_randomize_starts \
+#   --out_dir ./out_mc_shakespeare_abs_cyclic_random

--- a/explorations/absolute_position_embedding_comparison.yaml
+++ b/explorations/absolute_position_embedding_comparison.yaml
@@ -13,7 +13,21 @@ named_static_groups:
     absolute_pos_embedding_variant: ["cyclic"]
     cyclic_abs_pos_cycle_lengths:
       - [2, 3, 5]
-    cyclic_abs_pos_randomize_starts: [false]
+  - named_group: "abs_cyclic_2357"
+    use_abs_pos_embeddings: [true]
+    absolute_pos_embedding_variant: ["cyclic"]
+    cyclic_abs_pos_cycle_lengths:
+      - [2, 3, 5, 7]
+  - named_group: "abs_cyclic_235711"
+    use_abs_pos_embeddings: [true]
+    absolute_pos_embedding_variant: ["cyclic"]
+    cyclic_abs_pos_cycle_lengths:
+      - [2, 3, 5, 7, 11]
+  - named_group: "abs_cyclic_23571113"
+    use_abs_pos_embeddings: [true]
+    absolute_pos_embedding_variant: ["cyclic"]
+    cyclic_abs_pos_cycle_lengths:
+      - [2, 3, 5, 7, 11, 13]
 
   - named_group: "rope_only"
     use_abs_pos_embeddings: [false]
@@ -29,13 +43,20 @@ named_static_groups:
 
   - named_group: "abs_norm_on"
     norm_variant_abs: ["hyperspherenorm"]
+    norm_abs_radius_learning: [true]
     norm_abs_radius: ["20.0"]
     norm_abs_scale: ["1.0"]
     norm_abs_gain: [false]
 
 named_variation_groups:
   - named_group: "abs_variant"
-    named_group_alternates: ["abs_learned", "abs_cyclic_235"]
+    named_group_alternates:
+      - "abs_learned"
+      - "abs_cyclic_235"
+      - "abs_cyclic_2357"
+      - "abs_cyclic_235711"
+      - "abs_cyclic_23571113"
+    cyclic_abs_pos_randomize_starts: [true, false]
   - named_group: "rotary_toggle"
     named_group_alternates: ["rotary_off", "rotary_on"]
 

--- a/explorations/absolute_position_embedding_comparison.yaml
+++ b/explorations/absolute_position_embedding_comparison.yaml
@@ -1,0 +1,74 @@
+---
+# Compare standard learned absolute embeddings, cyclic absolute embeddings, and RoPE.
+# Includes with/without norm_variant_abs for absolute variants, and with/without rotary.
+
+named_static_groups:
+  # Positional embedding strategy
+  - named_group: "abs_learned"
+    use_abs_pos_embeddings: [true]
+    absolute_pos_embedding_variant: ["learned"]
+
+  - named_group: "abs_cyclic_235"
+    use_abs_pos_embeddings: [true]
+    absolute_pos_embedding_variant: ["cyclic"]
+    cyclic_abs_pos_cycle_lengths:
+      - [2, 3, 5]
+    cyclic_abs_pos_randomize_starts: [false]
+
+  - named_group: "rope_only"
+    use_abs_pos_embeddings: [false]
+    use_rotary_embeddings: [true]
+    rope_variant: ["rope"]
+
+  # Rotary toggle for absolute-embedding runs
+  - named_group: "rotary_off"
+    use_rotary_embeddings: [false]
+  - named_group: "rotary_on"
+    use_rotary_embeddings: [true]
+    rope_variant: ["rope"]
+
+  - named_group: "abs_norm_on"
+    norm_variant_abs: ["hyperspherenorm"]
+    norm_abs_radius: ["20.0"]
+    norm_abs_scale: ["1.0"]
+    norm_abs_gain: [false]
+
+named_variation_groups:
+  - named_group: "abs_variant"
+    named_group_alternates: ["abs_learned", "abs_cyclic_235"]
+  - named_group: "rotary_toggle"
+    named_group_alternates: ["rotary_off", "rotary_on"]
+
+common_group:
+  dataset: ["minipile"]
+  max_iters: [5000]
+  eval_interval: [500]
+  n_layer: [6]
+  n_head: [6]
+  n_embd: [384]
+  block_size: [256]
+  batch_size: [64]
+  device: ["cuda"]
+  dtype: ["bfloat16"]
+  compile: [true]
+  never_save_checkpoint: [true]
+  use_qk_norm: [true]
+  use_qk_norm_scale: [true]
+  use_peri_ln: [true]
+
+parameter_groups:
+  # Cartesian product across:
+  # - absolute variant: learned vs cyclic
+  # - rotary: off vs on
+  # (no abs post-norm)
+  - named_group_variations: ["abs_variant", "rotary_toggle"]
+    tensorboard_run_name: ["abs_pos_variant_matrix_no_abs_norm"]
+
+  # Same matrix but with abs post-norm enabled
+  - named_group_static: ["abs_norm_on"]
+    named_group_variations: ["abs_variant", "rotary_toggle"]
+    tensorboard_run_name: ["abs_pos_variant_matrix_with_abs_norm"]
+
+  # RoPE-only baseline (no absolute table)
+  - named_group_static: ["rope_only"]
+    tensorboard_run_name: ["rope_only"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -335,6 +335,9 @@ class GPTConfig:
     use_fire_embeddings: bool = False
     shared_fire_embeddings: bool = False
     use_rotary_embeddings: bool = False
+    absolute_pos_embedding_variant: str = "learned"  # options: "learned", "cyclic"
+    cyclic_abs_pos_cycle_lengths: list[int] | None = None
+    cyclic_abs_pos_randomize_starts: bool = False
     sym_rot_num_angles: int = 512
     rope_variant: str = "rope" # options: "shortrope", "rope"
     rope_length: int = 8 # number of embeddings to use in shortrope

--- a/model.py
+++ b/model.py
@@ -34,6 +34,7 @@ from variations.lsv_variations import lsv_dictionary
 from variations.softmax_variations import softmax_dictionary
 from variations.norm_variations import norm_dictionary
 from variations.position_encoding_variations import QuantizedEmbedding, RotaryEmbedding, SymmetricalOverlapAngularPositions, FIRE
+from variations.absolute_position_variations import absolute_position_embedding_dict
 from variations.activation_variations import activation_dictionary
 from variations.linear_variations import linear_dictionary
 from variations.router_variations import router_dictionary
@@ -151,11 +152,7 @@ class GPT(nn.Module):
             self.transformer['post_abs_norm'] = self.build_norm_from_variant(config, "norm_variant_abs", "norm_abs")
 
         if self.config.use_abs_pos_embeddings:
-            if config.quantize_wpe:
-                pos_embd = QuantizedEmbedding(config.block_size, config.n_embd, config.quantize_wpe_method, config.quantize_wpe_bits)
-            else:
-                pos_embd = nn.Embedding(config.block_size, config.n_embd)
-            self.transformer['wpe'] = pos_embd
+            self.transformer['wpe'] = absolute_position_embedding_dict[config.absolute_pos_embedding_variant](config)
 
         # Select softmax variant for output layer
         self.softmax_variant_output = config.softmax_variant_output
@@ -226,7 +223,7 @@ class GPT(nn.Module):
         """
         n_params = sum(p.numel() for p in self.parameters())
         if non_embedding and self.config.use_abs_pos_embeddings:
-            n_params -= self.transformer.wpe.weight.numel()
+            n_params -= sum(p.numel() for p in self.transformer.wpe.parameters())
         return n_params
 
     def update_block_size(self, new_block_size):
@@ -234,11 +231,7 @@ class GPT(nn.Module):
         if new_block_size > self.config.block_size:
             self.config.block_size = new_block_size
             if self.config.use_abs_pos_embeddings:
-                if self.config.quantize_wpe:
-                    pos_embd = QuantizedEmbedding(new_block_size, self.config.n_embd, self.config.quantize_wpe_method, self.config.quantize_wpe_bits)
-                else:
-                    pos_embd = nn.Embedding(new_block_size, self.config.n_embd)
-                self.transformer.wpe = pos_embd
+                self.transformer.wpe.update_block_size(new_block_size)
             for block in self.transformer.h:
                 if hasattr(block.attn, 'bias'):
                     block.attn.bias = torch.tril(torch.ones(new_block_size, new_block_size)).view(1, 1, new_block_size, new_block_size)
@@ -397,8 +390,7 @@ class GPT(nn.Module):
                 x = x * self.embedding_scale
 
             if self.config.use_abs_pos_embeddings:
-                pos = torch.arange(0, t, dtype=torch.long, device=device)
-                pos_emb = self.transformer.wpe(pos)  # (t, n_embd)
+                pos_emb = self.transformer.wpe(t, device=device, training=self.training)  # (t, n_embd)
                 x = self.transformer.drop(x + pos_emb)
             else:
                 x = self.transformer.drop(x)
@@ -539,8 +531,7 @@ class GPT(nn.Module):
                 tok_emb = self.transformer.post_embedding_norm(tok_emb)
 
             if self.config.use_abs_pos_embeddings:
-                pos = torch.arange(0, t, dtype=torch.long, device=device) # shape (t)
-                pos_emb = self.transformer.wpe(pos) # position embeddings of shape (t, n_embd)
+                pos_emb = self.transformer.wpe(t, device=device, training=self.training) # position embeddings of shape (t, n_embd)
                 x = tok_emb + pos_emb
                 if self.config.norm_variant_abs is not None:
                     x = self.transformer.post_abs_norm(x)
@@ -648,8 +639,7 @@ class GPT(nn.Module):
 
         if self.config.use_abs_pos_embeddings:
             t = idx.size(1)
-            pos = torch.arange(0, t, dtype=torch.long, device=device)
-            tok_emb = tok_emb + self.transformer.wpe(pos)
+            tok_emb = tok_emb + self.transformer.wpe(t, device=device, training=self.training)
             if self.config.norm_variant_abs is not None:
                 tok_emb = self.transformer.post_abs_norm(tok_emb)
 
@@ -810,7 +800,7 @@ class GPT(nn.Module):
         assert block_size <= self.config.block_size
         self.config.block_size = block_size
         if self.config.use_abs_pos_embeddings:
-            self.transformer.wpe.weight = nn.Parameter(self.transformer.wpe.weight[:block_size])
+            self.transformer.wpe.crop_block_size(block_size)
         for block in self.transformer.h:
             if hasattr(block.attn, 'bias'):
                 block.attn.bias = block.attn.bias[:,:,:block_size,:block_size]

--- a/train_args.py
+++ b/train_args.py
@@ -1164,6 +1164,26 @@ def parse_args():
     model_group.add_argument("--rope_variant", type=str, default="rope", choices=["rope", "soap"])
     model_group.add_argument("--rope_length", type=int, default=None, help="Defaults to all embeddings (if set to None), else must be even.")
     model_group.add_argument('--use_abs_pos_embeddings', default=True, action=argparse.BooleanOptionalAction)
+    model_group.add_argument(
+        "--absolute_pos_embedding_variant",
+        type=str,
+        default="learned",
+        choices=["learned", "cyclic"],
+        help="Absolute position embedding style: standard learned table or cyclic multi-table sum.",
+    )
+    model_group.add_argument(
+        "--cyclic_abs_pos_cycle_lengths",
+        nargs="+",
+        type=int,
+        default=None,
+        help="Cycle lengths for cyclic absolute embeddings (e.g. --cyclic_abs_pos_cycle_lengths 2 3 5).",
+    )
+    model_group.add_argument(
+        "--cyclic_abs_pos_randomize_starts",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="If enabled, each cyclic embedding list starts from a random offset during training.",
+    )
     model_group.add_argument('--use_fire_embeddings', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--shared_fire_embeddings', default=False, action=argparse.BooleanOptionalAction)
 

--- a/variations/absolute_position_variations.py
+++ b/variations/absolute_position_variations.py
@@ -1,0 +1,105 @@
+import torch
+import torch.nn as nn
+
+from variations.position_encoding_variations import QuantizedEmbedding
+
+
+class LearnedAbsolutePositionEmbedding(nn.Module):
+    """Standard learned absolute position embeddings."""
+
+    def __init__(self, config):
+        super().__init__()
+        if config.quantize_wpe:
+            self.embedding = QuantizedEmbedding(
+                config.block_size,
+                config.n_embd,
+                config.quantize_wpe_method,
+                config.quantize_wpe_bits,
+            )
+        else:
+            self.embedding = nn.Embedding(config.block_size, config.n_embd)
+
+    def forward(self, seq_len, device, training=False):
+        del training  # unused, kept for interface compatibility
+        pos = torch.arange(0, seq_len, dtype=torch.long, device=device)
+        return self.embedding(pos)
+
+    def update_block_size(self, new_block_size):
+        old_weight = self.embedding.weight.data
+        old_block_size, dim = old_weight.shape
+        if new_block_size <= old_block_size:
+            return
+
+        if isinstance(self.embedding, QuantizedEmbedding):
+            new_embedding = QuantizedEmbedding(
+                new_block_size,
+                dim,
+                self.embedding.quantization_method,
+                self.embedding.quantization_bits,
+            )
+        else:
+            new_embedding = nn.Embedding(new_block_size, dim)
+
+        with torch.no_grad():
+            new_embedding.weight[:old_block_size] = old_weight
+        self.embedding = new_embedding
+
+    def crop_block_size(self, block_size):
+        self.embedding.weight = nn.Parameter(self.embedding.weight[:block_size])
+
+
+class CyclicAbsolutePositionEmbedding(nn.Module):
+    """Sums learned embeddings from multiple cyclic periods.
+
+    For cycle lengths [2, 3, 5], position i uses:
+      emb2[i % 2] + emb3[i % 3] + emb5[i % 5].
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        if config.quantize_wpe:
+            raise ValueError("cyclic absolute position embeddings currently do not support quantized wpe")
+
+        cycle_lengths = config.cyclic_abs_pos_cycle_lengths
+        if cycle_lengths is None or len(cycle_lengths) == 0:
+            raise ValueError("cyclic_abs_pos_cycle_lengths must be set for cyclic_abs_pos embedding variant")
+        if any(length <= 0 for length in cycle_lengths):
+            raise ValueError("All cyclic_abs_pos_cycle_lengths values must be positive")
+
+        self.cycle_lengths = [int(length) for length in cycle_lengths]
+        self.randomize_starts = config.cyclic_abs_pos_randomize_starts
+
+        self.embeddings = nn.ModuleList([
+            nn.Embedding(cycle_len, config.n_embd) for cycle_len in self.cycle_lengths
+        ])
+
+    def forward(self, seq_len, device, training=False):
+        pos = torch.arange(0, seq_len, dtype=torch.long, device=device)
+        out = None
+
+        for cycle_len, emb in zip(self.cycle_lengths, self.embeddings):
+            if training and self.randomize_starts:
+                start = torch.randint(0, cycle_len, (1,), device=device).item()
+            else:
+                start = 0
+
+            cycle_pos = (pos + start) % cycle_len
+            cycle_emb = emb(cycle_pos)
+            out = cycle_emb if out is None else out + cycle_emb
+
+        return out
+
+    def update_block_size(self, new_block_size):
+        del new_block_size
+        # No-op; these embeddings are cycle-length based.
+        return
+
+    def crop_block_size(self, block_size):
+        del block_size
+        return
+
+
+absolute_position_embedding_dict = {
+    "learned": LearnedAbsolutePositionEmbedding,
+    "cyclic": CyclicAbsolutePositionEmbedding,
+}


### PR DESCRIPTION
This pull request adds support for cyclic absolute position embeddings as an alternative to standard learned absolute position embeddings, enabling more flexible and configurable positional encoding strategies. It introduces a new modular system for absolute position embeddings, updates the model to use this system, and adds configuration options for experimenting with different embedding variants. Additionally, new demo and exploration scripts are provided for comparing these approaches.

**Core features and architecture:**

* Introduced a modular absolute position embedding system via `absolute_position_embedding_dict`, supporting both standard learned (`"learned"`) and new cyclic (`"cyclic"`) variants, implemented in `variations/absolute_position_variations.py`. The cyclic variant sums embeddings from multiple cycles with configurable lengths and optional random phase offsets during training.

* Updated the model to use the new absolute position embedding interface: position embeddings are now constructed via the selected variant, and methods like `update_block_size` and `crop_block_size` are delegated to the embedding module. Calls to the embedding now use a unified interface for both variants. [[1]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43R37) [[2]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L154-R155) [[3]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L229-R234) [[4]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L400-R393) [[5]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L542-R534) [[6]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L651-R642) [[7]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L813-R803)

**Configuration and CLI:**

* Added new configuration options to `GPTConfig` and CLI arguments in `train_args.py` for selecting the absolute position embedding variant (`--absolute_pos_embedding_variant`), specifying cycle lengths (`--cyclic_abs_pos_cycle_lengths`), and enabling random phase offsets (`--cyclic_abs_pos_randomize_starts`). [[1]](diffhunk://#diff-114e7747956438292f72cb8316c075c30638fe5c68dab6a7ac466f33639df288R338-R340) [[2]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R1167-R1186)

**Experimentation and demos:**

* Added a new shell demo script (`demos/multicontext_prime_demo_absolute_cyclic.sh`) to compare standard learned and cyclic absolute embeddings in a multicontext setting.

* Added a new YAML experiment configuration (`explorations/absolute_position_embedding_comparison.yaml`) for systematic comparison of learned, cyclic, and rotary (RoPE) positional embedding strategies, with and without normalization.