### PR TITLE
Add distilled zeus monitoring

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -16,6 +16,7 @@ from rich.table import Table
 LOG_DIR = Path("exploration_logs")
 LOG_DIR.mkdir(exist_ok=True)
 METRICS_FILENAME = "best_val_loss_and_iter.txt"
+ZEUS_SUMMARY_FILENAME = "zeus_summary.json"
 METRIC_KEYS = [
     "best_val_loss",
     "best_val_iter",
@@ -27,6 +28,7 @@ METRIC_KEYS = [
     "peak_torch_reserved_mb",
     "peak_process_gpu_mb",
     "iter_latency_avg",
+    "zeus_best_train_step_energy_j",
     "avg_top1_prob",
     "avg_top1_correct",
     "avg_target_rank",
@@ -38,6 +40,11 @@ METRIC_KEYS = [
     "ln_f_cosine_95",
     "rankme",
     "areq",
+    "zeus_total_energy_j",
+    "zeus_total_time_s",
+    "zeus_avg_power_w",
+    "zeus_train_step_energy_j",
+    "zeus_energy_per_token_j",
 ]
 
 
@@ -552,6 +559,30 @@ def read_metrics(out_dir: str) -> dict:
     line = path.read_text().strip()
     parts = [p.strip() for p in line.split(',')]
 
+    base_metric_keys = [
+        "best_val_loss",
+        "best_val_iter",
+        "best_val_tokens",
+        "num_params",
+        "better_than_chance",
+        "btc_per_param",
+        "peak_torch_allocated_mb",
+        "peak_torch_reserved_mb",
+        "peak_process_gpu_mb",
+        "iter_latency_avg",
+        "zeus_best_train_step_energy_j",
+        "avg_top1_prob",
+        "avg_top1_correct",
+        "avg_target_rank",
+        "avg_target_left_prob",
+        "avg_target_prob",
+        "target_rank_95",
+        "left_prob_95",
+        "avg_ln_f_cosine",
+        "ln_f_cosine_95",
+        "rankme",
+        "areq",
+    ]
     casts = [
         float,
         int,
@@ -576,7 +607,26 @@ def read_metrics(out_dir: str) -> dict:
         float,
     ]
 
-    return {k: typ(v) for k, typ, v in zip(METRIC_KEYS, casts, parts)}
+    metrics: dict[str, float] = {}
+    for key, typ, value in zip(base_metric_keys, casts, parts):
+        metrics[key] = float("nan") if value == "" else typ(value)
+
+    zeus_summary_path = Path(out_dir) / ZEUS_SUMMARY_FILENAME
+    if zeus_summary_path.exists():
+        summary = json.loads(zeus_summary_path.read_text())
+        metrics["zeus_total_energy_j"] = float(summary.get("zeus_total_energy_j", float("nan")))
+        metrics["zeus_total_time_s"] = float(summary.get("zeus_total_time_s", float("nan")))
+        metrics["zeus_avg_power_w"] = float(summary.get("zeus_avg_power_w", float("nan")))
+        metrics["zeus_train_step_energy_j"] = float(summary.get("zeus_train_step_energy_j", float("nan")))
+        metrics["zeus_energy_per_token_j"] = float(summary.get("zeus_energy_per_token_j", float("nan")))
+    else:
+        metrics["zeus_total_energy_j"] = float("nan")
+        metrics["zeus_total_time_s"] = float("nan")
+        metrics["zeus_avg_power_w"] = float("nan")
+        metrics["zeus_train_step_energy_j"] = float("nan")
+        metrics["zeus_energy_per_token_j"] = float("nan")
+
+    return {k: metrics.get(k, float("nan")) for k in METRIC_KEYS}
 
 
 def completed_runs(log_file: Path) -> set[str]:

--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -605,6 +605,7 @@ def read_metrics(out_dir: str) -> dict:
         float,
         float,
         float,
+        float,
     ]
 
     metrics: dict[str, float] = {}

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -191,6 +191,7 @@ class MonitorApp(App):
             "peak_torch_reserved_mb",
             "peak_process_gpu_mb",
             "iter_latency_avg",
+            "zeus_best_train_step_energy_j",
             "avg_top1_prob",
             "avg_top1_correct",
             "avg_target_rank",
@@ -202,6 +203,11 @@ class MonitorApp(App):
             "ln_f_cosine_95",
             "rankme",
             "areq",
+            "zeus_total_energy_j",
+            "zeus_total_time_s",
+            "zeus_avg_power_w",
+            "zeus_train_step_energy_j",
+            "zeus_energy_per_token_j",
         ] + self.param_keys
         self.all_columns = base_cols.copy()
         self.columns = base_cols.copy()
@@ -209,6 +215,11 @@ class MonitorApp(App):
         if self.config_file.exists():
             cfg = json.loads(self.config_file.read_text())
             self.all_columns = cfg.get("all_columns", self.all_columns)
+            # Preserve saved ordering, but append any newly introduced columns
+            # (e.g., newly added metrics) so they become visible automatically.
+            for column in base_cols:
+                if column not in self.all_columns:
+                    self.all_columns.append(column)
             self.hidden_cols = set(cfg.get("hidden_cols", []))
             self.columns = [c for c in self.all_columns if c not in self.hidden_cols]
             self.sort_stack = [tuple(p) for p in cfg.get("sort_stack", [])]
@@ -298,6 +309,7 @@ class MonitorApp(App):
             "peak_torch_reserved_mb",
             "peak_process_gpu_mb",
             "iter_latency_avg",
+            "zeus_best_train_step_energy_j",
             "avg_top1_prob",
             "avg_top1_correct",
             "avg_target_rank",
@@ -309,6 +321,11 @@ class MonitorApp(App):
             "ln_f_cosine_95",
             "rankme",
             "areq",
+            "zeus_total_energy_j",
+            "zeus_total_time_s",
+            "zeus_avg_power_w",
+            "zeus_train_step_energy_j",
+            "zeus_energy_per_token_j",
         ):
             return entry.get(col_name)
         return entry.get("config", {}).get(col_name)

--- a/train.py
+++ b/train.py
@@ -29,6 +29,11 @@ from train_variations.distillation_loss_variants import build_distillation_loss
 from utils.gpu_monitoring import get_gpu_memory_info, get_process_gpu_memory_bytes
 from torch.cuda import reset_peak_memory_stats, max_memory_allocated, max_memory_reserved
 
+try:
+    from zeus.monitor import ZeusMonitor
+except ImportError:
+    ZeusMonitor = None
+
 from utils.model_info import (
     print_summary,
     print_module_structure,
@@ -103,6 +108,13 @@ class Trainer:
         self.peak_torch_allocated = 0.0
         self.peak_torch_reserved = 0.0
         self.peak_process_gpu_usage = 0.0
+        self.zeus_monitor = None
+        self.zeus_enabled = False
+        self.zeus_total_energy_j = 0.0
+        self.zeus_total_time_s = 0.0
+        self.zeus_train_step_energy_j = 0.0
+        self.zeus_best_train_step_energy_j = 0.0
+        self.zeus_last_step_energy_j = 0.0
         self.total_training_time_ms: float = 0.0   # total run-time from start of training
         self.time_remaining_ms: float= 0.0
         self.total_time_est_ms: float= 0.0
@@ -245,6 +257,27 @@ class Trainer:
         self.device_type = 'cuda' if 'cuda' in self.args.device else 'cpu'
         if self.device_type == 'cuda':
             reset_peak_memory_stats(self.device)
+
+        if self.args.zeus_log:
+            if self.device_type != 'cuda':
+                raise ValueError("Zeus energy logging requires a CUDA device.")
+            if ZeusMonitor is None:
+                raise ImportError(
+                    "Zeus is not installed. Install it with `pip install zeus` "
+                    "or rerun with `--no-zeus_log`."
+                )
+            if self.ddp:
+                gpu_indices = [self.ddp_local_rank]
+            else:
+                gpu_indices = [torch.cuda.current_device()]
+            self.zeus_monitor = ZeusMonitor(
+                gpu_indices=gpu_indices,
+                cpu_indices=[],
+                approx_instant_energy=self.args.zeus_approx_instant_energy,
+                log_file=self.args.zeus_log_file,
+                sync_execution_with="torch",
+            )
+            self.zeus_enabled = True
 
         self.ptdtype = {"bfloat16" : torch.bfloat16, "float16" : torch.float16, "float32" : torch.float32}[self.args.dtype]
         self.ctx = nullcontext() if self.device_type == 'cpu' else torch.amp.autocast(device_type=self.device_type, dtype=self.ptdtype)
@@ -1594,7 +1627,48 @@ class Trainer:
             if self.args.gns_type is not None:
                 args.append(self.gns)
             args.append(self.iter_latency_avg)
+            if self.zeus_enabled:
+                args.append(self.zeus_train_step_energy_j)
+                args.append(self.zeus_last_step_energy_j)
             writer.writerow(args)
+
+    def _write_zeus_summary(self):
+        if not self.zeus_enabled or not self.master_process:
+            return
+        total_tokens = self.tokens_trained if self.tokens_trained else self.best_tokens
+        summary = {
+            "dataset": self.args.dataset,
+            "iter_num": self.iter_num,
+            "best_iter": self.best_iter,
+            "best_tokens": self.best_tokens,
+            "num_params": int(self.model.num_param),
+            "peak_torch_allocated_mb": self.peak_torch_allocated / (1024 ** 2),
+            "peak_torch_reserved_mb": self.peak_torch_reserved / (1024 ** 2),
+            "peak_process_gpu_mb": self.peak_process_gpu_usage / (1024 ** 2),
+            "iter_latency_avg_ms": self.iter_latency_avg,
+            "zeus_total_energy_j": self.zeus_total_energy_j,
+            "zeus_total_time_s": self.zeus_total_time_s,
+            "zeus_avg_power_w": (
+                self.zeus_total_energy_j / self.zeus_total_time_s
+                if self.zeus_total_time_s > 0
+                else 0.0
+            ),
+            "zeus_train_step_energy_j": self.zeus_train_step_energy_j,
+            "zeus_best_train_step_energy_j": self.zeus_best_train_step_energy_j,
+            "zeus_energy_per_token_j": (
+                self.zeus_total_energy_j / total_tokens
+                if total_tokens > 0
+                else 0.0
+            ),
+            "zeus_energy_train_per_token_j": (
+                self.zeus_train_step_energy_j / total_tokens
+                if total_tokens > 0
+                else 0.0
+            ),
+        }
+        summary_path = os.path.join(self.args.out_dir, "zeus_summary.json")
+        with open(summary_path, "w", encoding="utf-8") as summary_file:
+            json.dump(summary, summary_file, indent=2, sort_keys=True)
 
 
     def log_gamma_beta(self, gamma, beta, layer_num, head_num=None):
@@ -1791,6 +1865,8 @@ class Trainer:
                 self.best_val_loss = losses['val']
                 self.best_iter = self.iter_num
                 self.best_tokens = self.tokens_trained
+                if self.zeus_enabled:
+                    self.zeus_best_train_step_energy_j = self.zeus_train_step_energy_j
                 peak_torch_allocated_mb = self.peak_torch_allocated / (1024 ** 2)
                 peak_torch_reserved_mb = self.peak_torch_reserved / (1024 ** 2)
                 peak_process_gpu_mb = self.peak_process_gpu_usage / (1024 ** 2)
@@ -1807,6 +1883,7 @@ class Trainer:
                             f"{peak_torch_reserved_mb:.1f}",
                             f"{peak_process_gpu_mb:.1f}",
                             f"{self.iter_latency_avg:.1f}",
+                            f"{self.zeus_best_train_step_energy_j:.3f}" if self.zeus_enabled else "",
                             f"{self.latest_top1_prob:.6f}",
                             f"{self.latest_top1_correct:.6f}",
                             f"{self.latest_target_rank:.2f}",
@@ -1989,6 +2066,8 @@ class Trainer:
                     lnf_cos95=f"{self.latest_ln_f_cosine_95:.6f}",
                     )
 
+            if self.zeus_enabled:
+                self.zeus_monitor.begin_window("entire_training")
             while True:
                 if self.scheduler is not None:
                     self.lr = self.get_lr(self.iter_num)
@@ -2010,6 +2089,8 @@ class Trainer:
                 if self.args.eval_only:
                     break
 
+                if self.zeus_enabled:
+                    self.zeus_monitor.begin_window("train_step")
 
                 for micro_step in range(self.args.gradient_accumulation_steps):
                     if self.ddp:
@@ -2135,6 +2216,11 @@ class Trainer:
                 t0 = t1
                 self.total_training_time_ms = (t1 - t_start) * 1000.0
 
+                if self.zeus_enabled:
+                    zeus_step_measurement = self.zeus_monitor.end_window("train_step")
+                    self.zeus_last_step_energy_j = zeus_step_measurement.total_energy
+                    self.zeus_train_step_energy_j += zeus_step_measurement.total_energy
+
                 # Estimate ETA
                 eta_update: ETAUpdate = self.eta.update(
                         iter_num=self.iter_num,
@@ -2211,6 +2297,12 @@ class Trainer:
 
             if self.args.plot_statistics:
                 plot_statistics(self.args, self.stats, graph_y_labels)
+
+            if self.zeus_enabled:
+                zeus_total_measurement = self.zeus_monitor.end_window("entire_training")
+                self.zeus_total_energy_j = zeus_total_measurement.total_energy
+                self.zeus_total_time_s = zeus_total_measurement.time
+                self._write_zeus_summary()
 
             if self.args.tensorboard_log:
                 self.writer.flush()

--- a/train.py
+++ b/train.py
@@ -1490,6 +1490,7 @@ class Trainer:
                 self.writer.add_scalar(f"{target_dataset}/gns_iters", self.gns, self.iter_num)
                 self.writer.add_scalar(f"{target_dataset}/gns_tokens", self.gns, tokens_trained)
 
+            self._log_zeus_tensorboard(target_dataset, tokens_trained)
             self._log_bit_metrics(target_dataset, tokens_trained)
 
 
@@ -1590,6 +1591,7 @@ class Trainer:
                 self.writer.add_scalar(f"{target_dataset}/gns_iters", self.gns, self.iter_num)
                 self.writer.add_scalar(f"{target_dataset}/gns_tokens", self.gns, tokens_trained)
 
+            self._log_zeus_tensorboard(target_dataset, tokens_trained)
             self._log_bit_metrics(target_dataset, tokens_trained)
 
     def write_to_csv(self, *args, prefix=""):
@@ -1735,6 +1737,26 @@ class Trainer:
         if torch.is_tensor(value):
             return value.item()
         return float(value)
+
+    def _log_zeus_tensorboard(self, target_dataset: str, tokens_trained: float) -> None:
+        if not self.zeus_enabled or not self.args.tensorboard_log:
+            return
+        self.writer.add_scalar(
+            f"{target_dataset}/zeus_train_step_energy_j",
+            self.zeus_train_step_energy_j,
+            self.iter_num,
+        )
+        self.writer.add_scalar(
+            f"{target_dataset}/zeus_last_step_energy_j",
+            self.zeus_last_step_energy_j,
+            self.iter_num,
+        )
+        if tokens_trained > 0:
+            self.writer.add_scalar(
+                f"{target_dataset}/zeus_energy_train_per_token_j",
+                self.zeus_train_step_energy_j / tokens_trained,
+                self.iter_num,
+            )
 
     def underscore_abbr(self, dataset_name):
         """ Transforms long dataset name to abbreviation
@@ -2302,6 +2324,15 @@ class Trainer:
                 zeus_total_measurement = self.zeus_monitor.end_window("entire_training")
                 self.zeus_total_energy_j = zeus_total_measurement.total_energy
                 self.zeus_total_time_s = zeus_total_measurement.time
+                if self.args.tensorboard_log:
+                    avg_power_w = (
+                        self.zeus_total_energy_j / self.zeus_total_time_s
+                        if self.zeus_total_time_s > 0
+                        else 0.0
+                    )
+                    self.writer.add_scalar("zeus/total_energy_j", self.zeus_total_energy_j, self.iter_num)
+                    self.writer.add_scalar("zeus/total_time_s", self.zeus_total_time_s, self.iter_num)
+                    self.writer.add_scalar("zeus/avg_power_w", avg_power_w, self.iter_num)
                 self._write_zeus_summary()
 
             if self.args.tensorboard_log:

--- a/train_args.py
+++ b/train_args.py
@@ -1383,6 +1383,9 @@ def parse_args():
     logging_group.add_argument('--csv_log', default=True, action=argparse.BooleanOptionalAction)
     logging_group.add_argument('--csv_dir', default='csv_logs', type=str)
     logging_group.add_argument('--csv_name', default='output', type=str, help="Output csv basename. Note, the .csv will be automatically appended.")
+    logging_group.add_argument('--zeus_log', default=False, action=argparse.BooleanOptionalAction, help='Enable Zeus GPU energy logging during training')
+    logging_group.add_argument('--zeus_log_file', type=str, default=None, help='Optional Zeus monitor log file path')
+    logging_group.add_argument('--zeus_approx_instant_energy', default=True, action=argparse.BooleanOptionalAction, help='Use Zeus instant-power fallback for short measurement windows')
 
     # Tensorboard args
     logging_group.add_argument('--tensorboard_log', default=True, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
This pull request adds comprehensive support for GPU energy usage tracking during training using the Zeus energy monitoring library. It introduces command-line options to enable Zeus logging, integrates Zeus metrics into the training loop, logs these metrics to TensorBoard and CSV, and outputs a summary JSON file for later analysis. The metrics reading pipeline is updated to include these new energy-related metrics.

**Zeus energy monitoring integration:**

- Added Zeus energy monitoring support in `train.py`, including initialization, measurement during training steps, and final summary reporting. Zeus metrics such as total energy, average power, and per-step energy are now tracked and stored. (`[[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R32-R36)`, `[[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R111-R117)`, `[[3]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R261-R281)`, `[[4]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R2091-R2092)`, `[[5]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R2114-R2115)`, `[[6]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R2241-R2245)`, `[[7]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R2323-R2337)`)
- New command-line arguments in `train_args.py` allow enabling Zeus logging and configuring its behavior. (`[train_args.pyR1386-R1388](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R1386-R1388)`)

**Metrics logging and reporting:**

- Zeus energy metrics are logged to TensorBoard and CSV, and a summary is written to `zeus_summary.json` in the output directory. This includes per-step, per-token, and total energy usage. (`[[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R1493)`, `[[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R1594)`, `[[3]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R1632-R1674)`, `[[4]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R1741-R1760)`, `[[5]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R1890-R1891)`, `[[6]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R1908)`)
- The best training step energy is tracked and logged when a new best validation loss is achieved. (`[[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R1890-R1891)`, `[[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R1908)`)

**Metrics reading pipeline:**

- Updated `run_experiments.py` to include Zeus energy metrics in the metrics list and to read them from the new summary JSON file. This ensures downstream analysis scripts can access the new energy metrics. (`[[1]](diffhunk://#diff-0a54d7401d1b0b1ceef5356bde8f00cd5e2bf0cfd514f0bc7434b2d28fdef869R19)`, `[[2]](diffhunk://#diff-0a54d7401d1b0b1ceef5356bde8f00cd5e2bf0cfd514f0bc7434b2d28fdef869R31)`, `[[3]](diffhunk://#diff-0a54d7401d1b0b1ceef5356bde8f00cd5e2bf0cfd514f0bc7434b2d28fdef869R43-R47)`, `[[4]](diffhunk://#diff-0a54d7401d1b0b1ceef5356bde8f00cd5e2bf0cfd514f0bc7434b2d28fdef869R562-R585)`, `[[5]](diffhunk://#diff-0a54d7401d1b0b1ceef5356bde8f00cd5e2bf0cfd514f0bc7434b2d28fdef869R608-R630)`)