### PR TITLE
Add configurable learned-spline init activation and exploration sweep

### DIFF
--- a/explorations/default_inf_lsa_init_mlp_swiglu.yaml
+++ b/explorations/default_inf_lsa_init_mlp_swiglu.yaml
@@ -1,0 +1,59 @@
+# default_inf_lsa_init_mlp_swiglu.yaml
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Relu2Max
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "relu2max"
+      - "infinite"
+      - "mqa"
+      - "hd_100"
+    mlp_variant: ["mlp", "swiglu"]
+    activation_variant: ["learned_spline"]
+    lsa_init_activation: ["mish", "silu", "gelu", "squared_relu"]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -442,6 +442,7 @@ class GPTConfig:
 
     ## LearnedSplineActivation - lsa
     lsa_num_knots: int = 30
+    lsa_init_activation: str = "gelu"
 
 
     # Linear Alternatives

--- a/plot_view.py
+++ b/plot_view.py
@@ -430,6 +430,23 @@ def plot_multi_bars_trim(                     # NEW
     fig.write_image(f"{safe}.png", scale=2)
     fig.show()
 
+def plot_bars_trim(
+    rows: List[Dict[str, Any]],
+    *,
+    y: str,
+    label_cols: List[str],
+) -> None:
+    """
+    Backward-compatible single-metric Δ-bar helper used by monitor ``z`` hotkey.
+
+    This intentionally mirrors ``plot_bars`` args while delegating to the
+    multi-metric trimmed implementation.
+    """
+    if not label_cols:
+        raise ValueError("Need ≥1 label column for bar chart")
+    plot_multi_bars_trim(rows, y_cols=[y], label_cols=label_cols)
+
+
 # ───────────────────────────── CLI wrapper ──────────────────────────
 
 

--- a/train_args.py
+++ b/train_args.py
@@ -835,6 +835,10 @@ def parse_args():
             "tanh",
             "identity",
         ]
+    lsa_init_activation_variations = [
+            variation for variation in activation_variations
+            if variation != "learned_spline"
+        ]
 
     ## DynamicActivations
     model_group.add_argument("--dact_activation", type=str, default="tanh", choices=activation_variations)
@@ -873,6 +877,13 @@ def parse_args():
 
     ## LearnedSplineActivation - lsa
     model_group.add_argument("--lsa_num_knots", type=int, default=30)
+    model_group.add_argument(
+        "--lsa_init_activation",
+        type=str,
+        default="gelu",
+        choices=lsa_init_activation_variations,
+        help="Activation used to initialize learned_spline knot y-values.",
+    )
 
 
     # Attention Variations

--- a/variations/activation_variations.py
+++ b/variations/activation_variations.py
@@ -173,17 +173,40 @@ class LearnedSplineActivation(nn.Module):
 
     def __init__(self, config, num_knots=10, init_x_range=(-5, 5)):
         super().__init__()
-        self.num_knots = config.lsa_num_knots
+        self.num_knots = getattr(config, "lsa_num_knots", num_knots)
+        self.init_activation_name = getattr(config, "lsa_init_activation", "gelu")
+
+        if self.init_activation_name == "learned_spline":
+            raise ValueError(
+                "lsa_init_activation cannot be 'learned_spline' because it would recurse during initialization."
+            )
+
+        init_activation_cls = activation_dictionary.get(self.init_activation_name)
+        if init_activation_cls is None:
+            raise ValueError(
+                f"Unknown lsa_init_activation '{self.init_activation_name}'. "
+                f"Expected one of: {sorted(activation_dictionary.keys())}"
+            )
 
         # Initialize learnable x_vals and y_vals
-        x_init = torch.linspace(init_x_range[0], init_x_range[1], num_knots)
+        x_init = torch.linspace(init_x_range[0], init_x_range[1], self.num_knots)
+        init_activation = init_activation_cls(config)
 
-        # Create an instance of GELU
-        gelu = nn.GELU()
-        y_init = gelu(x_init)  # Use the GELU instance here
+        with torch.no_grad():
+            if self.init_activation_name == "glu":
+                # GLU halves the last dimension, so feed a 2-channel input and squeeze back.
+                y_init = init_activation(torch.stack((x_init, x_init), dim=-1)).squeeze(-1)
+            else:
+                y_init = init_activation(x_init)
+
+        if y_init.shape != x_init.shape:
+            raise ValueError(
+                f"lsa_init_activation='{self.init_activation_name}' must preserve shape. "
+                f"Got output shape {tuple(y_init.shape)} for input shape {tuple(x_init.shape)}."
+            )
 
         self.x_vals = nn.Parameter(x_init)
-        self.y_vals = nn.Parameter(y_init)
+        self.y_vals = nn.Parameter(y_init.detach().clone())
 
     def forward(self, x):
         # Compute spline coefficients


### PR DESCRIPTION
This pull request introduces support for customizable initialization of the learned spline activation (LSA) function by allowing users to specify the activation function used to initialize the spline's knot y-values. This makes the LSA module more flexible and configurable, and adds related options to configuration files and argument parsing.

**Learned Spline Activation (LSA) Customization:**

* Added a new argument and configuration option, `lsa_init_activation`, to specify the activation function used for initializing the learned spline's knot y-values. This is now available in both `GPTConfig` and as a command-line argument, with validation to prevent recursion and ensure valid choices. [[1]](diffhunk://#diff-114e7747956438292f72cb8316c075c30638fe5c68dab6a7ac466f33639df288R445) [[2]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R880-R886)
* Updated the `LearnedSplineActivation` class in `activation_variations.py` to use the specified `lsa_init_activation` for initializing y-values, including shape checks and error handling for invalid or recursive activations.

**Configuration and Argument Parsing:**

* Added a new YAML configuration file, `default_inf_lsa_init_mlp_swiglu.yaml`, which includes `lsa_init_activation` among other grouped model hyperparameters for exploration.
* Updated argument parsing in `train_args.py` to provide valid choices for `lsa_init_activation`, excluding `learned_spline` itself to avoid recursion. [[1]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R838-R841) [[2]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R880-R886)