### PR TITLE
Add support for huggingface tokenization

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -47,7 +47,9 @@ This file gives coding agents the minimum repository-specific rules needed to co
   new dataset folder describing the dataset, a link to the original source, as
   well the license of the original dataset.`
 - `data/template/...`: `This will have any tokenizer related changes.
-  data/template/tokenizers.py will have tokenizer definitions,
+  data/template/nanogpt_tokenizers.py will have tokenizer definitions
+  (the file is intentionally NOT named tokenizers.py so it does not shadow
+  the third-party HuggingFace tokenizers package on sys.path),
   data/template/prepare.py will be how one calls the tokenizer and selects
   argparse settings, and data/template/tests.py has tests for each of the
   tokenizer definitions. When adding new features to the tokenizer, or new

--- a/data/template/nanogpt_tokenizers.py
+++ b/data/template/nanogpt_tokenizers.py
@@ -1,4 +1,10 @@
-# tokenizers.py
+# nanogpt_tokenizers.py
+#
+# NOTE: this module is deliberately NOT named `tokenizers.py`. An earlier
+# revision was, which shadowed the third-party HuggingFace `tokenizers`
+# package on `sys.path` (because `data/*/prepare.py` are symlinks to
+# `data/template/prepare.py`, so Python's `sys.path[0]` resolves to this
+# directory) and broke `from transformers import AutoTokenizer`.
 import os
 import pickle
 import tempfile
@@ -234,13 +240,15 @@ class TiktokenTokenizer(Tokenizer):
 class HuggingFaceTokenizer(Tokenizer):
     """Wrap any HuggingFace tokenizer via `transformers.AutoTokenizer`.
 
-    Note: we intentionally go through `transformers.AutoTokenizer` instead of
-    importing the `tokenizers` Python package directly, because this file is
-    itself named ``tokenizers.py`` and would shadow the HF package on import.
     `AutoTokenizer` is a unified entry point that transparently loads both
     fast (Rust `tokenizers`-backed) and slow (Python) variants, from either a
     Hub name (e.g. ``"gpt2"``) or a local directory saved via
     ``save_pretrained``.
+
+    This module is intentionally named ``nanogpt_tokenizers.py`` rather than
+    ``tokenizers.py`` so that it cannot shadow the third-party
+    ``tokenizers`` package that ``transformers`` imports internally (via
+    ``from tokenizers import decoders, normalizers, ...``).
     """
 
     def __init__(self, args):

--- a/data/template/prepare.py
+++ b/data/template/prepare.py
@@ -3,7 +3,7 @@ import json
 import os
 import argparse
 import numpy as np
-from tokenizers import (
+from nanogpt_tokenizers import (
     SentencePieceTokenizer,
     TiktokenTokenizer,
     HuggingFaceTokenizer,

--- a/data/template/prepare.py
+++ b/data/template/prepare.py
@@ -6,6 +6,7 @@ import numpy as np
 from tokenizers import (
     SentencePieceTokenizer,
     TiktokenTokenizer,
+    HuggingFaceTokenizer,
     CustomTokenizer,
     ByteTokenizer,
     CharTokenizer,
@@ -31,8 +32,17 @@ def parse_arguments():
 
     # Tokenizer selection and configuration
     parser.add_argument("--method", type=str,
-                       choices=["sentencepiece", "tiktoken", "char", "char_bpe", "custom", "byte", "custom_char_byte_fallback", "json_byte_fallback", "python_programming", "sinewave", "whisper_mel_csv"],
+                       choices=["sentencepiece", "tiktoken", "huggingface", "char", "char_bpe", "custom", "byte", "custom_char_byte_fallback", "json_byte_fallback", "python_programming", "sinewave", "whisper_mel_csv"],
                        default="tiktoken", help="Tokenization method")
+
+    # HuggingFace tokenizer arguments
+    parser.add_argument("--hf_tokenizer_name", type=str, default=None,
+                        help="HuggingFace tokenizer name (Hub id like 'gpt2') or local path "
+                             "(for the huggingface method)")
+    parser.add_argument("--hf_trust_remote_code", action="store_true",
+                        help="Trust remote code when loading a HuggingFace tokenizer")
+    parser.add_argument("--hf_use_fast", action=argparse.BooleanOptionalAction, default=True,
+                        help="Use the fast (Rust-based) HuggingFace tokenizer variant if available")
 
     # Sine wave tokenizer arguments
     parser.add_argument("--sine_period", type=float, default=1.0,
@@ -134,6 +144,9 @@ def main():
             output_dir = os.path.splitext(os.path.basename(args.json_tokens_file))[0]
         elif args.method == "sentencepiece":
             output_dir = f"sp_{args.vocab_size}"
+        elif args.method == "huggingface" and args.hf_tokenizer_name:
+            sanitized = args.hf_tokenizer_name.replace("/", "_").replace(os.sep, "_")
+            output_dir = f"hf_{sanitized}"
         else:
             output_dir = args.method
         if args.output_subdir_suffix:
@@ -168,6 +181,8 @@ def main():
         tokenizer = SentencePieceTokenizer(args, input_files=args.train_input)
     elif args.method == "tiktoken":
         tokenizer = TiktokenTokenizer(args)
+    elif args.method == "huggingface":
+        tokenizer = HuggingFaceTokenizer(args)
     elif args.method == "custom":
         tokenizer = CustomTokenizer(args)
     elif args.method == "byte":
@@ -194,8 +209,8 @@ def main():
         train_ids = tokenizer.tokenize(args.train_input)
     else:
         train_ids = tokenizer.tokenize(train_data)
-    if args.method == "tiktoken":
-        print(f"[tiktoken] Total train tokens: {tokenizer.last_token_count:,}")
+    if args.method in ("tiktoken", "huggingface"):
+        print(f"[{args.method}] Total train tokens: {tokenizer.last_token_count:,}")
     if args.method == "whisper_mel_csv" and args.val_input is None:
         split_point = int(len(train_ids) * args.percentage_train)
         val_ids = train_ids[split_point:]
@@ -209,8 +224,8 @@ def main():
             val_ids = tokenizer.tokenize(args.val_input)
         else:
             val_ids = tokenizer.tokenize(val_data)
-        if args.method == "tiktoken":
-            print(f"[tiktoken] Total val tokens: {tokenizer.last_token_count:,}")
+        if args.method in ("tiktoken", "huggingface"):
+            print(f"[{args.method}] Total val tokens: {tokenizer.last_token_count:,}")
     else:
         val_ids = None
 

--- a/data/template/tests.py
+++ b/data/template/tests.py
@@ -6,7 +6,7 @@ import sys
 import pickle
 import json
 import prepare
-from tokenizers import (
+from nanogpt_tokenizers import (
     SentencePieceTokenizer,
     TiktokenTokenizer,
     HuggingFaceTokenizer,

--- a/data/template/tests.py
+++ b/data/template/tests.py
@@ -9,6 +9,7 @@ import prepare
 from tokenizers import (
     SentencePieceTokenizer,
     TiktokenTokenizer,
+    HuggingFaceTokenizer,
     CustomTokenizer,
     ByteTokenizer,
     CharTokenizer,
@@ -183,6 +184,48 @@ class TestTokenizers(unittest.TestCase):
         console.print(detokenized, style="output")
 
         self.assertEqual(self.sample_text, detokenized)
+
+    def test_huggingface_tokenizer(self):
+        try:
+            import transformers  # noqa: F401
+        except ImportError:
+            self.skipTest("transformers package not installed")
+
+        args = Namespace(
+            hf_tokenizer_name="gpt2",
+            hf_trust_remote_code=False,
+            hf_use_fast=True,
+            meta_output_path="meta.pkl",
+        )
+        try:
+            tokenizer = HuggingFaceTokenizer(args)
+        except Exception as exc:
+            # Offline environments or missing model files should not hard-fail
+            # the whole suite.
+            self.skipTest(f"could not load HF tokenizer 'gpt2': {exc}")
+
+        ids = tokenizer.tokenize(self.sample_text)
+        detokenized = tokenizer.detokenize(ids)
+
+        console.print("[input]Input:[/input]")
+        console.print(self.sample_text, style="input")
+        console.print("[output]Detokenized Output:[/output]")
+        console.print(detokenized, style="output")
+
+        self.assertEqual(self.sample_text, detokenized)
+
+        with open("meta.pkl", "rb") as f:
+            meta = pickle.load(f)
+        self.assertEqual(meta["tokenizer"], "huggingface")
+        self.assertEqual(meta["hf_tokenizer_name"], "gpt2")
+        self.assertGreater(meta["vocab_size"], 0)
+        self.assertIn("stoi", meta)
+        self.assertIn("itos", meta)
+
+        # Clean up the snapshot directory written next to meta.pkl.
+        import shutil
+        if os.path.isdir("hf_tokenizer"):
+            shutil.rmtree("hf_tokenizer", ignore_errors=True)
 
 
     def test_custom_tokenizer(self):

--- a/data/template/tokenizers.py
+++ b/data/template/tokenizers.py
@@ -231,6 +231,109 @@ class TiktokenTokenizer(Tokenizer):
         return ''.join(result)
 
 
+class HuggingFaceTokenizer(Tokenizer):
+    """Wrap any HuggingFace tokenizer via `transformers.AutoTokenizer`.
+
+    Note: we intentionally go through `transformers.AutoTokenizer` instead of
+    importing the `tokenizers` Python package directly, because this file is
+    itself named ``tokenizers.py`` and would shadow the HF package on import.
+    `AutoTokenizer` is a unified entry point that transparently loads both
+    fast (Rust `tokenizers`-backed) and slow (Python) variants, from either a
+    Hub name (e.g. ``"gpt2"``) or a local directory saved via
+    ``save_pretrained``.
+    """
+
+    def __init__(self, args):
+        super().__init__(args)
+        try:
+            from transformers import AutoTokenizer  # lazy import
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise ImportError(
+                "HuggingFaceTokenizer requires the `transformers` package. "
+                "Install with `pip install transformers`."
+            ) from exc
+
+        self.hf_tokenizer_name = getattr(args, "hf_tokenizer_name", None)
+        if not self.hf_tokenizer_name:
+            raise ValueError(
+                "--hf_tokenizer_name must be provided for the huggingface method "
+                "(accepts a Hub id like 'gpt2' or a local path)."
+            )
+
+        trust_remote_code = bool(getattr(args, "hf_trust_remote_code", False))
+        use_fast = getattr(args, "hf_use_fast", True)
+        if use_fast is None:
+            use_fast = True
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.hf_tokenizer_name,
+            trust_remote_code=trust_remote_code,
+            use_fast=bool(use_fast),
+        )
+
+        # Where to cache a local snapshot of the tokenizer so `sample.py` /
+        # `train.py` can reload it even without network access.
+        meta_output_path = getattr(args, "meta_output_path", "meta.pkl")
+        output_dir = os.path.dirname(meta_output_path) or "."
+        self.hf_local_dir = os.path.join(output_dir, "hf_tokenizer")
+        self.last_token_count = 0
+
+    def _build_vocab_maps(self):
+        try:
+            stoi = dict(self.tokenizer.get_vocab())
+        except Exception:
+            stoi = {}
+        itos = {int(v): k for k, v in stoi.items()}
+        return stoi, itos
+
+    def _effective_vocab_size(self):
+        # `len(tokenizer)` includes added/special tokens. Fall back gracefully.
+        try:
+            return len(self.tokenizer)
+        except Exception:
+            return int(getattr(self.tokenizer, "vocab_size", 0))
+
+    def tokenize(self, data):
+        # Encode without special tokens to match the behavior of our other
+        # subword tokenizers (tiktoken/sentencepiece) so that text resumes
+        # cleanly across chunks.
+        ids = self.tokenizer.encode(data, add_special_tokens=False)
+
+        for token_id in ids:
+            self.record_token(token_id)
+
+        stoi, itos = self._build_vocab_maps()
+
+        # Save a local snapshot of the tokenizer next to meta.pkl so it can
+        # be reloaded offline during sampling / training.
+        hf_saved_path = None
+        try:
+            os.makedirs(self.hf_local_dir, exist_ok=True)
+            self.tokenizer.save_pretrained(self.hf_local_dir)
+            hf_saved_path = self.hf_local_dir
+        except Exception as exc:  # pragma: no cover - best effort
+            print(f"[huggingface] Warning: could not save tokenizer snapshot to "
+                  f"{self.hf_local_dir}: {exc}")
+
+        meta = {
+            "vocab_size": self._effective_vocab_size(),
+            "tokenizer": "huggingface",
+            "hf_tokenizer_name": self.hf_tokenizer_name,
+            "hf_tokenizer_path": hf_saved_path,
+            "hf_use_fast": bool(getattr(self.args, "hf_use_fast", True)),
+            "hf_trust_remote_code": bool(getattr(self.args, "hf_trust_remote_code", False)),
+            "stoi": stoi,
+            "itos": itos,
+        }
+        self.finalize_meta(meta)
+
+        self.last_token_count = len(ids)
+        return ids
+
+    def detokenize(self, ids):
+        return self.tokenizer.decode(list(ids), skip_special_tokens=False)
+
+
 class CustomTokenizer(Tokenizer):
     def __init__(self, args):
         super().__init__(args)

--- a/sample.py
+++ b/sample.py
@@ -1161,6 +1161,46 @@ def get_tokenizer_functions(meta):
         decode = lambda l: enc.decode(l)
         return encode, decode
 
+    if meta['tokenizer'] == 'huggingface':
+        try:
+            from transformers import AutoTokenizer
+        except ImportError as exc:
+            raise ImportError(
+                "Loading a 'huggingface' tokenizer from meta.pkl requires the "
+                "`transformers` package. Install with `pip install transformers`."
+            ) from exc
+
+        hf_name = meta.get('hf_tokenizer_name')
+        hf_local_path = meta.get('hf_tokenizer_path')
+        trust_remote_code = bool(meta.get('hf_trust_remote_code', False))
+        use_fast = meta.get('hf_use_fast', True)
+
+        # Prefer the local snapshot written at prepare-time so we work offline.
+        load_target = None
+        if hf_local_path and os.path.isdir(hf_local_path):
+            load_target = hf_local_path
+        elif hf_name:
+            load_target = hf_name
+        else:
+            raise ValueError(
+                "meta.pkl is missing 'hf_tokenizer_name' / 'hf_tokenizer_path' "
+                "for huggingface tokenizer."
+            )
+
+        hf_tok = AutoTokenizer.from_pretrained(
+            load_target,
+            trust_remote_code=trust_remote_code,
+            use_fast=bool(use_fast),
+        )
+
+        def encode(s):
+            return hf_tok.encode(s, add_special_tokens=False)
+
+        def decode(ids):
+            return hf_tok.decode(list(ids), skip_special_tokens=False)
+
+        return encode, decode
+
     if meta['tokenizer'] == 'byte':
         return byte_encode, byte_decode
 


### PR DESCRIPTION
<img width="710" height="356" alt="image" src="https://github.com/user-attachments/assets/8e7e5490-f805-4fdf-8a53-39f6ed39eab8" />
This pull request adds support for HuggingFace tokenizers to the data preparation and testing pipeline, while also renaming the tokenizer implementation file to avoid conflicts with the third-party `tokenizers` package. The main improvements include a new `HuggingFaceTokenizer` class, CLI argument integration, adjustments to output handling, and comprehensive tests for the new feature.

**HuggingFace Tokenizer Integration:**

- Added a `HuggingFaceTokenizer` class to `nanogpt_tokenizers.py`, enabling the use of any HuggingFace tokenizer via `transformers.AutoTokenizer`. This includes handling for offline use by saving a local snapshot of the tokenizer and supporting both "fast" and "slow" variants.
- Updated the CLI in `prepare.py` to support a new `huggingface` method, with additional arguments for specifying the tokenizer name, trust for remote code, and use of the fast variant. Output directories are now named according to the HuggingFace tokenizer used. [[1]](diffhunk://#diff-58b2dc0b265404d36d3448fd9a562773151592db2eb8be9f9554c3f7a89ff9fbL34-R46) [[2]](diffhunk://#diff-58b2dc0b265404d36d3448fd9a562773151592db2eb8be9f9554c3f7a89ff9fbR147-R149)
- Modified the main logic in `prepare.py` to instantiate and use `HuggingFaceTokenizer` when the `huggingface` method is selected, including printing token counts for both tiktoken and huggingface methods. [[1]](diffhunk://#diff-58b2dc0b265404d36d3448fd9a562773151592db2eb8be9f9554c3f7a89ff9fbR184-R185) [[2]](diffhunk://#diff-58b2dc0b265404d36d3448fd9a562773151592db2eb8be9f9554c3f7a89ff9fbL197-R213) [[3]](diffhunk://#diff-58b2dc0b265404d36d3448fd9a562773151592db2eb8be9f9554c3f7a89ff9fbL212-R228)

**File and Import Refactoring:**

- Renamed `tokenizers.py` to `nanogpt_tokenizers.py` to prevent shadowing the third-party `tokenizers` package, and updated all imports accordingly in `prepare.py` and `tests.py`. [[1]](diffhunk://#diff-a841182f8420877b072cab85020900fed36f25f2a1cd9fcdc14b1292c8984cdeL1-R7) [[2]](diffhunk://#diff-58b2dc0b265404d36d3448fd9a562773151592db2eb8be9f9554c3f7a89ff9fbL6-R9) [[3]](diffhunk://#diff-812a42fe8c4ff8527db5b6a53f8a57c4a8b66b42006dc1fd7030060d444c2ce9L9-R12)
- Updated documentation in `Agents.md` to reflect the new filename and explain the rationale behind the renaming.

**Testing and Sample Decoding:**

- Added a comprehensive test for `HuggingFaceTokenizer` to `tests.py`, including checks for correct encoding/decoding, meta information, and cleanup of local snapshots.
- Modified `sample.py` to properly load and use HuggingFace tokenizers based on `meta.pkl`, preferring local snapshots for offline compatibility and supporting both encoding and decoding.