### PR TITLE
Add trimmed gemma270m vocab 2

### DIFF
--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -64,3 +64,83 @@ python huggingface_model/gemma/270M/jl_head_eval.py \
   --annotate_stats true \
   --output_dir jl_eval_outputs
 ```
+
+## Latin/punctuation/other manual router (OPUS-100 en-es)
+
+`latin_punct_router_eval.py` builds three token groups from the Gemma vocabulary:
+
+1. Tokens whose decoded UTF text contains at least one Latin-script codepoint.
+2. Tokens that are punctuation/layout-only (Unicode punctuation plus common English/Spanish punctuation symbols, and whitespace/layout tokens like tabs/newlines).
+3. Everything else (including byte/special tokens).
+
+It then:
+
+- prints a raw-count and percentage table for all three groups,
+- computes one average LM-head vector per group,
+- L2-normalizes those three vectors into unit routing prototypes,
+- routes each decoding step by dot product of final-layer hidden state with the 3 prototypes,
+- and performs next-token scoring only within the routed token subset.
+- reports side-by-side teacher-forced token accuracy with and without routing.
+- prints validation-set example translations before (full LM head) and after (routed LM head).
+- uses a fixed 3-shot English→Spanish prompt template before each evaluated/generated example.
+- can optionally freeze the model and train 3 route scalars (initialized to 1.0) for the 3 prototypes on OPUS-100 `en-es`.
+
+Example:
+
+```bash
+python huggingface_model/gemma/270M/latin_punct_router_eval.py \
+  --model_name google/gemma-3-270m-it \
+  --split "train[:1%]" \
+  --max_samples 100 \
+  --max_target_tokens 64 \
+  --example_split "validation[:20]" \
+  --num_examples 3 \
+  --example_max_new_tokens 64 \
+  --route_mode three_way \
+  --byte_fallback \
+  --device cuda
+```
+
+Notes:
+
+- Evaluation is teacher-forced next-token prediction over OPUS-100 `en-es` translation targets.
+- The script uses cosine-style scoring (unit-normalized hidden state and LM-head rows) for both routing and routed token selection.
+
+
+Alternative 2-way routing (latin+punct vs other):
+
+```bash
+python huggingface_model/gemma/270M/latin_punct_router_eval.py \
+  --route_mode latin_punct_vs_other \
+  --byte_fallback
+```
+
+Use `--no-byte_fallback` to disable unioning byte tokens into non-`other` candidate sets.
+
+Alternative 2-way routing that never selects `other` (latin vs punct only):
+
+```bash
+python huggingface_model/gemma/270M/latin_punct_router_eval.py \
+  --route_mode latin_vs_punct_only \
+  --byte_fallback
+```
+
+Single-bucket latin+punct mode (no routing decision; only score in latin+punct section):
+
+```bash
+python huggingface_model/gemma/270M/latin_punct_router_eval.py \
+  --route_mode latin_punct_only \
+  --byte_fallback
+```
+
+Train only the three route scalars (model frozen) for `three_way` mode:
+
+```bash
+python huggingface_model/gemma/270M/latin_punct_router_eval.py \
+  --route_mode three_way \
+  --train_route_scales \
+  --train_split "train[:1%]" \
+  --train_max_samples 100 \
+  --train_epochs 1 \
+  --train_lr 1e-2
+```

--- a/huggingface_model/gemma/270M/latin_punct_router_eval.py
+++ b/huggingface_model/gemma/270M/latin_punct_router_eval.py
@@ -131,10 +131,11 @@ def _router_scores(
     ordered_names: Sequence[str],
     route_scales: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    mat = torch.stack([prototypes[name] for name in ordered_names], dim=0)
+    mat = torch.stack([prototypes[name] for name in ordered_names], dim=0).to(dtype=torch.float32)
     if route_scales is not None:
-        mat = mat * route_scales.unsqueeze(-1)
-    return torch.matmul(hidden_last, mat.T)
+        mat = mat * route_scales.to(dtype=torch.float32).unsqueeze(-1)
+    hidden = hidden_last.to(dtype=torch.float32)
+    return torch.matmul(hidden, mat.T)
 
 
 def _build_route_groups(base_groups: Dict[str, Sequence[int]], route_mode: str) -> Dict[str, List[int]]:

--- a/huggingface_model/gemma/270M/latin_punct_router_eval.py
+++ b/huggingface_model/gemma/270M/latin_punct_router_eval.py
@@ -1,0 +1,572 @@
+"""Build a manual LM-head router for Gemma 270M and evaluate on OPUS-100 en-es.
+
+Base groups:
+1) latin: tokens containing Latin-script characters.
+2) punct: punctuation-only tokens (Unicode punctuation + common ES/EN punctuation).
+3) other: everything else (including byte/special tokens).
+
+Routing modes:
+- three_way: latin vs punct vs other.
+- latin_punct_vs_other: (latin U punct) vs other.
+- latin_vs_punct_only: latin vs punct (never routes to other).
+- latin_punct_only: only score within (latin U punct), no routing decision.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Sequence
+
+import torch
+import torch.nn.functional as F
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+COMMON_ES_EN_PUNCT = {
+    ".", ",", "!", "?", ":", ";", "'", '"', "-", "—", "–", "(", ")", "[", "]", "{", "}",
+    "¡", "¿", "…", "«", "»", "‹", "›", "`", "´", "/", "\\", "|", "@", "#", "&", "*", "%",
+    "_",
+}
+BYTE_TOKEN_RE = re.compile(r"^<0x[0-9A-Fa-f]{2}>$")
+FEW_SHOT_EXAMPLES = [
+    ("Good morning.", "Buenos días."),
+    ("Where is the train station?", "¿Dónde está la estación de tren?"),
+    ("I would like a glass of water.", "Me gustaría un vaso de agua."),
+]
+
+
+@dataclass
+class EvalStats:
+    total_target_tokens: int = 0
+    top1_correct_routed: int = 0
+    top1_correct_full: int = 0
+    route_counts: Dict[str, int] = field(default_factory=lambda: defaultdict(int))
+
+
+def _normalize_rows(x: torch.Tensor) -> torch.Tensor:
+    return torch.nn.functional.normalize(x, dim=-1)
+
+
+def _is_latin_char(ch: str) -> bool:
+    if not ch:
+        return False
+    try:
+        name = unicodedata.name(ch)
+    except ValueError:
+        return False
+    return "LATIN" in name
+
+
+def _is_common_punctuation(ch: str) -> bool:
+    if ch in COMMON_ES_EN_PUNCT:
+        return True
+    return unicodedata.category(ch).startswith("P")
+
+
+def _is_punctuation_only_text(text: str) -> bool:
+    if not text:
+        return False
+    return all(c.isspace() or _is_common_punctuation(c) for c in text)
+
+
+def _build_token_groups(tokenizer: AutoTokenizer, vocab_size: int) -> Dict[str, List[int]]:
+    groups = {"latin": [], "punct": [], "other": [], "byte": []}
+    raw_tokens = tokenizer.convert_ids_to_tokens(list(range(vocab_size)))
+
+    for token_id, raw_token in enumerate(raw_tokens):
+        decoded = tokenizer.decode([token_id], skip_special_tokens=False)
+        if BYTE_TOKEN_RE.match(raw_token or ""):
+            groups["byte"].append(token_id)
+        if any(_is_latin_char(c) for c in decoded):
+            groups["latin"].append(token_id)
+        elif _is_punctuation_only_text(decoded):
+            groups["punct"].append(token_id)
+        else:
+            groups["other"].append(token_id)
+    return groups
+
+
+def _print_group_table(groups: Dict[str, Sequence[int]], vocab_size: int) -> None:
+    headers = ["Group", "Raw token count", "% of vocab"]
+    rows = []
+    for key in ("latin", "punct", "other", "byte (subset of other)"):
+        src_key = "byte" if key.startswith("byte") else key
+        count = len(groups[src_key])
+        pct = 100.0 * count / vocab_size
+        rows.append((key, count, f"{pct:.2f}%"))
+
+    widths = [max(len(str(h)), max(len(str(r[i])) for r in rows)) for i, h in enumerate(headers)]
+    line = "+" + "+".join("-" * (w + 2) for w in widths) + "+"
+    print("\nToken routing groups for vocabulary")
+    print(line)
+    print("| " + " | ".join(str(h).ljust(widths[i]) for i, h in enumerate(headers)) + " |")
+    print(line)
+    for row in rows:
+        print("| " + " | ".join(str(row[i]).ljust(widths[i]) for i in range(len(headers))) + " |")
+    print(line)
+
+
+def _compute_group_prototypes(
+    lm_head_weight: torch.Tensor,
+    route_groups: Dict[str, Sequence[int]],
+    device: torch.device,
+) -> Dict[str, torch.Tensor]:
+    out = {}
+    for key, id_list in route_groups.items():
+        if not id_list:
+            raise ValueError(f"Routing group '{key}' is empty; cannot compute average prototype.")
+        ids = torch.tensor(id_list, dtype=torch.long, device=lm_head_weight.device)
+        avg = lm_head_weight.index_select(0, ids).mean(dim=0)
+        out[key] = torch.nn.functional.normalize(avg, dim=0).to(device)
+    return out
+
+
+def _router_scores(
+    hidden_last: torch.Tensor,
+    prototypes: Dict[str, torch.Tensor],
+    ordered_names: Sequence[str],
+    route_scales: torch.Tensor | None = None,
+) -> torch.Tensor:
+    mat = torch.stack([prototypes[name] for name in ordered_names], dim=0)
+    if route_scales is not None:
+        mat = mat * route_scales.unsqueeze(-1)
+    return torch.matmul(hidden_last, mat.T)
+
+
+def _build_route_groups(base_groups: Dict[str, Sequence[int]], route_mode: str) -> Dict[str, List[int]]:
+    if route_mode == "three_way":
+        return {
+            "latin": list(base_groups["latin"]),
+            "punct": list(base_groups["punct"]),
+            "other": list(base_groups["other"]),
+        }
+    if route_mode == "latin_punct_vs_other":
+        latin_punct = sorted(set(base_groups["latin"]) | set(base_groups["punct"]))
+        return {
+            "latin_punct": latin_punct,
+            "other": list(base_groups["other"]),
+        }
+    if route_mode == "latin_vs_punct_only":
+        return {
+            "latin": list(base_groups["latin"]),
+            "punct": list(base_groups["punct"]),
+        }
+    if route_mode == "latin_punct_only":
+        latin_punct = sorted(set(base_groups["latin"]) | set(base_groups["punct"]))
+        return {
+            "latin_punct_only": latin_punct,
+        }
+    raise ValueError(f"Unknown route_mode: {route_mode}")
+
+
+def _build_3shot_prompt(english_text: str) -> str:
+    lines = [
+        "Translate English to Spanish.",
+        "",
+    ]
+    for src, tgt in FEW_SHOT_EXAMPLES:
+        lines.append(f"English: {src}")
+        lines.append(f"Spanish: {tgt}")
+        lines.append("")
+    lines.append(f"English: {english_text}")
+    lines.append("Spanish:")
+    return "\n".join(lines)
+
+
+def _evaluate_router(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    route_groups: Dict[str, Sequence[int]],
+    byte_ids: Sequence[int],
+    prototypes: Dict[str, torch.Tensor],
+    split: str,
+    max_samples: int,
+    max_target_tokens: int,
+    device: torch.device,
+    byte_fallback: bool,
+    route_scales: torch.Tensor | None = None,
+) -> EvalStats:
+    stats = EvalStats()
+    ds = load_dataset("Helsinki-NLP/opus-100", "en-es", split=split)
+    lm_head_weight = _normalize_rows(model.lm_head.weight.detach())
+
+    route_names = list(route_groups.keys())
+    byte_set = set(byte_ids)
+    group_ids = {
+        k: torch.tensor(v, dtype=torch.long, device=device)
+        for k, v in route_groups.items()
+    }
+
+    for ex in ds.select(range(min(max_samples, len(ds)))):
+        en = ex["translation"]["en"]
+        es = ex["translation"]["es"]
+        prompt = _build_3shot_prompt(en)
+
+        prompt_ids = tokenizer(prompt, add_special_tokens=True, return_tensors="pt").input_ids.to(device)
+        target_ids = tokenizer(es, add_special_tokens=False, return_tensors="pt").input_ids.to(device)
+        if target_ids.numel() == 0:
+            continue
+
+        steps = min(max_target_tokens, target_ids.size(1))
+        running = prompt_ids
+
+        for idx in range(steps):
+            with torch.no_grad():
+                out = model(running, output_hidden_states=True, use_cache=False)
+            hidden_last = out.hidden_states[-1][:, -1, :]  # post-final layernorm state
+            if len(route_names) == 1:
+                chosen = route_names[0]
+            else:
+                route = _router_scores(hidden_last, prototypes, route_names, route_scales).argmax(dim=-1).item()
+                chosen = route_names[route]
+            stats.route_counts[chosen] += 1
+
+            candidate_ids_list = list(route_groups[chosen])
+            if byte_fallback and chosen != "other":
+                candidate_ids_list = sorted(set(candidate_ids_list) | byte_set)
+            if not candidate_ids_list:
+                candidate_ids_list = list(byte_set)
+            candidate_ids = torch.tensor(candidate_ids_list, dtype=torch.long, device=device)
+
+            candidate_weight = lm_head_weight.index_select(0, candidate_ids)
+            logits = torch.matmul(torch.nn.functional.normalize(hidden_last, dim=-1), candidate_weight.T)
+            pred_local = torch.argmax(logits, dim=-1)
+            pred_id = candidate_ids[pred_local].item()
+            full_logits = torch.matmul(torch.nn.functional.normalize(hidden_last, dim=-1), lm_head_weight.T)
+            pred_id_full = torch.argmax(full_logits, dim=-1).item()
+            gold_id = target_ids[0, idx].item()
+
+            stats.total_target_tokens += 1
+            if pred_id == gold_id:
+                stats.top1_correct_routed += 1
+            if pred_id_full == gold_id:
+                stats.top1_correct_full += 1
+
+            next_gold = target_ids[:, idx : idx + 1]
+            running = torch.cat([running, next_gold], dim=1)
+
+    return stats
+
+
+def _next_token_id(
+    hidden_last: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    route_names: Sequence[str],
+    route_groups: Dict[str, Sequence[int]],
+    prototypes: Dict[str, torch.Tensor],
+    byte_set: set[int],
+    byte_fallback: bool,
+    routed: bool,
+    device: torch.device,
+    route_scales: torch.Tensor | None = None,
+) -> int:
+    hidden_norm = torch.nn.functional.normalize(hidden_last, dim=-1)
+    if not routed:
+        logits_full = torch.matmul(hidden_norm, lm_head_weight.T)
+        return torch.argmax(logits_full, dim=-1).item()
+
+    if len(route_names) == 1:
+        chosen = route_names[0]
+    else:
+        route = _router_scores(hidden_last, prototypes, route_names, route_scales).argmax(dim=-1).item()
+        chosen = route_names[route]
+    candidate_ids_list = list(route_groups[chosen])
+    if byte_fallback and chosen != "other":
+        candidate_ids_list = sorted(set(candidate_ids_list) | byte_set)
+    if not candidate_ids_list:
+        candidate_ids_list = list(byte_set)
+
+    candidate_ids = torch.tensor(candidate_ids_list, dtype=torch.long, device=device)
+    candidate_weight = lm_head_weight.index_select(0, candidate_ids)
+    logits = torch.matmul(hidden_norm, candidate_weight.T)
+    pred_local = torch.argmax(logits, dim=-1)
+    return candidate_ids[pred_local].item()
+
+
+def _generate_translation(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    english_text: str,
+    route_groups: Dict[str, Sequence[int]],
+    prototypes: Dict[str, torch.Tensor],
+    byte_ids: Sequence[int],
+    max_new_tokens: int,
+    routed: bool,
+    byte_fallback: bool,
+    device: torch.device,
+    route_scales: torch.Tensor | None = None,
+) -> str:
+    prompt = _build_3shot_prompt(english_text)
+    running = tokenizer(prompt, add_special_tokens=True, return_tensors="pt").input_ids.to(device)
+
+    route_names = list(route_groups.keys())
+    byte_set = set(byte_ids)
+    lm_head_weight = _normalize_rows(model.lm_head.weight.detach())
+    eos = tokenizer.eos_token_id
+
+    for _ in range(max_new_tokens):
+        with torch.no_grad():
+            out = model(running, output_hidden_states=True, use_cache=False)
+        hidden_last = out.hidden_states[-1][:, -1, :]
+        next_id = _next_token_id(
+            hidden_last=hidden_last,
+            lm_head_weight=lm_head_weight,
+            route_names=route_names,
+            route_groups=route_groups,
+            prototypes=prototypes,
+            byte_set=byte_set,
+            byte_fallback=byte_fallback,
+            routed=routed,
+            device=device,
+            route_scales=route_scales,
+        )
+        next_token = torch.tensor([[next_id]], dtype=torch.long, device=device)
+        running = torch.cat([running, next_token], dim=1)
+        if eos is not None and next_id == eos:
+            break
+
+    full_text = tokenizer.decode(running[0], skip_special_tokens=True)
+    if "Spanish:" in full_text:
+        return full_text.split("Spanish:", 1)[1].strip()
+    return full_text.strip()
+
+
+def _print_validation_examples(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    route_groups: Dict[str, Sequence[int]],
+    prototypes: Dict[str, torch.Tensor],
+    byte_ids: Sequence[int],
+    example_split: str,
+    num_examples: int,
+    max_new_tokens: int,
+    byte_fallback: bool,
+    device: torch.device,
+    route_scales: torch.Tensor | None = None,
+) -> None:
+    if num_examples <= 0:
+        return
+    ds = load_dataset("Helsinki-NLP/opus-100", "en-es", split=example_split)
+    count = min(num_examples, len(ds))
+
+    print("\nValidation examples (before=full LM head, after=routed LM head)")
+    for idx, ex in enumerate(ds.select(range(count)), start=1):
+        en = ex["translation"]["en"]
+        es_ref = ex["translation"]["es"]
+        pred_full = _generate_translation(
+            model=model,
+            tokenizer=tokenizer,
+            english_text=en,
+            route_groups=route_groups,
+            prototypes=prototypes,
+            byte_ids=byte_ids,
+            max_new_tokens=max_new_tokens,
+            routed=False,
+            byte_fallback=byte_fallback,
+            device=device,
+            route_scales=route_scales,
+        )
+        pred_routed = _generate_translation(
+            model=model,
+            tokenizer=tokenizer,
+            english_text=en,
+            route_groups=route_groups,
+            prototypes=prototypes,
+            byte_ids=byte_ids,
+            max_new_tokens=max_new_tokens,
+            routed=True,
+            byte_fallback=byte_fallback,
+            device=device,
+            route_scales=route_scales,
+        )
+        print(f"\nExample {idx}")
+        print(f"EN: {en}")
+        print(f"REF: {es_ref}")
+        print(f"Before (full): {pred_full}")
+        print(f"After  (routed): {pred_routed}")
+
+
+def _train_route_scales(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    prototypes: Dict[str, torch.Tensor],
+    route_groups: Dict[str, Sequence[int]],
+    split: str,
+    max_samples: int,
+    max_target_tokens: int,
+    epochs: int,
+    lr: float,
+    device: torch.device,
+) -> torch.Tensor:
+    route_names = list(route_groups.keys())
+    if route_names != ["latin", "punct", "other"]:
+        raise ValueError("Scalar training currently supports only --route_mode three_way.")
+
+    for param in model.parameters():
+        param.requires_grad = False
+    model.eval()
+
+    token_to_group = torch.full((tokenizer.vocab_size,), fill_value=2, dtype=torch.long, device=device)
+    token_to_group[torch.tensor(route_groups["latin"], dtype=torch.long, device=device)] = 0
+    token_to_group[torch.tensor(route_groups["punct"], dtype=torch.long, device=device)] = 1
+    token_to_group[torch.tensor(route_groups["other"], dtype=torch.long, device=device)] = 2
+
+    scales = torch.nn.Parameter(torch.ones(len(route_names), device=device))
+    optimizer = torch.optim.Adam([scales], lr=lr)
+    ds = load_dataset("Helsinki-NLP/opus-100", "en-es", split=split)
+
+    print("\nTraining route scales with frozen model weights")
+    print(f"- init scales: {[round(x, 4) for x in scales.detach().cpu().tolist()]}")
+    for epoch in range(epochs):
+        total_loss = 0.0
+        total_steps = 0
+        for ex in ds.select(range(min(max_samples, len(ds)))):
+            en = ex["translation"]["en"]
+            es = ex["translation"]["es"]
+            prompt = _build_3shot_prompt(en)
+
+            prompt_ids = tokenizer(prompt, add_special_tokens=True, return_tensors="pt").input_ids.to(device)
+            target_ids = tokenizer(es, add_special_tokens=False, return_tensors="pt").input_ids.to(device)
+            if target_ids.numel() == 0:
+                continue
+            steps = min(max_target_tokens, target_ids.size(1))
+            running = prompt_ids
+
+            for idx in range(steps):
+                with torch.no_grad():
+                    out = model(running, output_hidden_states=True, use_cache=False)
+                hidden_last = out.hidden_states[-1][:, -1, :]
+                route_logits = _router_scores(hidden_last, prototypes, route_names, scales)
+                gold_id = target_ids[0, idx]
+                target_group = token_to_group[gold_id].unsqueeze(0)
+                loss = F.cross_entropy(route_logits, target_group)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+                total_loss += loss.item()
+                total_steps += 1
+                running = torch.cat([running, target_ids[:, idx : idx + 1]], dim=1)
+
+        avg_loss = total_loss / max(1, total_steps)
+        print(
+            f"- epoch {epoch + 1}/{epochs}: avg_route_ce={avg_loss:.4f}, "
+            f"scales={[round(x, 4) for x in scales.detach().cpu().tolist()]}"
+        )
+    return scales.detach()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manual Gemma 270M token router eval (OPUS-100 en-es).")
+    parser.add_argument("--model_name", type=str, default="google/gemma-3-270m-it")
+    parser.add_argument("--split", type=str, default="train[:1%]")
+    parser.add_argument("--max_samples", type=int, default=100)
+    parser.add_argument("--max_target_tokens", type=int, default=64)
+    parser.add_argument(
+        "--route_mode",
+        type=str,
+        default="three_way",
+        choices=["three_way", "latin_punct_vs_other", "latin_vs_punct_only", "latin_punct_only"],
+        help=(
+            "Routing mode: 3-way (latin/punct/other), 2-way ((latin+punct)/other), "
+            "latin vs punct only (never route to other), or latin+punct only (no routing)."
+        ),
+    )
+    parser.add_argument(
+        "--byte_fallback",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Include byte tokens in non-other candidate sets as fallback.",
+    )
+    parser.add_argument("--example_split", type=str, default="validation[:20]")
+    parser.add_argument("--num_examples", type=int, default=3)
+    parser.add_argument("--example_max_new_tokens", type=int, default=64)
+    parser.add_argument("--train_route_scales", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--train_split", type=str, default="train[:1%]")
+    parser.add_argument("--train_max_samples", type=int, default=100)
+    parser.add_argument("--train_max_target_tokens", type=int, default=64)
+    parser.add_argument("--train_epochs", type=int, default=1)
+    parser.add_argument("--train_lr", type=float, default=1e-2)
+    parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    model = AutoModelForCausalLM.from_pretrained(args.model_name, attn_implementation="eager")
+    model.to(device)
+    model.eval()
+
+    vocab_size = tokenizer.vocab_size
+    base_groups = _build_token_groups(tokenizer, vocab_size)
+    _print_group_table(base_groups, vocab_size)
+
+    route_groups = _build_route_groups(base_groups, args.route_mode)
+    prototypes = _compute_group_prototypes(model.lm_head.weight.detach(), route_groups, device)
+    learned_scales = None
+    if args.train_route_scales:
+        learned_scales = _train_route_scales(
+            model=model,
+            tokenizer=tokenizer,
+            prototypes=prototypes,
+            route_groups=route_groups,
+            split=args.train_split,
+            max_samples=args.train_max_samples,
+            max_target_tokens=args.train_max_target_tokens,
+            epochs=args.train_epochs,
+            lr=args.train_lr,
+            device=device,
+        )
+    stats = _evaluate_router(
+        model=model,
+        tokenizer=tokenizer,
+        route_groups=route_groups,
+        byte_ids=base_groups["byte"],
+        prototypes=prototypes,
+        split=args.split,
+        max_samples=args.max_samples,
+        max_target_tokens=args.max_target_tokens,
+        device=device,
+        byte_fallback=args.byte_fallback,
+        route_scales=learned_scales,
+    )
+
+    acc_routed = 100.0 * stats.top1_correct_routed / max(1, stats.total_target_tokens)
+    acc_full = 100.0 * stats.top1_correct_full / max(1, stats.total_target_tokens)
+    print("\nRouter evaluation (teacher-forced next-token prediction)")
+    print(f"- Routing mode: {args.route_mode}")
+    print(f"- Byte fallback: {args.byte_fallback}")
+    print(
+        "- Route scales: {}".format(
+            [round(x, 4) for x in (learned_scales.detach().cpu().tolist() if learned_scales is not None else [1.0] * len(route_groups))]
+        )
+    )
+    print(f"- Evaluated tokens: {stats.total_target_tokens}")
+    print(f"- Top-1 accuracy without routing (full LM head): {acc_full:.2f}%")
+    print(f"- Top-1 accuracy with routing: {acc_routed:.2f}%")
+    route_total = max(1, sum(stats.route_counts.values()))
+    route_summary = " ".join(
+        f"{name}={100.0 * count / route_total:.2f}%" for name, count in stats.route_counts.items()
+    )
+    print(f"- Route distribution: {route_summary}")
+
+    _print_validation_examples(
+        model=model,
+        tokenizer=tokenizer,
+        route_groups=route_groups,
+        prototypes=prototypes,
+        byte_ids=base_groups["byte"],
+        example_split=args.example_split,
+        num_examples=args.num_examples,
+        max_new_tokens=args.example_max_new_tokens,
+        byte_fallback=args.byte_fallback,
+        device=device,
+        route_scales=learned_scales,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface_model/gemma/270M/trim_demo.sh
+++ b/huggingface_model/gemma/270M/trim_demo.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+python latin_punct_router_eval.py \
+  --model_name google/gemma-3-270m-it \
+  --split "train[:1%]" \
+  --max_samples 100 \
+  --max_target_tokens 64 \
+  --example_split "validation[:20]" \
+  --num_examples 3 \
+  --example_max_new_tokens 64 \
+  --route_mode latin_punct_only \
+  --byte_fallback \
+  --device cuda


### PR DESCRIPTION
This pull request introduces a new evaluation script and updates the documentation for evaluating routing strategies on the Gemma 270M model, specifically focusing on Latin, punctuation, and other token groups for English-Spanish translation. It also adds a shell script to demonstrate running the evaluation. The changes provide both detailed instructions and ready-to-use commands for various routing modes.

**New evaluation features and documentation:**

* Added a comprehensive section to `README.md` describing the new `latin_punct_router_eval.py` script, which evaluates routing strategies by grouping tokens into Latin, punctuation, and other categories, and provides example commands for different routing modes and training route scalars.

**Demo and usability improvements:**

* Added a `trim_demo.sh` shell script to run the evaluation with the `latin_punct_only` routing mode, making it easier to quickly test the new evaluation script.