### PR TITLE
Add trimmed gemma270m vocab 3

### DIFF
--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -82,6 +82,7 @@ It then:
 - and performs next-token scoring only within the routed token subset.
 - reports side-by-side teacher-forced token accuracy with and without routing.
 - prints validation-set example translations before (full LM head) and after (routed LM head).
+- color-highlights the actually generated continuation segment (excluding the fixed multi-shot prompt context).
 - uses a fixed 3-shot English→Spanish prompt template before each evaluated/generated example.
 - can optionally freeze the model and train 3 route scalars (initialized to 1.0) for the 3 prototypes on OPUS-100 `en-es`.
 
@@ -153,3 +154,5 @@ python huggingface_model/gemma/270M/latin_punct_router_eval.py \
   --route_mode three_way \
   --example_max_new_tokens 64
 ```
+
+In chat mode, user input is color-highlighted and generated continuations are also highlighted in the printed full outputs.

--- a/huggingface_model/gemma/270M/README.md
+++ b/huggingface_model/gemma/270M/README.md
@@ -144,3 +144,12 @@ python huggingface_model/gemma/270M/latin_punct_router_eval.py \
   --train_epochs 1 \
   --train_lr 1e-2
 ```
+
+Interactive chat mode (type your own English sentence and compare full vs routed translation):
+
+```bash
+python huggingface_model/gemma/270M/latin_punct_router_eval.py \
+  --chat_mode \
+  --route_mode three_way \
+  --example_max_new_tokens 64
+```

--- a/huggingface_model/gemma/270M/latin_punct_router_eval.py
+++ b/huggingface_model/gemma/270M/latin_punct_router_eval.py
@@ -391,6 +391,59 @@ def _print_validation_examples(
         print(f"After  (routed): {pred_routed}")
 
 
+def _run_chat_mode(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    route_groups: Dict[str, Sequence[int]],
+    prototypes: Dict[str, torch.Tensor],
+    byte_ids: Sequence[int],
+    example_max_new_tokens: int,
+    byte_fallback: bool,
+    device: torch.device,
+    route_scales: torch.Tensor | None = None,
+) -> None:
+    print("\nChat mode: enter English text and get Spanish translations.")
+    print("Type 'exit' or 'quit' to stop.")
+    while True:
+        try:
+            user_text = input("\nEN> ").strip()
+        except EOFError:
+            break
+        if not user_text:
+            continue
+        if user_text.lower() in {"exit", "quit"}:
+            break
+
+        pred_full = _generate_translation(
+            model=model,
+            tokenizer=tokenizer,
+            english_text=user_text,
+            route_groups=route_groups,
+            prototypes=prototypes,
+            byte_ids=byte_ids,
+            max_new_tokens=example_max_new_tokens,
+            routed=False,
+            byte_fallback=byte_fallback,
+            device=device,
+            route_scales=route_scales,
+        )
+        pred_routed = _generate_translation(
+            model=model,
+            tokenizer=tokenizer,
+            english_text=user_text,
+            route_groups=route_groups,
+            prototypes=prototypes,
+            byte_ids=byte_ids,
+            max_new_tokens=example_max_new_tokens,
+            routed=True,
+            byte_fallback=byte_fallback,
+            device=device,
+            route_scales=route_scales,
+        )
+        print(f"ES (full):   {pred_full}")
+        print(f"ES (routed): {pred_routed}")
+
+
 def _train_route_scales(
     model: AutoModelForCausalLM,
     tokenizer: AutoTokenizer,
@@ -486,6 +539,7 @@ def main() -> None:
     parser.add_argument("--example_split", type=str, default="validation[:20]")
     parser.add_argument("--num_examples", type=int, default=3)
     parser.add_argument("--example_max_new_tokens", type=int, default=64)
+    parser.add_argument("--chat_mode", action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument("--train_route_scales", action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument("--train_split", type=str, default="train[:1%]")
     parser.add_argument("--train_max_samples", type=int, default=100)
@@ -567,6 +621,18 @@ def main() -> None:
         device=device,
         route_scales=learned_scales,
     )
+    if args.chat_mode:
+        _run_chat_mode(
+            model=model,
+            tokenizer=tokenizer,
+            route_groups=route_groups,
+            prototypes=prototypes,
+            byte_ids=base_groups["byte"],
+            example_max_new_tokens=args.example_max_new_tokens,
+            byte_fallback=args.byte_fallback,
+            device=device,
+            route_scales=learned_scales,
+        )
 
 
 if __name__ == "__main__":

--- a/huggingface_model/gemma/270M/latin_punct_router_eval.py
+++ b/huggingface_model/gemma/270M/latin_punct_router_eval.py
@@ -37,6 +37,9 @@ FEW_SHOT_EXAMPLES = [
     ("Where is the train station?", "¿Dónde está la estación de tren?"),
     ("I would like a glass of water.", "Me gustaría un vaso de agua."),
 ]
+ANSI_RESET = "\033[0m"
+ANSI_GEN = "\033[92m"
+ANSI_USER = "\033[96m"
 
 
 @dataclass
@@ -288,6 +291,12 @@ def _next_token_id(
     return candidate_ids[pred_local].item()
 
 
+def _highlight_generated(full_text: str, prompt: str, color: str = ANSI_GEN) -> str:
+    if full_text.startswith(prompt):
+        return f"{prompt}{color}{full_text[len(prompt):]}{ANSI_RESET}"
+    return f"{color}{full_text}{ANSI_RESET}"
+
+
 def _generate_translation(
     model: AutoModelForCausalLM,
     tokenizer: AutoTokenizer,
@@ -300,7 +309,7 @@ def _generate_translation(
     byte_fallback: bool,
     device: torch.device,
     route_scales: torch.Tensor | None = None,
-) -> str:
+) -> tuple[str, str]:
     prompt = _build_3shot_prompt(english_text)
     running = tokenizer(prompt, add_special_tokens=True, return_tensors="pt").input_ids.to(device)
 
@@ -332,8 +341,10 @@ def _generate_translation(
 
     full_text = tokenizer.decode(running[0], skip_special_tokens=True)
     if "Spanish:" in full_text:
-        return full_text.split("Spanish:", 1)[1].strip()
-    return full_text.strip()
+        generated = full_text.split("Spanish:", 1)[1].strip()
+    else:
+        generated = full_text.strip()
+    return generated, _highlight_generated(full_text, prompt)
 
 
 def _print_validation_examples(
@@ -358,7 +369,7 @@ def _print_validation_examples(
     for idx, ex in enumerate(ds.select(range(count)), start=1):
         en = ex["translation"]["en"]
         es_ref = ex["translation"]["es"]
-        pred_full = _generate_translation(
+        pred_full, pred_full_colored = _generate_translation(
             model=model,
             tokenizer=tokenizer,
             english_text=en,
@@ -371,7 +382,7 @@ def _print_validation_examples(
             device=device,
             route_scales=route_scales,
         )
-        pred_routed = _generate_translation(
+        pred_routed, pred_routed_colored = _generate_translation(
             model=model,
             tokenizer=tokenizer,
             english_text=en,
@@ -389,6 +400,8 @@ def _print_validation_examples(
         print(f"REF: {es_ref}")
         print(f"Before (full): {pred_full}")
         print(f"After  (routed): {pred_routed}")
+        print(f"Before (full, generated highlighted): {pred_full_colored}")
+        print(f"After  (routed, generated highlighted): {pred_routed_colored}")
 
 
 def _run_chat_mode(
@@ -406,7 +419,7 @@ def _run_chat_mode(
     print("Type 'exit' or 'quit' to stop.")
     while True:
         try:
-            user_text = input("\nEN> ").strip()
+            user_text = input(f"\n{ANSI_USER}EN>{ANSI_RESET} ").strip()
         except EOFError:
             break
         if not user_text:
@@ -414,7 +427,7 @@ def _run_chat_mode(
         if user_text.lower() in {"exit", "quit"}:
             break
 
-        pred_full = _generate_translation(
+        pred_full, pred_full_colored = _generate_translation(
             model=model,
             tokenizer=tokenizer,
             english_text=user_text,
@@ -427,7 +440,7 @@ def _run_chat_mode(
             device=device,
             route_scales=route_scales,
         )
-        pred_routed = _generate_translation(
+        pred_routed, pred_routed_colored = _generate_translation(
             model=model,
             tokenizer=tokenizer,
             english_text=user_text,
@@ -440,8 +453,11 @@ def _run_chat_mode(
             device=device,
             route_scales=route_scales,
         )
+        print(f"{ANSI_USER}EN input:{ANSI_RESET} {ANSI_USER}{user_text}{ANSI_RESET}")
         print(f"ES (full):   {pred_full}")
         print(f"ES (routed): {pred_routed}")
+        print(f"ES (full, generated highlighted):   {pred_full_colored}")
+        print(f"ES (routed, generated highlighted): {pred_routed_colored}")
 
 
 def _train_route_scales(

--- a/huggingface_model/gemma/270M/trim_demo.sh
+++ b/huggingface_model/gemma/270M/trim_demo.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+python latin_punct_router_eval.py \
+  --model_name google/gemma-3-270m-it \
+  --split "train[:1%]" \
+  --max_samples 100 \
+  --max_target_tokens 64 \
+  --example_split "validation[:20]" \
+  --num_examples 3 \
+  --example_max_new_tokens 64 \
+  --route_mode latin_punct_only \
+  --byte_fallback \
+  --device cuda


### PR DESCRIPTION
This pull request adds a new interactive chat mode to the `latin_punct_router_eval.py` script, allowing users to input English sentences and compare full vs routed Spanish translations with color-highlighted outputs. It also enhances the validation example output with generated text highlighting and introduces a demo shell script for streamlined testing.

**New interactive chat mode and usability improvements:**

* Added a `--chat_mode` flag and the `_run_chat_mode` function to enable an interactive mode where users can input English sentences and receive both full and routed Spanish translations, with color highlighting for user input and generated continuations. [[1]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eR558) [[2]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eR403-R460) [[3]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eR640-R651) [[4]](diffhunk://#diff-1fd0707cb5fddbaf1809d3eb2989eae8c1135ef64fe69bdd639c77337a319fe9R148-R158)
* Introduced ANSI color codes (`ANSI_USER`, `ANSI_GEN`, `ANSI_RESET`) and the `_highlight_generated` helper to visually distinguish generated segments in both chat and validation outputs. [[1]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eR40-R42) [[2]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eR294-R299)

**Output and evaluation enhancements:**

* Modified `_generate_translation` to return both the plain and color-highlighted generated text, and updated validation example printing to display these highlights. [[1]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eL303-R312) [[2]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eL335-R347) [[3]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eL361-R372) [[4]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eL374-R385) [[5]](diffhunk://#diff-8ab14391e1756c4a19cc5d9c813a0429d6bba158e8afc16f483f8f97d667a52eR403-R460)
* Updated the `README.md` with documentation for the new chat mode and the highlighting features. [[1]](diffhunk://#diff-1fd0707cb5fddbaf1809d3eb2989eae8c1135ef64fe69bdd639c77337a319fe9R85) [[2]](diffhunk://#diff-1fd0707cb5fddbaf1809d3eb2989eae8c1135ef64fe69bdd639c77337a319fe9R148-R158)

**Demo and reproducibility:**

* Added a `trim_demo.sh` shell script to demonstrate running the evaluation with standard parameters.