### PR TITLE
Add time duration and completed to run explorations

### DIFF
--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -1,7 +1,8 @@
 import json
 import subprocess
+import time
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from itertools import product
 import argparse
 import os
@@ -753,15 +754,14 @@ def run_experiment(
     # Build and run
     cmd = build_command(combo)
     print(f"Running: {' '.join(cmd)}")
-    run_started_at = datetime.now()
+    run_started_at = time.perf_counter()
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError:
         print(f"[red]Process exited with error for run:[/] {run_name}")
-    run_finished_at = datetime.now()
-    run_total_time_s = (run_finished_at - run_started_at).total_seconds()
-    run_completed_at = run_finished_at.strftime("%Y-%m-%d %H:%M:%S")
-
+    run_total_time_s = time.perf_counter() - run_started_at
+    run_completed_at = datetime.now(timezone.utc).isoformat()
+    
     # Read metrics (use existing or nan on failure)
     try:
         metrics = read_metrics(str(combo['out_dir']))
@@ -789,7 +789,7 @@ def main():
         all_combos.extend(list(generate_combinations(cfg)))
 
     total = len(all_combos)
-    start_time = datetime.now()
+    start_time_monotonic = time.perf_counter()
     progress_log = LOG_DIR / f"{base}_progress.log"
     for idx, (combo, common_keys) in enumerate(all_combos, 1):
         configs_left = total - idx + 1
@@ -802,13 +802,12 @@ def main():
             print(f"[green]{message}[/]")
             append_progress(progress_log, message)
         else:
-            now = datetime.now()
-            elapsed = (now - start_time).total_seconds()
+            elapsed = time.perf_counter() - start_time_monotonic
             avg = elapsed / (idx - 1)
             eta_seconds = int(avg * configs_left)
             eta = timedelta(seconds=eta_seconds)
-            finish_time = now + timedelta(seconds=eta_seconds)
-            finish_formatted = finish_time.strftime("%Y-%m-%d %H:%M:%S")
+            finish_time = datetime.now(timezone.utc) + timedelta(seconds=eta_seconds)
+            finish_formatted = finish_time.strftime("%Y-%m-%d %H:%M:%S UTC")
             message = (
                 "Starting config "
                 f"{idx}/{total} ({configs_left} configs left). "

--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -45,6 +45,8 @@ METRIC_KEYS = [
     "zeus_avg_power_w",
     "zeus_train_step_energy_j",
     "zeus_energy_per_token_j",
+    "run_total_time_s",
+    "run_completed_at",
 ]
 
 
@@ -652,11 +654,24 @@ def completed_runs(log_file: Path) -> set[str]:
     return runs
 
 
-def append_log(log_file: Path, name: str, combo: dict, metrics: dict) -> None:
+def append_log(
+    log_file: Path,
+    name: str,
+    combo: dict,
+    metrics: dict,
+    run_total_time_s: float,
+    run_completed_at: str,
+) -> None:
     """
     Append a YAML entry with run details and metrics.
     """
-    entry = {'formatted_name': name, 'config': combo, **metrics}
+    entry = {
+        'formatted_name': name,
+        'config': combo,
+        **metrics,
+        'run_total_time_s': run_total_time_s,
+        'run_completed_at': run_completed_at,
+    }
     with log_file.open('a') as f:
         yaml.safe_dump(entry, f, explicit_start=True)
 
@@ -738,10 +753,14 @@ def run_experiment(
     # Build and run
     cmd = build_command(combo)
     print(f"Running: {' '.join(cmd)}")
+    run_started_at = datetime.now()
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError:
         print(f"[red]Process exited with error for run:[/] {run_name}")
+    run_finished_at = datetime.now()
+    run_total_time_s = (run_finished_at - run_started_at).total_seconds()
+    run_completed_at = run_finished_at.strftime("%Y-%m-%d %H:%M:%S")
 
     # Read metrics (use existing or nan on failure)
     try:
@@ -749,7 +768,14 @@ def run_experiment(
     except Exception:
         metrics = {k: float("nan") for k in METRIC_KEYS}
 
-    append_log(log_file, run_name, combo, metrics)
+    append_log(
+        log_file,
+        run_name,
+        combo,
+        metrics,
+        run_total_time_s=run_total_time_s,
+        run_completed_at=run_completed_at,
+    )
 
 
 def main():

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -302,33 +302,7 @@ class MonitorApp(App):
 
     def get_cell(self, entry: Dict, col_name: str):
         """Retrieve the value for a given column in an entry."""
-        if col_name in (
-            "best_val_loss",
-            "best_val_iter",
-            "best_val_tokens",
-            "num_params",
-            "peak_torch_allocated_mb",
-            "peak_torch_reserved_mb",
-            "peak_process_gpu_mb",
-            "iter_latency_avg",
-            "zeus_best_train_step_energy_j",
-            "avg_top1_prob",
-            "avg_top1_correct",
-            "avg_target_rank",
-            "avg_target_left_prob",
-            "avg_target_prob",
-            "target_rank_95",
-            "left_prob_95",
-            "avg_ln_f_cosine",
-            "ln_f_cosine_95",
-            "rankme",
-            "areq",
-            "zeus_total_energy_j",
-            "zeus_total_time_s",
-            "zeus_avg_power_w",
-            "zeus_train_step_energy_j",
-            "zeus_energy_per_token_j",
-        ):
+        if col_name in entry:
             return entry.get(col_name)
         return entry.get("config", {}).get(col_name)
 

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -208,6 +208,8 @@ class MonitorApp(App):
             "zeus_avg_power_w",
             "zeus_train_step_energy_j",
             "zeus_energy_per_token_j",
+            "run_total_time_s",
+            "run_completed_at",
         ] + self.param_keys
         self.all_columns = base_cols.copy()
         self.columns = base_cols.copy()


### PR DESCRIPTION
This pull request adds tracking and logging of experiment run timing information, specifically the total runtime and completion timestamp, to both the experiment execution and monitoring code. This helps with better monitoring and analysis of experiment runs.

**Experiment Timing and Logging Enhancements**

* `optimization_and_search/run_experiments.py`:
  - Added `run_total_time_s` and `run_completed_at` to the list of metrics being logged for each experiment run.
  - Modified the `append_log` function to accept and log `run_total_time_s` and `run_completed_at` fields.
  - Updated the `run_experiment` function to record the start and end time of each run, calculate the total runtime, format the completion timestamp, and pass these to the log.

**Monitoring UI Updates**

* `run_exploration_monitor.py`:
  - Added `run_total_time_s` and `run_completed_at` to the default columns displayed in the monitoring UI.
  - Simplified the logic in `get_cell` to allow dynamic access to any column present in the entry, making it easier to add new metrics like the timing fields.