### PR TITLE
Add heatmaps for activations

### DIFF
--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -145,6 +145,17 @@ def parse_args():
         help="Output HTML file for activation heatmaps",
     )
     p.add_argument(
+        "--activation_hist_file",
+        default="activation_hist.html",
+        help="Output HTML file for activation-input histograms overlaid with activation curves",
+    )
+    p.add_argument(
+        "--activation_hist_bins",
+        type=int,
+        default=120,
+        help="Number of bins for per-layer activation-input histograms",
+    )
+    p.add_argument(
         "--components",
         choices=["wte", "attn", "mlp", "resid"],
         nargs="+",
@@ -207,6 +218,7 @@ def main():
 
     lines: List[str] = []
     heatmap_traces = None
+    heatmap_inputs = None
 
     if args.display == "token":
         ids: List[int] = []
@@ -255,6 +267,7 @@ def main():
         if args.activation_heatmap:
             if heatmap_traces is None:
                 heatmap_traces = [[] for _ in range(model.config.n_layer)]
+                heatmap_inputs = [[] for _ in range(model.config.n_layer)]
             for li, blk in enumerate(model.transformer.h):
                 if hasattr(blk.mlp, "activation_variant"):
                     act_call_counts[li] = 0
@@ -262,7 +275,9 @@ def main():
                         def hook(module, inp, out):
                             # SwigLU / DualPath* can call activation multiple times; take the first call per token.
                             if act_call_counts[layer_idx] == 0:
+                                in_vec = inp[0][0, -1, :].detach().float().cpu()
                                 vec = out[0, -1, :].detach().float().cpu()
+                                heatmap_inputs[layer_idx].append(in_vec.numpy())
                                 heatmap_traces[layer_idx].append(vec.numpy())
                             act_call_counts[layer_idx] += 1
                         return hook
@@ -494,6 +509,47 @@ def main():
         fig.write_html(args.activation_heatmap_file)
         np.savez(Path(args.activation_heatmap_file).with_suffix('.npz'), **npy_payload)
         console.print(f"[cyan]Saved activation heatmaps → {args.activation_heatmap_file}[/cyan]")
+
+        hist_fig = make_subplots(
+            rows=rows,
+            cols=1,
+            shared_xaxes=False,
+            subplot_titles=[f"layer {i+1}" for i in range(rows)],
+            specs=[[{"secondary_y": True}] for _ in range(rows)],
+        )
+        hist_payload = {}
+        for i, layer_inputs in enumerate(heatmap_inputs):
+            if not layer_inputs:
+                continue
+            arr_in = np.concatenate([a.reshape(-1) for a in layer_inputs], axis=0)
+            hist_payload[f"layer_{i+1}_activation_input"] = arr_in
+            counts, edges = np.histogram(arr_in, bins=args.activation_hist_bins, density=True)
+            centers = (edges[:-1] + edges[1:]) * 0.5
+            layer_mlp = model.transformer.h[i].mlp
+            x_eval = torch.from_numpy(centers.astype(np.float32)).to(args.device)
+            with torch.no_grad():
+                y_eval = layer_mlp.activation_variant(x_eval).detach().float().cpu().numpy()
+
+            hist_fig.add_trace(
+                go.Bar(x=centers, y=counts, name=f"L{i+1} hist", marker_color="rgba(55, 83, 109, 0.55)"),
+                row=i + 1,
+                col=1,
+                secondary_y=False,
+            )
+            hist_fig.add_trace(
+                go.Scatter(x=centers, y=y_eval, mode="lines", name=f"L{i+1} act(x)", line={"color": "crimson", "width": 2}),
+                row=i + 1,
+                col=1,
+                secondary_y=True,
+            )
+            hist_fig.update_yaxes(title_text="density", row=i + 1, col=1, secondary_y=False)
+            hist_fig.update_yaxes(title_text="activation(x)", row=i + 1, col=1, secondary_y=True)
+            hist_fig.update_xaxes(title_text="activation input", row=i + 1, col=1)
+
+        hist_fig.update_layout(height=max(280 * rows, 400), barmode="overlay")
+        hist_fig.write_html(args.activation_hist_file)
+        np.savez(Path(args.activation_hist_file).with_suffix('.npz'), **hist_payload)
+        console.print(f"[cyan]Saved activation histograms → {args.activation_hist_file}[/cyan]")
 
 if __name__ == "__main__":
     main()

--- a/colorize_dataset.py
+++ b/colorize_dataset.py
@@ -31,10 +31,10 @@ python colorize_dataset.py \
 from __future__ import annotations
 
 import argparse, io, pickle, math
+import numpy as np
 from pathlib import Path
 from typing import Callable, List, Sequence
 
-import numpy as np
 import torch, torch.nn.functional as F
 from rich.console import Console
 from rich.table import Table
@@ -134,6 +134,17 @@ def parse_args():
         ),
     )
     p.add_argument(
+        "--activation_heatmap",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Collect per-layer activation traces and save heatmap HTML/NPY outputs",
+    )
+    p.add_argument(
+        "--activation_heatmap_file",
+        default="activation_heatmap.html",
+        help="Output HTML file for activation heatmaps",
+    )
+    p.add_argument(
         "--components",
         choices=["wte", "attn", "mlp", "resid"],
         nargs="+",
@@ -195,6 +206,7 @@ def main():
     tokens_left = min(args.num_tokens, len(data) - 1 - pos)
 
     lines: List[str] = []
+    heatmap_traces = None
 
     if args.display == "token":
         ids: List[int] = []
@@ -239,6 +251,22 @@ def main():
 
         activations = {"t0": None, "attn": [], "mlp": [], "ar": [], "mr": []}
         handles = []
+        act_call_counts = {}
+        if args.activation_heatmap:
+            if heatmap_traces is None:
+                heatmap_traces = [[] for _ in range(model.config.n_layer)]
+            for li, blk in enumerate(model.transformer.h):
+                if hasattr(blk.mlp, "activation_variant"):
+                    act_call_counts[li] = 0
+                    def make_act_hook(layer_idx):
+                        def hook(module, inp, out):
+                            # SwigLU / DualPath* can call activation multiple times; take the first call per token.
+                            if act_call_counts[layer_idx] == 0:
+                                vec = out[0, -1, :].detach().float().cpu()
+                                heatmap_traces[layer_idx].append(vec.numpy())
+                            act_call_counts[layer_idx] += 1
+                        return hook
+                    handles.append(blk.mlp.activation_variant.register_forward_hook(make_act_hook(li)))
         if args.display != "token" and args.activation_view != "none":
             def t0_hook(module, inp, out):
                 activations["t0"] = out[0, -1, :].detach()
@@ -445,6 +473,27 @@ def main():
         fig.write_html(args.plot_file)
         console.print(f"[cyan]Saved plot → {args.plot_file}[/cyan]")
 
+
+    if args.activation_heatmap and heatmap_traces is not None:
+        from plotly.subplots import make_subplots
+        import plotly.graph_objects as go
+
+        rows = len(heatmap_traces)
+        fig = make_subplots(rows=rows, cols=1, shared_xaxes=True,
+                            subplot_titles=[f"layer {i+1}" for i in range(rows)])
+        npy_payload = {}
+        for i, layer_series in enumerate(heatmap_traces):
+            if not layer_series:
+                continue
+            arr = np.stack(layer_series, axis=0)  # (tokens, hidden_or_mlp_dim)
+            npy_payload[f"layer_{i+1}"] = arr
+            fig.add_trace(go.Heatmap(z=arr.T, coloraxis="coloraxis", showscale=(i == 0)), row=i+1, col=1)
+            fig.update_yaxes(title_text="unit", row=i+1, col=1)
+
+        fig.update_layout(height=max(280 * rows, 400), coloraxis={"colorscale": "RdBu", "cmid": 0.0})
+        fig.write_html(args.activation_heatmap_file)
+        np.savez(Path(args.activation_heatmap_file).with_suffix('.npz'), **npy_payload)
+        console.print(f"[cyan]Saved activation heatmaps → {args.activation_heatmap_file}[/cyan]")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request adds a new feature to collect and visualize per-layer activation traces in the `colorize_dataset.py` script. Users can now generate HTML heatmaps and histograms of model activations for deeper analysis. The main changes include new CLI arguments, activation-tracing hooks, and visualization/export code.

**New activation visualization feature:**

* Added CLI arguments (`--activation_heatmap`, `--activation_heatmap_file`, `--activation_hist_file`, `--activation_hist_bins`) to enable and configure per-layer activation trace collection and output files.
* Implemented hooks into model layers to capture activation inputs and outputs during forward passes when the new feature is enabled.

**Activation data export and visualization:**

* After processing, generates interactive HTML heatmaps and histograms of per-layer activations using Plotly, and saves the raw data as `.npz` files.

**Codebase maintenance:**

* Moved the `numpy` import to the top of the file for consistency.
* Added variables to store activation traces and inputs for later visualization.