### PR TITLE
Add nfd from nfc and muon adam compare

### DIFF
--- a/data/hangul/hangul_nfc_to_nfd.py
+++ b/data/hangul/hangul_nfc_to_nfd.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Convert only precomposed Korean Hangul syllables from NFC to NFD.
+
+Everything outside the Hangul syllables block U+AC00..U+D7A3 is left unchanged.
+So Latin accents, emoji, punctuation, spaces, line endings, etc. are not normalized.
+
+Usage:
+  python3 hangul_nfc_to_nfd.py input.txt output.txt
+  python3 hangul_nfc_to_nfd.py --in-place input.txt
+  cat input.txt | python3 hangul_nfc_to_nfd.py > output.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+import unicodedata
+from pathlib import Path
+
+
+HANGUL_SYLLABLES_START = 0xAC00
+HANGUL_SYLLABLES_END = 0xD7A3
+
+
+def is_precomposed_hangul_syllable(ch: str) -> bool:
+    codepoint = ord(ch)
+    return HANGUL_SYLLABLES_START <= codepoint <= HANGUL_SYLLABLES_END
+
+
+def hangul_only_nfd(text: str) -> str:
+    """
+    Apply Unicode NFD only to precomposed Hangul syllables.
+
+    Example:
+      한 U+D55C -> ᄒ U+1112 + ᅡ U+1161 + ᆫ U+11AB
+
+    Non-Hangul characters are returned exactly as they are.
+    """
+    return "".join(
+        unicodedata.normalize("NFD", ch)
+        if is_precomposed_hangul_syllable(ch)
+        else ch
+        for ch in text
+    )
+
+
+def convert_bytes(data: bytes, encoding: str) -> bytes:
+    # surrogateescape preserves invalid bytes when decoding/re-encoding.
+    text = data.decode(encoding, errors="surrogateescape")
+    converted = hangul_only_nfd(text)
+    return converted.encode(encoding, errors="surrogateescape")
+
+
+def convert_file(input_path: Path, output_path: Path, encoding: str) -> None:
+    data = input_path.read_bytes()
+    output_path.write_bytes(convert_bytes(data, encoding))
+
+
+def convert_file_in_place(path: Path, encoding: str) -> None:
+    converted = convert_bytes(path.read_bytes(), encoding)
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+
+    try:
+        with os.fdopen(fd, "wb") as tmp:
+            tmp.write(converted)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert only Korean Hangul syllables from NFC to NFD."
+    )
+    parser.add_argument("input", nargs="?", help="Input file. If omitted, reads stdin.")
+    parser.add_argument("output", nargs="?", help="Output file. If omitted, writes stdout.")
+    parser.add_argument(
+        "-i",
+        "--in-place",
+        action="store_true",
+        help="Rewrite the input file in place.",
+    )
+    parser.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="Text encoding to use. Default: utf-8.",
+    )
+
+    args = parser.parse_args()
+
+    if args.in_place:
+        if not args.input or args.output:
+            parser.error("--in-place requires exactly one input file and no output file.")
+        convert_file_in_place(Path(args.input), args.encoding)
+        return 0
+
+    if args.input:
+        input_path = Path(args.input)
+        if args.output:
+            convert_file(input_path, Path(args.output), args.encoding)
+        else:
+            sys.stdout.buffer.write(convert_bytes(input_path.read_bytes(), args.encoding))
+        return 0
+
+    if args.output:
+        parser.error("An output file requires an input file.")
+
+    sys.stdout.buffer.write(convert_bytes(sys.stdin.buffer.read(), args.encoding))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/default_inf_muon_adam_compare.yaml
+++ b/default_inf_muon_adam_compare.yaml
@@ -1,0 +1,98 @@
+# default.yaml using named group mechanisms from sample.yaml
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm Type
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position Embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # Embedding Norm
+  - named_group: "rmsnorm_wte"
+    norm_variant_wte: ["rmsnorm"]
+
+  # MLP Activation
+  - named_group: "squared_relu"
+    activation_variant: ["squared_relu"]
+
+  # Relu2Max
+  - named_group: "relu2max"
+    softmax_variant_attn: ["relu2max"]
+
+  # Softmax
+  - named_group: "softmax"
+    softmax_variant_attn: ["softmax"]
+
+  # Infinite Attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # Head Dimension
+  - named_group: "hd_100"
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  - named_group: "hd_150"
+    n_qk_head_dim: [150]
+    n_v_head_dim: [150]
+
+  - named_group: "hd_200"
+    n_qk_head_dim: [200]
+    n_v_head_dim: [200]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+    n_head: ["3"]
+    optimizer: ["muon", "adamw"]
+    weight_decay: ["1e-1", "0"]
+    named_group_alternates: ["hd_100"]
+    # HSNorm arch
+    norm_variant_wte: "hyperspherenorm"
+    norm_variant_attn: "hyperspherenorm"
+    norm_variant_output: "hyperspherenorm"
+    # Learnable radius
+    norm_wte_radius_learning: true
+    hsnorm_radius_learning: true
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "softmax"
+      - "infinite"
+    n_head: ["3"]
+    optimizer: ["muon", "adamw"]
+    weight_decay: ["1e-1", "0"]
+    named_group_alternates: ["hd_100"]
+    norm_variant_wte: "rmsnorm"
+    norm_variant_attn: "rmsnorm"
+    norm_variant_output: "rmsnorm"


### PR DESCRIPTION
This pull request introduces a new utility script for Hangul normalization and adds a new YAML configuration for model experiments. The most important changes are grouped below:

### New utility script for Hangul normalization

* Added `hangul_nfc_to_nfd.py`, a standalone Python script that converts only precomposed Korean Hangul syllables from NFC to NFD, leaving all other characters unchanged. The script supports file and stdin/stdout operations, in-place editing, and custom encodings.

### Experiment configuration

* Added `default_inf_muon_adam_compare.yaml`, a new configuration file using named group mechanisms to define experimental parameter sets for model training. It includes static groups for normalization, attention, embeddings, activation, and optimizer variants, and defines parameter groups for comparing hyperspherenorm and rmsnorm architectures with different optimizers and weight decays.