### PR TITLE
Refactor progress metric formatting

### DIFF
--- a/train.py
+++ b/train.py
@@ -11,6 +11,7 @@ import sys
 import time
 from collections import deque
 from datetime import datetime, timedelta
+from typing import Any
 
 from rich.console import Group
 from rich.console import Console
@@ -27,6 +28,7 @@ from train_variations.loss_variants import build_loss_function
 from train_variations.distillation_loss_variants import build_distillation_loss
 
 from utils.gpu_monitoring import get_gpu_memory_info, get_process_gpu_memory_bytes
+from utils.progress_bar import format_progress_metrics
 from torch.cuda import reset_peak_memory_stats, max_memory_allocated, max_memory_reserved
 
 try:
@@ -1797,6 +1799,29 @@ class Trainer:
                 }
         torch.save(checkpoint, os.path.join(self.args.out_dir, filename))
 
+
+    def get_progress_metrics(self) -> dict[str, Any]:
+        """Return raw values backing all Rich progress-bar task fields."""
+        return {
+            "best_iter": self.best_iter,
+            "best_val_loss": self.best_val_loss,
+            "best_tokens": self.best_tokens,
+            "eta": self.formatted_completion_eta,
+            "time_remaining_ms": self.time_remaining_ms,
+            "total_time_est_ms": self.total_time_est_ms,
+            "iter_latency_avg": self.iter_latency_avg,
+            "peak_torch_allocated": self.peak_torch_allocated,
+            "latest_top1_prob": self.latest_top1_prob,
+            "latest_top1_correct": self.latest_top1_correct,
+            "latest_target_rank": self.latest_target_rank,
+            "latest_target_prob": self.latest_target_prob,
+            "latest_target_left_prob": self.latest_target_left_prob,
+            "latest_rank_95": self.latest_rank_95,
+            "latest_left_prob_95": self.latest_left_prob_95,
+            "latest_ln_f_cosine": self.latest_ln_f_cosine,
+            "latest_ln_f_cosine_95": self.latest_ln_f_cosine_95,
+        }
+
     def run_validation_step(self, running_mfu, current_epoch, current_dataset, num_steps_with_worse_loss, live=None):
         losses = self.estimate_loss()
 
@@ -2080,25 +2105,7 @@ class Trainer:
             task_id = progress.add_task(
                     "[green]Training...",
                     total=((self.args.max_iters - self.iter_num) + self.evaluations_remaining * self.args.eval_iters),
-                    eta=self.formatted_completion_eta,
-                    total_hour=f"{int(self.total_time_est_ms // 3_600_000)}",
-                    total_min=f"{int((self.total_time_est_ms // 60_000) % 60):02d}",
-                    hour=f"{int((self.time_remaining_ms // (1000*3600)) % 24):02d}",
-                    min=f"{int((self.time_remaining_ms // 60000) % 60):02d}",
-                    best_val_loss=f"{self.best_val_loss:.3f}",
-                    best_iter=f"{self.best_iter}",
-                    best_tokens=f"{self.best_tokens}",
-                    iter_latency=f"{self.iter_latency_avg:.1f}",
-                    peak_gpu_mb=f"{self.peak_torch_allocated / (1024 ** 2):.1f}",
-                    t1p=f"{self.latest_top1_prob:.6f}",
-                    t1c=f"{self.latest_top1_correct:.6f}",
-                    tr=f"{self.latest_target_rank:.2f}",
-                    tp=f"{self.latest_target_prob:.6f}",
-                    tlp=f"{self.latest_target_left_prob:.6f}",
-                    r95=f"{self.latest_rank_95:.2f}",
-                    p95=f"{self.latest_left_prob_95:.6f}",
-                    lnf_cos=f"{self.latest_ln_f_cosine:.6f}",
-                    lnf_cos95=f"{self.latest_ln_f_cosine_95:.6f}",
+                    **format_progress_metrics(self.get_progress_metrics()),
                     )
 
             if self.zeus_enabled:
@@ -2294,25 +2301,7 @@ class Trainer:
                 progress.update(
                         task_id,
                         advance=progress_advance,
-                        eta=self.formatted_completion_eta,
-                        total_hour=f"{int(self.total_time_est_ms // 3_600_000)}",
-                        total_min=f"{int((self.total_time_est_ms // 60_000) % 60):02d}",
-                        hour=f"{int((self.time_remaining_ms // 3_600_000) % 24):02d}",
-                        min=f"{int((self.time_remaining_ms // 60_000) % 60):02d}",
-                        best_val_loss=f"{self.best_val_loss:.3f}",
-                        best_iter=f"{self.best_iter}",
-                        best_tokens=f"{self.best_tokens}",
-                        iter_latency=f"{self.iter_latency_avg:.1f}",
-                        peak_gpu_mb=f"{self.peak_torch_allocated / (1024 ** 2):.1f}",
-                        t1p=f"{self.latest_top1_prob:.6f}",
-                        t1c=f"{self.latest_top1_correct:.6f}",
-                        tr=f"{self.latest_target_rank:.2f}",
-                        tp=f"{self.latest_target_prob:.6f}",
-                        tlp=f"{self.latest_target_left_prob:.6f}",
-                        r95=f"{self.latest_rank_95:.2f}",
-                        p95=f"{self.latest_left_prob_95:.6f}",
-                        lnf_cos=f"{self.latest_ln_f_cosine:.6f}",
-                        lnf_cos95=f"{self.latest_ln_f_cosine_95:.6f}",
+                        **format_progress_metrics(self.get_progress_metrics()),
                         )
                 live.update(Group(progress.get_renderable(), cli_text))
 

--- a/utils/progress_bar.py
+++ b/utils/progress_bar.py
@@ -1,0 +1,56 @@
+"""Formatting helpers for Rich training progress-bar task fields."""
+
+from typing import Any
+
+
+def _as_float(value: Any, default: float = float("nan")) -> float:
+    if value is None:
+        return default
+    item = getattr(value, "item", None)
+    if callable(item):
+        value = item()
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    item = getattr(value, "item", None)
+    if callable(item):
+        value = item()
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def format_progress_metrics(metrics: dict[str, Any]) -> dict[str, str]:
+    """Convert raw Trainer progress metrics into Rich task field strings."""
+    time_remaining_ms = _as_float(metrics.get("time_remaining_ms"), 0.0)
+    total_time_est_ms = _as_float(metrics.get("total_time_est_ms"), 0.0)
+    peak_torch_allocated = _as_float(metrics.get("peak_torch_allocated"), 0.0)
+
+    return {
+        "eta": str(metrics.get("eta", "waiting for calculation")),
+        "total_hour": f"{int(total_time_est_ms // 3_600_000)}",
+        "total_min": f"{int((total_time_est_ms // 60_000) % 60):02d}",
+        "hour": f"{int((time_remaining_ms // 3_600_000) % 24):02d}",
+        "min": f"{int((time_remaining_ms // 60_000) % 60):02d}",
+        "best_val_loss": f"{_as_float(metrics.get('best_val_loss')):.3f}",
+        "best_iter": f"{_as_int(metrics.get('best_iter'))}",
+        "best_tokens": f"{_as_int(metrics.get('best_tokens'))}",
+        "iter_latency": f"{_as_float(metrics.get('iter_latency_avg'), 0.0):.1f}",
+        "peak_gpu_mb": f"{peak_torch_allocated / (1024 ** 2):.1f}",
+        "t1p": f"{_as_float(metrics.get('latest_top1_prob')):.6f}",
+        "t1c": f"{_as_float(metrics.get('latest_top1_correct')):.6f}",
+        "tr": f"{_as_float(metrics.get('latest_target_rank')):.2f}",
+        "tp": f"{_as_float(metrics.get('latest_target_prob')):.6f}",
+        "tlp": f"{_as_float(metrics.get('latest_target_left_prob')):.6f}",
+        "r95": f"{_as_float(metrics.get('latest_rank_95')):.2f}",
+        "p95": f"{_as_float(metrics.get('latest_left_prob_95')):.6f}",
+        "lnf_cos": f"{_as_float(metrics.get('latest_ln_f_cosine')):.6f}",
+        "lnf_cos95": f"{_as_float(metrics.get('latest_ln_f_cosine_95')):.6f}",
+    }


### PR DESCRIPTION
This pull request refactors how progress metrics are formatted and displayed in the training progress bar, making the code more modular and easier to maintain. It introduces a new utility module for formatting progress metrics, centralizes the logic for converting raw metrics to display strings, and updates the training loop to use this new approach.

**Progress bar formatting improvements:**

* Added a new utility module `utils/progress_bar.py` with functions to format trainer progress metrics for display in the Rich progress bar, including helpers for safe type conversion and formatting.
* Updated `train.py` to use the new `format_progress_metrics` function when adding and updating progress bar tasks, replacing the previous inline formatting logic. [[1]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L2083-R2108) [[2]](diffhunk://#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L2297-R2304)
* Added a `get_progress_metrics` method to the Trainer class in `train.py` to collect all relevant raw metric values in a single dictionary for formatting.
* Imported the new formatting helper in `train.py` to enable the refactored progress bar updates.

**Type annotation and import improvements:**

* Added an import for `Any` from `typing` in `train.py` to support type annotations in the new `get_progress_metrics` method.