### PR TITLE
Implement flexible input norms for attn and mlp

### DIFF
--- a/explorations/muon_granular_norm_explore.yaml
+++ b/explorations/muon_granular_norm_explore.yaml
@@ -50,11 +50,12 @@ named_static_groups:
     muon_exclude_substrings: [["embed", "wte", "wpe", "lm_head"]]
 
 common_group:
-  dataset: ["minipile"]
-  eval_interval: [2500]
-  max_iters: [10000]
+  dataset: ["shakespeare_char"]
+  eval_interval: [100]
+  eval_iters: [50]
+  max_iters: [500]
   never_save_checkpoint: [true]
-  compile: [true]
+  compile: [false]
   log_rankme: [true]
   log_areq: [true]
 
@@ -71,13 +72,39 @@ parameter_groups:
 
     # Retain both attention activations from muon_norm_explore.yaml. For each
     # activation, the four lists below form the complete 2^4 norm matrix.
-    softmax_variant_attn: ["relu2max", "softmax"]
-    norm_variant_attn_input: ["rmsnorm", "hyperspherenorm"]
-    norm_variant_attn_output: ["rmsnorm", "hyperspherenorm"]
-    norm_variant_mlp_input: ["rmsnorm", "hyperspherenorm"]
-    norm_variant_mlp_output: ["rmsnorm", "hyperspherenorm"]
+    softmax_variant_attn: ["softmax"]
+    norm_variant_wte: [null, "rmsnorm", "hyperspherenorm"]
+    norm_variant_attn_input: ["rmsnorm", "hyperspherenorm", "cappedhyperspherenorm", "identity"]
+    norm_variant_attn_output: ["rmsnorm", "hyperspherenorm", "cappedhyperspherenorm", "identity"]
+    norm_variant_mlp_input: ["rmsnorm", "hyperspherenorm", "cappedhyperspherenorm", "identity"]
+    norm_variant_mlp_output: ["rmsnorm", "hyperspherenorm", "cappedhyperspherenorm", "identity"]
 
     # Match the HyperSphereNorm settings used by muon_norm_explore.yaml.
     hsnorm_scale: [1.0]
     hsnorm_gain: [false]
     hsnorm_radius_learning: [false]
+
+  - named_group_static:
+      - "qk_norm"
+      - "rotary"
+      - "squared_relu"
+      - "infinite"
+      - "mqa"
+      - "hd_100_three_heads"
+      - "muon_default"
+
+    # Retain both attention activations from muon_norm_explore.yaml. For each
+    # activation, the four lists below form the complete 2^4 norm matrix.
+    softmax_variant_attn: ["relu2max"]
+    use_peri_ln: [true]
+    norm_variant_wte: [null, "rmsnorm", "hyperspherenorm"]
+    norm_variant_attn_input: ["rmsnorm", "hyperspherenorm", "cappedhyperspherenorm", "identity"]
+    norm_variant_attn_output: ["cappedhyperspherenorm", "identity"]
+    norm_variant_mlp_input: ["rmsnorm", "hyperspherenorm", "cappedhyperspherenorm", "identity"]
+    norm_variant_mlp_output: ["cappedhyperspherenorm", "identity"]
+
+    # Match the HyperSphereNorm settings used by muon_norm_explore.yaml.
+    hsnorm_scale: [1.0]
+    hsnorm_gain: [false]
+    hsnorm_radius_learning: [false]
+

--- a/explorations/muon_granular_norm_explore.yaml
+++ b/explorations/muon_granular_norm_explore.yaml
@@ -1,0 +1,83 @@
+# muon_granular_norm_explore.yaml
+# Based on muon_norm_explore.yaml. Sweeps all 2^4 RMSNorm/HyperSphereNorm
+# combinations across the attention and MLP input/output normalization sites.
+---
+
+named_static_groups:
+  # QK Norm
+  - named_group: "qk_norm"
+    use_qk_norm: [true]
+    use_qk_norm_scale: [true]
+
+  # Norm placement
+  - named_group: "peri_ln"
+    use_pre_ln: [true]
+    use_peri_ln: [true]
+    use_post_ln: [false]
+
+  # Position embeddings
+  - named_group: "rotary"
+    use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+  # MLP activation
+  - named_group: "squared_relu"
+    activation_variant: ["squared_relu"]
+
+  # Infinite attention
+  - named_group: "infinite"
+    attention_variant: ["infinite"]
+    use_concat_heads: [true]
+
+  # MQA
+  - named_group: "mqa"
+    n_kv_group: [1]
+
+  # Fixed architecture requested for this norm sweep
+  - named_group: "hd_100_three_heads"
+    n_head: [3]
+    n_qk_head_dim: [100]
+    n_v_head_dim: [100]
+
+  # Optimizer
+  - named_group: "muon_default"
+    optimizer: ["muon"]
+    muon_momentum: [0.95]
+    muon_ns_steps: [5]
+    muon_nesterov: [true]
+    muon_include_all_weights: [false]
+    muon_min_ndim: [2]
+    muon_exclude_substrings: [["embed", "wte", "wpe", "lm_head"]]
+
+common_group:
+  dataset: ["minipile"]
+  eval_interval: [2500]
+  max_iters: [10000]
+  never_save_checkpoint: [true]
+  compile: [true]
+  log_rankme: [true]
+  log_areq: [true]
+
+parameter_groups:
+  - named_group_static:
+      - "qk_norm"
+      - "peri_ln"
+      - "rotary"
+      - "squared_relu"
+      - "infinite"
+      - "mqa"
+      - "hd_100_three_heads"
+      - "muon_default"
+
+    # Retain both attention activations from muon_norm_explore.yaml. For each
+    # activation, the four lists below form the complete 2^4 norm matrix.
+    softmax_variant_attn: ["relu2max", "softmax"]
+    norm_variant_attn_input: ["rmsnorm", "hyperspherenorm"]
+    norm_variant_attn_output: ["rmsnorm", "hyperspherenorm"]
+    norm_variant_mlp_input: ["rmsnorm", "hyperspherenorm"]
+    norm_variant_mlp_output: ["rmsnorm", "hyperspherenorm"]
+
+    # Match the HyperSphereNorm settings used by muon_norm_explore.yaml.
+    hsnorm_scale: [1.0]
+    hsnorm_gain: [false]
+    hsnorm_radius_learning: [false]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -398,6 +398,13 @@ class GPTConfig:
     norm_variant_attn: str = "rmsnorm"
     # Defaults to norm_variant_attn when None, preserving older configs/checkpoints.
     norm_variant_mlp: str | None = None
+    # More granular block norm variants. Input variants apply to pre-norms;
+    # output variants apply to peri/post norms. None falls back to the
+    # corresponding component norm above.
+    norm_variant_attn_input: str | None = None
+    norm_variant_attn_output: str | None = None
+    norm_variant_mlp_input: str | None = None
+    norm_variant_mlp_output: str | None = None
     norm_variant_output: str = "rmsnorm"
 
     norm_variant_wte: str | None = None

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -407,6 +407,11 @@ class GPTConfig:
     norm_variant_mlp_output: str | None = None
     norm_variant_output: str = "rmsnorm"
 
+    # STE norm uses the selected norm in the forward pass and substitutes the
+    # selected activation's gradient in the backward pass.
+    ste_norm_forward_variant: str = "rmsnorm"
+    ste_norm_backward_activation: str = "identity"
+
     norm_variant_wte: str | None = None
     norm_wte_radius: float | None = None
     norm_wte_scale: float | None = None

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -396,6 +396,8 @@ class GPTConfig:
 
     # Layernorm Alternatives and Options
     norm_variant_attn: str = "rmsnorm"
+    # Defaults to norm_variant_attn when None, preserving older configs/checkpoints.
+    norm_variant_mlp: str | None = None
     norm_variant_output: str = "rmsnorm"
 
     norm_variant_wte: str | None = None

--- a/train_args.py
+++ b/train_args.py
@@ -838,7 +838,35 @@ def parse_args():
         type=str,
         default=None,
         choices=norm_variations,
-        help="MLP input/peri/post norm variant. Defaults to --norm_variant_attn for backward compatibility.",
+        help="Default MLP block norm variant. Defaults to --norm_variant_attn for backward compatibility.",
+    )
+    model_group.add_argument(
+        "--norm_variant_attn_input",
+        type=str,
+        default=None,
+        choices=norm_variations,
+        help="Attention pre-norm variant. Defaults to --norm_variant_attn.",
+    )
+    model_group.add_argument(
+        "--norm_variant_attn_output",
+        type=str,
+        default=None,
+        choices=norm_variations,
+        help="Attention peri/post norm variant. Defaults to --norm_variant_attn.",
+    )
+    model_group.add_argument(
+        "--norm_variant_mlp_input",
+        type=str,
+        default=None,
+        choices=norm_variations,
+        help="MLP pre-norm variant. Defaults to --norm_variant_mlp, then --norm_variant_attn.",
+    )
+    model_group.add_argument(
+        "--norm_variant_mlp_output",
+        type=str,
+        default=None,
+        choices=norm_variations,
+        help="MLP peri/post norm variant. Defaults to --norm_variant_mlp, then --norm_variant_attn.",
     )
     model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=norm_variations)
     model_group.add_argument("--use_flash_norm", type=bool, default=None, action=argparse.BooleanOptionalAction)

--- a/train_args.py
+++ b/train_args.py
@@ -360,6 +360,7 @@ def parse_args():
             "dact",
             "cappedhyperspherenorm",
             "identity",
+            "ste_norm",
         ],
         help="Optional post-mapping normalization applied to numerical embedding channels.",
     )
@@ -830,6 +831,7 @@ def parse_args():
             "dact",
             "identity",
             "cappedhyperspherenorm",
+            "ste_norm",
             ]
 
     model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=norm_variations)
@@ -939,6 +941,22 @@ def parse_args():
             "tanh",
             "identity",
         ]
+
+    ## Straight-through norm
+    model_group.add_argument(
+        "--ste_norm_forward_variant",
+        type=str,
+        default="rmsnorm",
+        choices=[variant for variant in norm_variations if variant != "ste_norm"],
+        help="Norm used in the forward pass when a norm_variant is ste_norm.",
+    )
+    model_group.add_argument(
+        "--ste_norm_backward_activation",
+        type=str,
+        default="identity",
+        choices=activation_variations,
+        help="Activation whose gradient ste_norm uses in the backward pass (default: identity).",
+    )
 
     ## DynamicActivations
     model_group.add_argument("--dact_activation", type=str, default="tanh", choices=activation_variations)

--- a/train_args.py
+++ b/train_args.py
@@ -833,6 +833,13 @@ def parse_args():
             ]
 
     model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=norm_variations)
+    model_group.add_argument(
+        "--norm_variant_mlp",
+        type=str,
+        default=None,
+        choices=norm_variations,
+        help="MLP input/peri/post norm variant. Defaults to --norm_variant_attn for backward compatibility.",
+    )
     model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=norm_variations)
     model_group.add_argument("--use_flash_norm", type=bool, default=None, action=argparse.BooleanOptionalAction)
 

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -80,13 +80,18 @@ def parallel_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     # Make sure not to override skip connection
     x_in = x
 
-    # Pre-LN
-    if block.use_pre_ln:
-        x_in = block.pre_ln(x_in)
+    # Pre-LN. Keep the historical shared pre_ln path when available, but
+    # allow attention and MLP to deliberately choose different input norms.
+    if hasattr(block, "pre_ln"):
+        x_attn_in = block.pre_ln(x_in)
+        x_mlp_in = x_attn_in
+    else:
+        x_attn_in = block.pre_ln_attn(x_in) if block.use_pre_ln_attn else x_in
+        x_mlp_in = block.pre_ln_mlp(x_in) if block.use_pre_ln_mlp else x_in
 
     # Perform Operations
-    attn_out = block.attn(x_in, iter_num)
-    mlp_out = block.mlp(x_in, iter_num)
+    attn_out = block.attn(x_attn_in, iter_num)
+    mlp_out = block.mlp(x_mlp_in, iter_num)
 
     # Peri-LN
     if block.use_peri_ln_attn:
@@ -104,9 +109,15 @@ def parallel_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     combined = attn_out + mlp_out
     x = block._combine_resid("attn", x, combined)
 
-    # Post-LN
-    if block.use_post_ln:
+    # Post-LN. Keep shared legacy post_ln when present; otherwise apply the
+    # branch-specific post norms after the combined parallel residual update.
+    if hasattr(block, "post_ln"):
         x = block.post_ln(x)
+    else:
+        if block.use_post_ln_attn:
+            x = block.post_ln_attn(x)
+        if block.use_post_ln_mlp:
+            x = block.post_ln_mlp(x)
 
     return x
 
@@ -283,42 +294,56 @@ def _resolve_unit_norm_flags(self, config) -> None:
             setattr(self, granular_key, granular_val if (granular_val is not None) else general_val)
 
 
-def _setup_norms_parallel(self, config, norm_cls) -> None:
+def _setup_norms_parallel(self, config, norm_classes) -> None:
     """Norm layout for the 'parallel_mlp' variation."""
-    # Pre-LN
-    if getattr(self, "use_pre_ln", False):
-        self.pre_ln = norm_cls(config)
+    attn_norm_cls, mlp_norm_cls = norm_classes
+
+    # Pre-LN. If both branches use the same norm variant through the legacy
+    # global flag, keep a shared ``pre_ln`` module for checkpoint compatibility.
+    if getattr(self, "use_pre_ln_attn", False) and getattr(self, "use_pre_ln_mlp", False) and attn_norm_cls is mlp_norm_cls:
+        self.pre_ln = attn_norm_cls(config)
+    else:
+        if getattr(self, "use_pre_ln_attn", False):
+            self.pre_ln_attn = attn_norm_cls(config)
+        if getattr(self, "use_pre_ln_mlp", False):
+            self.pre_ln_mlp = mlp_norm_cls(config)
 
     # Peri-LN
     if getattr(self, "use_peri_ln_attn", False):
-        self.peri_ln_attn = norm_cls(config)
+        self.peri_ln_attn = attn_norm_cls(config)
     if getattr(self, "use_peri_ln_mlp", False):
-        self.peri_ln_mlp = norm_cls(config)
+        self.peri_ln_mlp = mlp_norm_cls(config)
 
-    # Post-LN
-    if getattr(self, "use_post_ln", False):
-        self.post_ln = norm_cls(config)
+    # Post-LN. Preserve the historical shared post_ln when possible.
+    if getattr(self, "use_post_ln_attn", False) and getattr(self, "use_post_ln_mlp", False) and attn_norm_cls is mlp_norm_cls:
+        self.post_ln = attn_norm_cls(config)
+    else:
+        if getattr(self, "use_post_ln_attn", False):
+            self.post_ln_attn = attn_norm_cls(config)
+        if getattr(self, "use_post_ln_mlp", False):
+            self.post_ln_mlp = mlp_norm_cls(config)
 
-def _setup_norms_sequential(self, config, norm_cls) -> None:
+def _setup_norms_sequential(self, config, norm_classes) -> None:
     """Norm layout for the 'attn_then_mlp' variation."""
+    attn_norm_cls, mlp_norm_cls = norm_classes
 
     # Pre-Norm
     if getattr(self, "use_pre_ln_attn", False):
-        self.pre_ln_attn = norm_cls(config)
+        self.pre_ln_attn = attn_norm_cls(config)
     if getattr(self, "use_pre_ln_mlp", False):
-        self.pre_ln_mlp = norm_cls(config)
+        self.pre_ln_mlp = mlp_norm_cls(config)
 
     # Peri-LN
     if getattr(self, "use_peri_ln_attn", False):
-        self.peri_ln_attn = norm_cls(config)
+        self.peri_ln_attn = attn_norm_cls(config)
     if getattr(self, "use_peri_ln_mlp", False):
-        self.peri_ln_mlp = norm_cls(config)
+        self.peri_ln_mlp = mlp_norm_cls(config)
 
     # Post-LN
     if getattr(self, "use_post_ln_attn", False):
-        self.post_ln_attn = norm_cls(config)
+        self.post_ln_attn = attn_norm_cls(config)
     if getattr(self, "use_post_ln_mlp", False):
-        self.post_ln_mlp = norm_cls(config)
+        self.post_ln_mlp = mlp_norm_cls(config)
 
 
 normalization_setup_variations = {
@@ -374,8 +399,12 @@ class Block(nn.Module):
     def __init__(self, config, mlp=None, attn=None):
         super().__init__()
 
-        # Choose norm class for attention/MLP blocks
-        norm_cls = norm_dictionary[config.norm_variant_attn]
+        # Choose norm classes for attention and MLP block norms.
+        # ``norm_variant_mlp=None`` intentionally falls back to the attention
+        # norm, so older configs and checkpoints keep their exact architecture.
+        attn_norm_cls = norm_dictionary[config.norm_variant_attn]
+        mlp_norm_variant = getattr(config, "norm_variant_mlp", None) or config.norm_variant_attn
+        mlp_norm_cls = norm_dictionary[mlp_norm_variant]
 
         # Resolve per-unit norm flags from config (pre/post/peri × attn/mlp)
         _resolve_unit_norm_flags(self, config)
@@ -412,7 +441,7 @@ class Block(nn.Module):
         self.block_forward = partial(block_forward_variations[variant], self)
 
         ## Instantiate norms for Block Forward Variant
-        normalization_setup_variations[variant](self, config, norm_cls)
+        normalization_setup_variations[variant](self, config, (attn_norm_cls, mlp_norm_cls))
 
         ## Instantiate (Optional) learned residual scalers for Block Forward Variant
         resid_scaler_setup_variations[variant](self, config)

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -296,54 +296,60 @@ def _resolve_unit_norm_flags(self, config) -> None:
 
 def _setup_norms_parallel(self, config, norm_classes) -> None:
     """Norm layout for the 'parallel_mlp' variation."""
-    attn_norm_cls, mlp_norm_cls = norm_classes
+    attn_input_norm_cls = norm_classes["attn_input"]
+    attn_output_norm_cls = norm_classes["attn_output"]
+    mlp_input_norm_cls = norm_classes["mlp_input"]
+    mlp_output_norm_cls = norm_classes["mlp_output"]
 
     # Pre-LN. If both branches use the same norm variant through the legacy
     # global flag, keep a shared ``pre_ln`` module for checkpoint compatibility.
-    if getattr(self, "use_pre_ln_attn", False) and getattr(self, "use_pre_ln_mlp", False) and attn_norm_cls is mlp_norm_cls:
-        self.pre_ln = attn_norm_cls(config)
+    if getattr(self, "use_pre_ln_attn", False) and getattr(self, "use_pre_ln_mlp", False) and attn_input_norm_cls is mlp_input_norm_cls:
+        self.pre_ln = attn_input_norm_cls(config)
     else:
         if getattr(self, "use_pre_ln_attn", False):
-            self.pre_ln_attn = attn_norm_cls(config)
+            self.pre_ln_attn = attn_input_norm_cls(config)
         if getattr(self, "use_pre_ln_mlp", False):
-            self.pre_ln_mlp = mlp_norm_cls(config)
+            self.pre_ln_mlp = mlp_input_norm_cls(config)
 
     # Peri-LN
     if getattr(self, "use_peri_ln_attn", False):
-        self.peri_ln_attn = attn_norm_cls(config)
+        self.peri_ln_attn = attn_output_norm_cls(config)
     if getattr(self, "use_peri_ln_mlp", False):
-        self.peri_ln_mlp = mlp_norm_cls(config)
+        self.peri_ln_mlp = mlp_output_norm_cls(config)
 
     # Post-LN. Preserve the historical shared post_ln when possible.
-    if getattr(self, "use_post_ln_attn", False) and getattr(self, "use_post_ln_mlp", False) and attn_norm_cls is mlp_norm_cls:
-        self.post_ln = attn_norm_cls(config)
+    if getattr(self, "use_post_ln_attn", False) and getattr(self, "use_post_ln_mlp", False) and attn_output_norm_cls is mlp_output_norm_cls:
+        self.post_ln = attn_output_norm_cls(config)
     else:
         if getattr(self, "use_post_ln_attn", False):
-            self.post_ln_attn = attn_norm_cls(config)
+            self.post_ln_attn = attn_output_norm_cls(config)
         if getattr(self, "use_post_ln_mlp", False):
-            self.post_ln_mlp = mlp_norm_cls(config)
+            self.post_ln_mlp = mlp_output_norm_cls(config)
 
 def _setup_norms_sequential(self, config, norm_classes) -> None:
     """Norm layout for the 'attn_then_mlp' variation."""
-    attn_norm_cls, mlp_norm_cls = norm_classes
+    attn_input_norm_cls = norm_classes["attn_input"]
+    attn_output_norm_cls = norm_classes["attn_output"]
+    mlp_input_norm_cls = norm_classes["mlp_input"]
+    mlp_output_norm_cls = norm_classes["mlp_output"]
 
     # Pre-Norm
     if getattr(self, "use_pre_ln_attn", False):
-        self.pre_ln_attn = attn_norm_cls(config)
+        self.pre_ln_attn = attn_input_norm_cls(config)
     if getattr(self, "use_pre_ln_mlp", False):
-        self.pre_ln_mlp = mlp_norm_cls(config)
+        self.pre_ln_mlp = mlp_input_norm_cls(config)
 
     # Peri-LN
     if getattr(self, "use_peri_ln_attn", False):
-        self.peri_ln_attn = attn_norm_cls(config)
+        self.peri_ln_attn = attn_output_norm_cls(config)
     if getattr(self, "use_peri_ln_mlp", False):
-        self.peri_ln_mlp = mlp_norm_cls(config)
+        self.peri_ln_mlp = mlp_output_norm_cls(config)
 
     # Post-LN
     if getattr(self, "use_post_ln_attn", False):
-        self.post_ln_attn = attn_norm_cls(config)
+        self.post_ln_attn = attn_output_norm_cls(config)
     if getattr(self, "use_post_ln_mlp", False):
-        self.post_ln_mlp = mlp_norm_cls(config)
+        self.post_ln_mlp = mlp_output_norm_cls(config)
 
 
 normalization_setup_variations = {
@@ -399,12 +405,18 @@ class Block(nn.Module):
     def __init__(self, config, mlp=None, attn=None):
         super().__init__()
 
-        # Choose norm classes for attention and MLP block norms.
-        # ``norm_variant_mlp=None`` intentionally falls back to the attention
-        # norm, so older configs and checkpoints keep their exact architecture.
-        attn_norm_cls = norm_dictionary[config.norm_variant_attn]
-        mlp_norm_variant = getattr(config, "norm_variant_mlp", None) or config.norm_variant_attn
-        mlp_norm_cls = norm_dictionary[mlp_norm_variant]
+        # Choose norm classes for attention and MLP block norms. Granular
+        # input/output variants fall back to their component defaults;
+        # ``norm_variant_mlp=None`` falls back to the attention default for
+        # older configs and checkpoints.
+        attn_norm_variant = config.norm_variant_attn
+        mlp_norm_variant = getattr(config, "norm_variant_mlp", None) or attn_norm_variant
+        norm_classes = {
+            "attn_input": norm_dictionary[getattr(config, "norm_variant_attn_input", None) or attn_norm_variant],
+            "attn_output": norm_dictionary[getattr(config, "norm_variant_attn_output", None) or attn_norm_variant],
+            "mlp_input": norm_dictionary[getattr(config, "norm_variant_mlp_input", None) or mlp_norm_variant],
+            "mlp_output": norm_dictionary[getattr(config, "norm_variant_mlp_output", None) or mlp_norm_variant],
+        }
 
         # Resolve per-unit norm flags from config (pre/post/peri × attn/mlp)
         _resolve_unit_norm_flags(self, config)
@@ -441,7 +453,7 @@ class Block(nn.Module):
         self.block_forward = partial(block_forward_variations[variant], self)
 
         ## Instantiate norms for Block Forward Variant
-        normalization_setup_variations[variant](self, config, (attn_norm_cls, mlp_norm_cls))
+        normalization_setup_variations[variant](self, config, norm_classes)
 
         ## Instantiate (Optional) learned residual scalers for Block Forward Variant
         resid_scaler_setup_variations[variant](self, config)

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -224,6 +224,28 @@ class IdentityNorm(nn.Module):
         return self.identity(x)
 
 
+class StraightThroughNorm(nn.Module):
+    """Apply a norm forward while differentiating through an activation."""
+
+    def __init__(self, config):
+        super().__init__()
+        forward_variant = config.ste_norm_forward_variant
+        if forward_variant == "ste_norm":
+            raise ValueError("ste_norm cannot wrap itself")
+
+        self.forward_norm = norm_dictionary[forward_variant](config)
+        self.backward_activation = activation_dictionary[
+            config.ste_norm_backward_activation
+        ](config)
+
+    def forward(self, x):
+        forward_value = self.forward_norm(x)
+        backward_value = self.backward_activation(x)
+        # This has the norm's value, but only the activation branch contributes
+        # gradients. With the default identity activation, d(output)/d(x) = 1.
+        return backward_value + (forward_value - backward_value).detach()
+
+
 norm_dictionary = {
     "layernorm": LayerNorm,
     "rmsnorm": RMSNorm,
@@ -233,4 +255,5 @@ norm_dictionary = {
     "dact": DynamicActivation,
     "identity": IdentityNorm,
     "cappedhyperspherenorm": CappedHyperSphereNorm,
+    "ste_norm": StraightThroughNorm,
 }

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -239,11 +239,11 @@ class StraightThroughNorm(nn.Module):
         ](config)
 
     def forward(self, x):
-        forward_value = self.forward_norm(x)
+        forward_value = self.forward_norm(x.detach())
         backward_value = self.backward_activation(x)
-        # This has the norm's value, but only the activation branch contributes
-        # gradients. With the default identity activation, d(output)/d(x) = 1.
-        return backward_value + (forward_value - backward_value).detach()
+        # Forward uses the norm's value, but gradients to x follow the activation.
+        # Gradients to the norm parameters are preserved via forward_norm(x.detach()).
+        return forward_value + (backward_value - backward_value.detach())
 
 
 norm_dictionary = {


### PR DESCRIPTION
This pull request introduces a more granular and configurable normalization scheme for transformer blocks, enabling independent selection of norm variants at each input/output site for both attention and MLP branches. It also adds a new "straight-through" normalization mode and updates configuration, argument parsing, and block construction logic to support these features.

**Granular normalization configuration:**
- Added new config fields and CLI arguments to independently specify norm variants for attention and MLP input/output sites (`norm_variant_attn_input`, `norm_variant_attn_output`, `norm_variant_mlp_input`, `norm_variant_mlp_output`, and `norm_variant_mlp`). These fall back to legacy defaults for compatibility. [[1]](diffhunk://#diff-114e7747956438292f72cb8316c075c30638fe5c68dab6a7ac466f33639df288R399-R414) [[2]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R834-R872)

**Straight-through normalization:**
- Introduced the `StraightThroughNorm` class (and `ste_norm` variant), which applies a norm in the forward pass but uses a different activation's gradient in the backward pass. Added config/CLI options to select the forward norm and backward activation. [[1]](diffhunk://#diff-fa194c1c5a34923267fe225203e5ea5b12859caff64754ec5eb69348096a143eR227-R248) [[2]](diffhunk://#diff-fa194c1c5a34923267fe225203e5ea5b12859caff64754ec5eb69348096a143eR258) [[3]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R945-R960) [[4]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R363)

**Block construction and norm setup:**
- Refactored block norm setup to instantiate separate norm modules for each site, preserving shared modules for compatibility when possible. Updated block forward logic to use the correct norm modules for each branch and site. [[1]](diffhunk://#diff-80b09083f457c585f1734a4319144b22de22c71af90750143b9ae8d226a9ba0aL286-R352) [[2]](diffhunk://#diff-80b09083f457c585f1734a4319144b22de22c71af90750143b9ae8d226a9ba0aL377-R419) [[3]](diffhunk://#diff-80b09083f457c585f1734a4319144b22de22c71af90750143b9ae8d226a9ba0aL415-R456) [[4]](diffhunk://#diff-80b09083f457c585f1734a4319144b22de22c71af90750143b9ae8d226a9ba0aL83-R94) [[5]](diffhunk://#diff-80b09083f457c585f1734a4319144b22de22c71af90750143b9ae8d226a9ba0aL107-R120)

**Experiment configuration:**
- Added a new YAML sweep (`muon_granular_norm_explore.yaml`) to explore all combinations of RMSNorm/HyperSphereNorm across attention and MLP normalization sites, leveraging the new granular configuration.