### PR TITLE
Add hf semantic factorization study

### DIFF
--- a/analysis/tokenizer_analysis/README.md
+++ b/analysis/tokenizer_analysis/README.md
@@ -14,8 +14,17 @@ replaced by a base row plus an orthographic feature. It applies these rules:
 3. Replace a token whose cased characters are all uppercase with
    `ALL_CAPS + lower(token)` when that counterpart exists.
 
-The rule sets overlap, so savings use their **union**, not their sum. On the
-`google/gemma-3-270m` `tokenizer.json` vocabulary (262,144 BPE tokens):
+The rule sets overlap, so savings use their **union**, not their sum. The CLI
+compares these defaults: `google/gemma-3-270m`, `Qwen/Qwen3-0.6B` (the released
+model is 0.6 **billion**, not 0.6 million), and tiktoken's `o200k_base`.
+
+| Vocabulary/head | Before | Unique removed | After | Reduction |
+|---|---:|---:|---:|---:|
+| Gemma 3 270M | 262,144 | 65,035 | 197,109 | 24.81% |
+| Qwen 3 0.6B | 151,936 | 32,799 | 119,137 | 21.59% |
+| tiktoken `o200k_base` | 200,019 | 47,022 | 152,997 | 23.51% |
+
+Gemma's per-rule detail is:
 
 | Rule | Matches | Newly removed in rule order |
 |---|---:|---:|
@@ -31,12 +40,37 @@ does not claim an immediately usable tokenizer: BPE merges referring to removed
 tokens must be rewritten, encoding must emit base-plus-feature structure, and
 the model must be trained or fine-tuned with compositional input/output heads.
 
-After accepting the Gemma license on Hugging Face, download `tokenizer.json` and
-run the reproducible analysis:
+Install the repository requirements, accept the Gemma license on Hugging Face,
+set `HF_TOKEN`, and run all defaults:
 
 ```bash
-python analysis/tokenizer_analysis/semantic_factorization.py /path/to/tokenizer.json
+python analysis/tokenizer_analysis/semantic_factorization.py
 ```
+
+Add any number of Hugging Face models or tiktoken encodings; one inaccessible
+model produces a warning without preventing the other comparisons:
+
+```bash
+python analysis/tokenizer_analysis/semantic_factorization.py \
+  --hf-model meta-llama/Llama-3.2-1B \
+  --hf-model Qwen/Qwen3-4B \
+  --tiktoken-encoding cl100k_base
+```
+
+Use `--no-defaults` to analyze only the explicitly supplied sources. Local
+Hugging Face tokenizer JSON files can also be positional arguments:
+
+```bash
+python analysis/tokenizer_analysis/semantic_factorization.py \
+  --no-defaults /path/to/tokenizer.json
+```
+
+For Hugging Face model IDs, `config.vocab_size` defines the current head size;
+unused/padded IDs remain in the estimate and added tokenizer IDs beyond the head
+are excluded. For tiktoken, `n_vocab` defines the extent, including reserved
+holes. Invalid UTF-8 byte fragments are retained but conservatively considered
+non-factorizable. A standalone tokenizer JSON has no model config, so its
+`model.vocab` length is used.
 
 A practical implementation can represent a factored token as
 `(base_id, feature_mask)`. For input embeddings, add learned feature vectors to

--- a/analysis/tokenizer_analysis/README.md
+++ b/analysis/tokenizer_analysis/README.md
@@ -1,5 +1,51 @@
 # Open Source CJK Analysis Tool
 
+## Gemma 3 270M semantic factorization
+
+`semantic_factorization.py` estimates how many embedding/LM-head rows can be
+replaced by a base row plus an orthographic feature. It applies these rules:
+
+1. Replace `▁token` with `SPACE + token` when `token` exists. Gemma's tokenizer
+   normalizer uses `▁` (U+2581) for a space; the vocabulary does not store a
+   literal leading ASCII space.
+2. Replace a token beginning with an uppercase Unicode character with
+   `CAPITALIZE + lower-first(token)` when that counterpart exists. A leading
+   `▁` is ignored while identifying the first character.
+3. Replace a token whose cased characters are all uppercase with
+   `ALL_CAPS + lower(token)` when that counterpart exists.
+
+The rule sets overlap, so savings use their **union**, not their sum. On the
+`google/gemma-3-270m` `tokenizer.json` vocabulary (262,144 BPE tokens):
+
+| Rule | Matches | Newly removed in rule order |
+|---|---:|---:|
+| Leading space | 40,893 | 40,893 |
+| Initial capital | 27,786 | 18,530 |
+| All caps | 8,859 | 5,612 |
+| **Unique total** | **65,035** | **65,035** |
+
+That reduces the estimated vocabulary/head from **262,144 to 197,109 rows**, a
+**24.81%** reduction. The estimate does not count three new feature vectors; if
+they occupy ordinary vocabulary rows, the physical total is 197,112. It also
+does not claim an immediately usable tokenizer: BPE merges referring to removed
+tokens must be rewritten, encoding must emit base-plus-feature structure, and
+the model must be trained or fine-tuned with compositional input/output heads.
+
+After accepting the Gemma license on Hugging Face, download `tokenizer.json` and
+run the reproducible analysis:
+
+```bash
+python analysis/tokenizer_analysis/semantic_factorization.py /path/to/tokenizer.json
+```
+
+A practical implementation can represent a factored token as
+`(base_id, feature_mask)`. For input embeddings, add learned feature vectors to
+the base embedding. For the output head, score the base rows once and predict
+the three feature bits with small auxiliary heads (or score only valid
+base/feature combinations). Retokenize training data and fine-tune before using
+the smaller head; simply deleting rows changes sequence boundaries and cannot
+reproduce the original BPE model.
+
 This repository contains the **Open Source CJK Analysis Tool**, a Python script (`open_source_cjk_analysis.py`) that provides detailed analysis of tokenizers with respect to Chinese (C), Japanese (J), and Korean (K) characters. The tool can analyze token coverage, symbol representation, and overlaps among these languages in tokenizer vocabularies.
 
 ## Features

--- a/analysis/tokenizer_analysis/semantic_factorization.py
+++ b/analysis/tokenizer_analysis/semantic_factorization.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
-"""Estimate vocabulary savings from factoring orthographic token features."""
+"""Compare orthographic vocabulary factorization across tokenizer families."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-SPACE_MARKER = "▁"
+DEFAULT_HF_MODELS = ("google/gemma-3-270m", "Qwen/Qwen3-0.6B")
+DEFAULT_TIKTOKEN_ENCODINGS = ("o200k_base",)
+SPACE_MARKERS = ("▁", "Ġ", " ")
 
 
 @dataclass(frozen=True)
@@ -27,15 +31,20 @@ class FactorizationResult:
     def factorized_vocabulary_size(self) -> int:
         return self.vocabulary_size - len(self.removed)
 
+    @property
+    def reduction_percent(self) -> float:
+        return 100 * len(self.removed) / self.vocabulary_size if self.vocabulary_size else 0.0
+
     def exclusive_counts(self) -> tuple[int, int, int]:
-        """Return counts attributed in the requested space/capital/caps order."""
         capital = self.initial_capital - self.leading_space
         all_caps = self.all_caps - self.leading_space - self.initial_capital
         return len(self.leading_space), len(capital), len(all_caps)
 
 
-def _split_space_marker(token: str) -> tuple[str, str]:
-    return (SPACE_MARKER, token[1:]) if token.startswith(SPACE_MARKER) else ("", token)
+def _split_space_marker(token: str, marker: str) -> tuple[str, str]:
+    if token.startswith(marker):
+        return marker, token[len(marker) :]
+    return "", token
 
 
 def _has_case(character: str) -> bool:
@@ -43,27 +52,24 @@ def _has_case(character: str) -> bool:
 
 
 def analyze_tokens(tokens: Iterable[str]) -> FactorizationResult:
-    """Find tokens having exact base-token counterparts under three rules.
-
-    Capitalization rules inspect the first decoded non-space character. This
-    makes the features composable: ``▁Hello`` may carry SPACE and CAPITALIZE.
-    Unicode's ``str.lower`` and ``str.isupper`` semantics are used.
-    """
+    """Find rows with exact counterparts under SPACE, CAPITALIZE, or ALL_CAPS."""
     vocabulary = frozenset(tokens)
+    # Tokenizer families serialize space differently. Select one convention for
+    # the whole vocabulary so a literal Ġ in SentencePiece is not misread as a
+    # byte-level-BPE marker (and vice versa).
+    space_marker = max(SPACE_MARKERS, key=lambda marker: sum(token.startswith(marker) for token in vocabulary))
     leading_space: set[str] = set()
     initial_capital: set[str] = set()
     all_caps: set[str] = set()
 
     for token in vocabulary:
-        if token.startswith(SPACE_MARKER) and len(token) > 1 and token[1:] in vocabulary:
+        prefix, text = _split_space_marker(token, space_marker)
+        if prefix and text and text in vocabulary:
             leading_space.add(token)
-
-        prefix, text = _split_space_marker(token)
         if text and text[0].isupper():
             counterpart = prefix + text[0].lower() + text[1:]
             if counterpart != token and counterpart in vocabulary:
                 initial_capital.add(token)
-
         cased_characters = [character for character in text if _has_case(character)]
         if cased_characters and all(character.isupper() for character in cased_characters):
             counterpart = prefix + text.lower()
@@ -71,45 +77,128 @@ def analyze_tokens(tokens: Iterable[str]) -> FactorizationResult:
                 all_caps.add(token)
 
     return FactorizationResult(
-        vocabulary_size=len(vocabulary),
-        leading_space=frozenset(leading_space),
-        initial_capital=frozenset(initial_capital),
-        all_caps=frozenset(all_caps),
+        len(vocabulary), frozenset(leading_space), frozenset(initial_capital), frozenset(all_caps)
     )
 
 
 def load_tokenizer_vocabulary(path: Path) -> dict[str, int]:
-    """Load the BPE vocabulary from a Hugging Face ``tokenizer.json`` file."""
+    """Load the model vocabulary from a Hugging Face ``tokenizer.json``."""
     with path.open(encoding="utf-8") as tokenizer_file:
         document = json.load(tokenizer_file)
     vocabulary = document.get("model", {}).get("vocab")
+    if isinstance(vocabulary, list):  # Unigram tokenizer JSON uses [token, score] rows.
+        if not all(isinstance(row, list) and row and isinstance(row[0], str) for row in vocabulary):
+            raise ValueError(f"{path} has an invalid model.vocab")
+        vocabulary = {row[0]: index for index, row in enumerate(vocabulary)}
     if not isinstance(vocabulary, dict):
-        raise ValueError(f"{path} does not contain an object at model.vocab")
+        raise ValueError(f"{path} does not contain a supported model.vocab")
     if not all(isinstance(token, str) and isinstance(token_id, int) for token, token_id in vocabulary.items()):
         raise ValueError(f"{path} has an invalid model.vocab")
     return vocabulary
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tokenizer_json", type=Path, help="Downloaded Hugging Face tokenizer.json")
-    parser.add_argument("--examples", type=int, default=5, help="Examples printed for each rule")
-    args = parser.parse_args()
+def load_huggingface_vocabulary(model_name: str) -> dict[str, int]:
+    """Load any Hugging Face tokenizer through Transformers."""
+    try:
+        from transformers import AutoConfig, AutoTokenizer
+    except ImportError as error:
+        raise RuntimeError("Hugging Face models require `pip install transformers`") from error
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    tokenizer = AutoTokenizer.from_pretrained(model_name, token=token)
+    config = AutoConfig.from_pretrained(model_name, token=token)
+    head_size = int(getattr(config, "vocab_size", 0) or tokenizer.vocab_size)
+    vocabulary = {text: token_id for text, token_id in tokenizer.get_vocab().items() if token_id < head_size}
+    used_ids = set(vocabulary.values())
+    for token_id in range(head_size):
+        if token_id not in used_ids:
+            vocabulary[f"<reserved:{token_id}>"] = token_id
+    return vocabulary
 
-    vocabulary = load_tokenizer_vocabulary(args.tokenizer_json)
+
+def load_tiktoken_vocabulary(encoding_name: str) -> dict[str, int]:
+    """Expose a tiktoken encoding as comparable token strings.
+
+    Valid UTF-8 byte tokens use their decoded text. Invalid byte fragments get
+    a private diagnostic spelling and therefore cannot produce false matches.
+    """
+    try:
+        import tiktoken
+    except ImportError as error:
+        raise RuntimeError("tiktoken encodings require `pip install tiktoken`") from error
+    encoding = tiktoken.get_encoding(encoding_name)
+    vocabulary: dict[str, int] = dict(encoding._special_tokens)
+    used_ids = set(vocabulary.values())
+    for raw, token_id in encoding._mergeable_ranks.items():
+        used_ids.add(token_id)
+        try:
+            token = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            token = f"<invalid-utf8:{raw.hex()}>"
+        vocabulary[token] = token_id
+    # n_vocab is the embedding/head extent. Preserve reserved holes so the
+    # before/after comparison does not pretend those rows have disappeared.
+    for token_id in range(encoding.n_vocab):
+        if token_id not in used_ids:
+            vocabulary[f"<reserved:{token_id}>"] = token_id
+    return vocabulary
+
+
+def _print_detail(label: str, vocabulary: dict[str, int], examples: int) -> FactorizationResult:
     result = analyze_tokens(vocabulary)
     exclusive = result.exclusive_counts()
-    rules = (
+    print(f"\n{label}")
+    for name, matches, newly_removed in (
         ("leading space", result.leading_space, exclusive[0]),
         ("initial capital", result.initial_capital, exclusive[1]),
         ("all caps", result.all_caps, exclusive[2]),
-    )
-    print(f"before: {result.vocabulary_size:,}")
-    for label, matches, exclusive_count in rules:
-        examples = sorted(matches, key=vocabulary.get)[: args.examples]
-        print(f"{label}: {len(matches):,} matches; {exclusive_count:,} newly removed; examples={examples!r}")
-    print(f"unique rows removed: {len(result.removed):,}")
-    print(f"after: {result.factorized_vocabulary_size:,}")
+    ):
+        sample = sorted(matches, key=vocabulary.get)[:examples]
+        print(f"  {name}: {len(matches):,} matches; {newly_removed:,} newly removed; examples={sample!r}")
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tokenizer_json", nargs="*", type=Path, help="Local Hugging Face tokenizer.json files")
+    parser.add_argument("--hf-model", action="append", default=[], help="Hugging Face model ID (repeatable)")
+    parser.add_argument("--tiktoken-encoding", action="append", default=[], help="tiktoken encoding (repeatable)")
+    parser.add_argument("--no-defaults", action="store_true", help="Do not include Gemma, Qwen, and o200k_base defaults")
+    parser.add_argument("--examples", type=int, default=3)
+    args = parser.parse_args()
+
+    hf_models = list(args.hf_model)
+    tiktoken_encodings = list(args.tiktoken_encoding)
+    if not args.no_defaults:
+        hf_models = list(DEFAULT_HF_MODELS) + hf_models
+        tiktoken_encodings = list(DEFAULT_TIKTOKEN_ENCODINGS) + tiktoken_encodings
+
+    sources = [(f"file:{path}", lambda path=path: load_tokenizer_vocabulary(path)) for path in args.tokenizer_json]
+    sources += [(f"hf:{name}", lambda name=name: load_huggingface_vocabulary(name)) for name in hf_models]
+    sources += [(f"tiktoken:{name}", lambda name=name: load_tiktoken_vocabulary(name)) for name in tiktoken_encodings]
+    if not sources:
+        parser.error("no tokenizer sources selected")
+
+    results: list[tuple[str, FactorizationResult]] = []
+    failures = 0
+    for label, loader in sources:
+        try:
+            vocabulary = loader()
+            results.append((label, _print_detail(label, vocabulary, args.examples)))
+        except Exception as error:  # Continue comparing independently loadable sources.
+            failures += 1
+            print(f"warning: could not analyze {label}: {error}", file=sys.stderr)
+
+    if not results:
+        raise SystemExit("no tokenizer could be analyzed")
+    print("\nComparison")
+    print(f"{'source':<38} {'before':>12} {'removed':>12} {'after':>12} {'reduction':>10}")
+    for label, result in results:
+        print(
+            f"{label:<38} {result.vocabulary_size:>12,} {len(result.removed):>12,} "
+            f"{result.factorized_vocabulary_size:>12,} {result.reduction_percent:>9.2f}%"
+        )
+    if failures:
+        print(f"\n{failures} source(s) failed; see warnings above.", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/analysis/tokenizer_analysis/semantic_factorization.py
+++ b/analysis/tokenizer_analysis/semantic_factorization.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Estimate vocabulary savings from factoring orthographic token features."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+SPACE_MARKER = "▁"
+
+
+@dataclass(frozen=True)
+class FactorizationResult:
+    vocabulary_size: int
+    leading_space: frozenset[str]
+    initial_capital: frozenset[str]
+    all_caps: frozenset[str]
+
+    @property
+    def removed(self) -> frozenset[str]:
+        return self.leading_space | self.initial_capital | self.all_caps
+
+    @property
+    def factorized_vocabulary_size(self) -> int:
+        return self.vocabulary_size - len(self.removed)
+
+    def exclusive_counts(self) -> tuple[int, int, int]:
+        """Return counts attributed in the requested space/capital/caps order."""
+        capital = self.initial_capital - self.leading_space
+        all_caps = self.all_caps - self.leading_space - self.initial_capital
+        return len(self.leading_space), len(capital), len(all_caps)
+
+
+def _split_space_marker(token: str) -> tuple[str, str]:
+    return (SPACE_MARKER, token[1:]) if token.startswith(SPACE_MARKER) else ("", token)
+
+
+def _has_case(character: str) -> bool:
+    return character.lower() != character.upper()
+
+
+def analyze_tokens(tokens: Iterable[str]) -> FactorizationResult:
+    """Find tokens having exact base-token counterparts under three rules.
+
+    Capitalization rules inspect the first decoded non-space character. This
+    makes the features composable: ``▁Hello`` may carry SPACE and CAPITALIZE.
+    Unicode's ``str.lower`` and ``str.isupper`` semantics are used.
+    """
+    vocabulary = frozenset(tokens)
+    leading_space: set[str] = set()
+    initial_capital: set[str] = set()
+    all_caps: set[str] = set()
+
+    for token in vocabulary:
+        if token.startswith(SPACE_MARKER) and len(token) > 1 and token[1:] in vocabulary:
+            leading_space.add(token)
+
+        prefix, text = _split_space_marker(token)
+        if text and text[0].isupper():
+            counterpart = prefix + text[0].lower() + text[1:]
+            if counterpart != token and counterpart in vocabulary:
+                initial_capital.add(token)
+
+        cased_characters = [character for character in text if _has_case(character)]
+        if cased_characters and all(character.isupper() for character in cased_characters):
+            counterpart = prefix + text.lower()
+            if counterpart != token and counterpart in vocabulary:
+                all_caps.add(token)
+
+    return FactorizationResult(
+        vocabulary_size=len(vocabulary),
+        leading_space=frozenset(leading_space),
+        initial_capital=frozenset(initial_capital),
+        all_caps=frozenset(all_caps),
+    )
+
+
+def load_tokenizer_vocabulary(path: Path) -> dict[str, int]:
+    """Load the BPE vocabulary from a Hugging Face ``tokenizer.json`` file."""
+    with path.open(encoding="utf-8") as tokenizer_file:
+        document = json.load(tokenizer_file)
+    vocabulary = document.get("model", {}).get("vocab")
+    if not isinstance(vocabulary, dict):
+        raise ValueError(f"{path} does not contain an object at model.vocab")
+    if not all(isinstance(token, str) and isinstance(token_id, int) for token, token_id in vocabulary.items()):
+        raise ValueError(f"{path} has an invalid model.vocab")
+    return vocabulary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tokenizer_json", type=Path, help="Downloaded Hugging Face tokenizer.json")
+    parser.add_argument("--examples", type=int, default=5, help="Examples printed for each rule")
+    args = parser.parse_args()
+
+    vocabulary = load_tokenizer_vocabulary(args.tokenizer_json)
+    result = analyze_tokens(vocabulary)
+    exclusive = result.exclusive_counts()
+    rules = (
+        ("leading space", result.leading_space, exclusive[0]),
+        ("initial capital", result.initial_capital, exclusive[1]),
+        ("all caps", result.all_caps, exclusive[2]),
+    )
+    print(f"before: {result.vocabulary_size:,}")
+    for label, matches, exclusive_count in rules:
+        examples = sorted(matches, key=vocabulary.get)[: args.examples]
+        print(f"{label}: {len(matches):,} matches; {exclusive_count:,} newly removed; examples={examples!r}")
+    print(f"unique rows removed: {len(result.removed):,}")
+    print(f"after: {result.factorized_vocabulary_size:,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/tokenizer_analysis/test_semantic_factorization.py
+++ b/analysis/tokenizer_analysis/test_semantic_factorization.py
@@ -1,8 +1,15 @@
 import json
+import sys
+from types import SimpleNamespace
 
 import pytest
 
-from semantic_factorization import analyze_tokens, load_tokenizer_vocabulary
+from semantic_factorization import (
+    analyze_tokens,
+    load_huggingface_vocabulary,
+    load_tiktoken_vocabulary,
+    load_tokenizer_vocabulary,
+)
 
 
 def test_factorization_rules_and_overlap():
@@ -21,6 +28,14 @@ def test_all_caps_requires_a_cased_character_and_counterpart():
     assert not analyze_tokens({"123", "!", "ABC", "mixed", "▁MISSING"}).all_caps
 
 
+def test_common_space_representations_are_supported():
+    assert analyze_tokens({"word", "Ġword"}).leading_space == {"Ġword"}
+    result = analyze_tokens({"word", " word", "Word", " WORD"})
+    assert result.leading_space == {" word"}
+    assert result.initial_capital == {"Word"}
+    assert result.all_caps == {" WORD"}
+
+
 def test_load_tokenizer_vocabulary(tmp_path):
     path = tmp_path / "tokenizer.json"
     path.write_text(json.dumps({"model": {"vocab": {"a": 0, "A": 1}}}), encoding="utf-8")
@@ -29,6 +44,33 @@ def test_load_tokenizer_vocabulary(tmp_path):
 
 def test_load_tokenizer_vocabulary_rejects_wrong_shape(tmp_path):
     path = tmp_path / "tokenizer.json"
-    path.write_text(json.dumps({"model": {"vocab": []}}), encoding="utf-8")
+    path.write_text(json.dumps({"model": {"vocab": "wrong"}}), encoding="utf-8")
     with pytest.raises(ValueError, match="model.vocab"):
         load_tokenizer_vocabulary(path)
+
+
+def test_load_tiktoken_vocabulary_preserves_reserved_head_rows(monkeypatch):
+    encoding = SimpleNamespace(
+        n_vocab=5,
+        _mergeable_ranks={b"word": 0, b" word": 1, b"\xff": 2},
+        _special_tokens={"<special>": 4},
+    )
+    monkeypatch.setitem(sys.modules, "tiktoken", SimpleNamespace(get_encoding=lambda _name: encoding))
+    vocabulary = load_tiktoken_vocabulary("fake")
+    assert len(vocabulary) == 5
+    assert vocabulary["<reserved:3>"] == 3
+    assert vocabulary["<invalid-utf8:ff>"] == 2
+
+
+def test_huggingface_vocabulary_matches_model_head_extent(monkeypatch):
+    tokenizer = SimpleNamespace(vocab_size=3, get_vocab=lambda: {"a": 0, "b": 2, "added": 5})
+    transformers = SimpleNamespace(
+        AutoTokenizer=SimpleNamespace(from_pretrained=lambda *_args, **_kwargs: tokenizer),
+        AutoConfig=SimpleNamespace(from_pretrained=lambda *_args, **_kwargs: SimpleNamespace(vocab_size=4)),
+    )
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+    vocabulary = load_huggingface_vocabulary("fake/model")
+    assert len(vocabulary) == 4
+    assert vocabulary["<reserved:1>"] == 1
+    assert vocabulary["<reserved:3>"] == 3
+    assert "added" not in vocabulary

--- a/analysis/tokenizer_analysis/test_semantic_factorization.py
+++ b/analysis/tokenizer_analysis/test_semantic_factorization.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+
+from semantic_factorization import analyze_tokens, load_tokenizer_vocabulary
+
+
+def test_factorization_rules_and_overlap():
+    tokens = {"hello", "▁hello", "Hello", "▁Hello", "NASA", "nasa", "▁NASA", "unrelated"}
+    result = analyze_tokens(tokens)
+    assert result.leading_space == {"▁hello", "▁Hello", "▁NASA"}
+    assert result.initial_capital == {"Hello", "▁Hello"}
+    # ▁NASA has no ▁nasa counterpart, so it is removable only by SPACE here.
+    assert result.all_caps == {"NASA"}
+    assert result.exclusive_counts() == (3, 1, 1)
+    assert len(result.removed) == 5
+    assert result.factorized_vocabulary_size == 3
+
+
+def test_all_caps_requires_a_cased_character_and_counterpart():
+    assert not analyze_tokens({"123", "!", "ABC", "mixed", "▁MISSING"}).all_caps
+
+
+def test_load_tokenizer_vocabulary(tmp_path):
+    path = tmp_path / "tokenizer.json"
+    path.write_text(json.dumps({"model": {"vocab": {"a": 0, "A": 1}}}), encoding="utf-8")
+    assert load_tokenizer_vocabulary(path) == {"a": 0, "A": 1}
+
+
+def test_load_tokenizer_vocabulary_rejects_wrong_shape(tmp_path):
+    path = tmp_path / "tokenizer.json"
+    path.write_text(json.dumps({"model": {"vocab": []}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="model.vocab"):
+        load_tokenizer_vocabulary(path)


### PR DESCRIPTION
This pull request introduces a new tool for analyzing and estimating orthographic factorization of vocabularies in various tokenizers, with a focus on Hugging Face and tiktoken models. It adds a detailed README section explaining the methodology and results, provides a robust and extensible CLI implementation, and includes comprehensive unit tests to ensure correctness of the analysis and vocabulary loading logic.

**New semantic factorization tool and documentation:**

* Added `semantic_factorization.py`, a CLI tool that analyzes tokenizer vocabularies for possible reductions via orthographic factorization (leading space, initial capital, all caps), supporting Hugging Face models, tiktoken encodings, and local tokenizer JSON files. The tool reports per-rule and overall vocabulary reduction estimates and handles reserved/unused IDs robustly.
* Extended `README.md` with a thorough explanation of the semantic factorization method, rule descriptions, example results for Gemma 3 270M and other models, and usage instructions for the new CLI tool.

**Testing and validation:**

* Added `test_semantic_factorization.py` with unit tests covering rule overlap logic, vocabulary loading for all supported formats, error handling, and reserved row preservation. Tests use both real and monkeypatched/mock objects for full coverage.