### PR TITLE
Add mel spectrogram tools

### DIFF
--- a/data/mel_spectrogram/.gitignore
+++ b/data/mel_spectrogram/.gitignore
@@ -1,0 +1,5 @@
+mel_out/
+*.wav
+*.flac
+*.mp3
+__pycache__

--- a/data/mel_spectrogram/README_audio_to_token_mel.md
+++ b/data/mel_spectrogram/README_audio_to_token_mel.md
@@ -1,0 +1,757 @@
+# Standalone bounded mel-token roundtrips
+
+This package has two Python scripts and one repeatable demo:
+
+- `audio_to_token_mel.py` decodes any non-DRM audio format supported by the
+  installed FFmpeg build and writes a self-describing CSV, a self-describing
+  QMel-PNG, or both. It can optionally apply a bounded, ladder-specific
+  automatic gain controller before mel analysis.
+- `token_mel_to_audio.py` reconstructs a best-effort mono PCM16 WAV from
+  **one CSV or one PNG**. It does not read a JSON sidecar.
+- `demo.sh` generates both containers and reconstructs each to a distinct WAV.
+
+The CSV has one data row per acoustic timestep. The PNG stores the same
+integer state matrix exactly, not a screenshot or an interpolated plot.
+JSON is now optional diagnostics only (`--write-json`) and is never needed
+for reconstruction.
+
+The forward CPU path uses a memory-mapped FFmpeg decode and batched NumPy
+operations, so the input and full floating-point spectrogram do not need to
+fit in RAM. A CUDA-enabled PyTorch installation can accelerate the forward
+FFT/mel projection and inverse mel/phase iterations.
+
+## Install
+
+Python 3.10 or later:
+
+```bash
+python -m pip install numpy pillow
+```
+
+Install the `ffmpeg` executable with the operating system package manager.
+Pillow is needed only when reading or writing PNG. PyTorch is optional; install
+a CUDA build only if GPU acceleration is wanted. Matplotlib, librosa, and
+soundfile are not required. Keep the two Python scripts in the same directory;
+the inverse imports the shared transform definitions from the forward script.
+
+Verify this five-tier release:
+
+```bash
+python3 audio_to_token_mel.py --version
+# audio_to_token_mel.py 2.3.0
+```
+
+Run the demo with an optional preset and device:
+
+```bash
+bash demo.sh recording.wav
+bash demo.sh recording.flac ultra cuda
+bash demo.sh recording.wav max cpu
+bash demo.sh recording.wav medium cuda mel_out \
+  --columns-per-timestep 32 --states-per-column 48
+bash demo.sh recording.wav medium cpu mel_out \
+  --agc --timestep-ms 12.5
+bash demo.sh recording.wav high cuda mel_out \
+  --agc --columns-per-timestep 64 --states-per-column 128 \
+  --timestep-ms 12.5
+```
+
+## CLI: audio to standalone CSV or PNG
+
+Write both standalone forms (the default):
+
+```bash
+python audio_to_token_mel.py recording.m4a \
+  --preset medium \
+  --output-format both \
+  --output-dir mel_out
+```
+
+Write only CSV:
+
+```bash
+python audio_to_token_mel.py recording.flac \
+  --preset medium \
+  --output-format csv \
+  --output-dir mel_out
+```
+
+Write only QMel-PNG:
+
+```bash
+python audio_to_token_mel.py recording.mp3 \
+  --preset medium \
+  --output-format png \
+  --output-dir mel_out
+```
+
+Generate all five quality levels:
+
+```bash
+python audio_to_token_mel.py interview.mp4 \
+  --preset all \
+  --output-format both \
+  --output-dir mel_out
+```
+
+Use CUDA when a CUDA-enabled PyTorch build is installed, or explicitly keep
+RAM use small on CPU:
+
+```bash
+python audio_to_token_mel.py speech.wav \
+  --preset high --device cuda --batch-frames 512
+
+python audio_to_token_mel.py speech.wav \
+  --preset high --device cpu --batch-frames 128
+```
+
+`Ultra` and especially `max` are compute-heavy on a small CPU. For constrained
+RAM, prefer CSV-only output, lower `--batch-frames` to 32 or 64, and lower
+`--mel-batch-frames` during inversion. The default 80-million-pixel PNG limit
+can represent roughly 160 MB of raw 16-bit raster before Pillow's working
+copies, so set a smaller `--png-max-pixels` when memory is tight. CUDA is
+recommended for routine ultra/max inversion.
+
+JSON remains available for human-readable histograms and diagnostics:
+
+```bash
+python audio_to_token_mel.py speech.wav \
+  --preset medium --write-json
+```
+
+Use `--force` to replace selected outputs and `--describe-presets` to print
+the exact built-in configurations.
+
+### Manual token geometry
+
+Choose a built-in preset for the remaining sample-rate, STFT, mel-range, hop,
+and dB defaults, then override the token matrix dimensions:
+
+```bash
+python audio_to_token_mel.py speech.wav \
+  --preset medium \
+  --columns-per-timestep 32 \
+  --states-per-column 48 \
+  --output-prefix speech.c32.k48 \
+  --output-format both \
+  --output-dir mel_out
+```
+
+Each timestep now contains exactly 32 acoustic values, and each value is a
+zero-based integer in `[0,47]`. `--n-mels 32` and `--levels 48` remain exact
+aliases. `K` need not be a power of two. Self-describing CSV and PNG outputs
+store the actual `C` and `K`, so their normal inverse commands need no matching
+flags. The demo automatically adds `.cC.kK` to custom output prefixes so
+different geometry experiments do not overwrite one another.
+
+The supported bounds are `1 ≤ C ≤ 4,096`, `2 ≤ K ≤ 65,536`, and
+`C×K ≤ 16,777,216`. The last bound caps the per-band diagnostic histogram at
+128 MiB (`8CK` bytes). A chosen `C` must also be feasible for the selected
+FFT and frequency interval; if a mel band would be empty, increase `--n-fft`,
+reduce `C`, or narrow the interval. Overrides cannot be combined with
+`--preset all`.
+
+At frame rate `F`, scalar serialization uses `C×F` tokens per second. Separate
+band/state embeddings require `C×K` learned vectors, while shared level plus
+band embeddings require only `C+K`.
+
+### Direct timestep control
+
+Set the spacing between rows directly with `--timestep-ms`; `--hop-ms` is an
+exact alias:
+
+```bash
+python audio_to_token_mel.py speech.wav \
+  --preset medium \
+  --timestep-ms 12.5 \
+  --output-format both \
+  --output-dir mel_out
+```
+
+The selected preset still supplies the sample rate, analysis window, FFT, mel
+range, columns, states, and dB range. Because a hop must contain a whole number
+of samples, requested time is converted as follows:
+
+```text
+H                = round(sample_rate × requested_timestep_ms / 1000)
+actual timestep  = 1000H / sample_rate  ms
+frame rate F     = sample_rate / H
+rows T           = ceil(decoded_sample_count / H)
+scalar tokens/s  = C × F
+```
+
+The command summary reports `timestep_ms` and `timesteps_per_second` from the
+actual sample-rounded hop, not merely the requested decimal. At the built-in
+medium sample rate, `--timestep-ms 12.5` is exactly 200 samples, 80 rows/s, and
+3,200 scalar tokens/s with the normal 40 columns. Combining it with 32 columns
+reduces that to 2,560 scalar tokens/s:
+
+```bash
+bash demo.sh speech.wav medium cpu mel_out \
+  --columns-per-timestep 32 \
+  --states-per-column 32 \
+  --timestep-ms 12.5
+```
+
+A shorter timestep increases sequence length linearly but does not change
+`K`, the per-column vocabulary. A longer timestep reduces sequence length but
+also reduces temporal detail and eventually makes phase reconstruction less
+stable. The timestep must be positive and no more than half the analysis
+window, so adjacent windows retain at least 50% overlap. Timestep and other
+transform overrides cannot be combined with `--preset all`; run each desired
+preset separately when overriding them.
+
+Self-describing CSV and PNG inputs store the actual integer hop, so their
+inverse commands need no timestep option. For a metadata-free input, give the
+same base preset and original timestep:
+
+```bash
+python token_mel_to_audio.py raw_states.csv \
+  -o recovered.wav \
+  --preset medium \
+  --timestep-ms 12.5
+```
+
+When given with a self-describing input, the inverse timestep option is an
+assertion and fails if its sample-rounded hop disagrees with the stored one.
+The demo adds `.dtMSms` to custom-timestep filenames so they cannot overwrite
+the built-in-timestep outputs.
+
+### Optional ladder-specific automatic gain control
+
+`--agc` enables a bounded broadband waveform gain controller before the STFT.
+It is off by default, so existing transforms remain unchanged. Each quality
+ladder has a profile chosen to trade level consistency against preservation of
+natural speech dynamics:
+
+| Quality | Control interval with built-in timestep | Target RMS | Attack | Release | Maximum boost | Maximum attenuation | Gate | Peak ceiling |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Small, lossy | 20 ms | −18 dBFS | 20 ms | 400 ms | +24 dB | 18 dB | −55 dBFS | −1 dBFS |
+| Medium | 10 ms | −20 dBFS | 10 ms | 500 ms | +24 dB | 24 dB | −60 dBFS | −1 dBFS |
+| High | 10 ms | −22 dBFS | 10 ms | 650 ms | +18 dB | 24 dB | −65 dBFS | −1 dBFS |
+| Ultra | 8 ms | −23 dBFS | 8 ms | 800 ms | +15 dB | 24 dB | −70 dBFS | −1 dBFS |
+| Max | 5 ms | −24 dBFS | 5 ms | 1000 ms | +12 dB | 24 dB | −75 dBFS | −1 dBFS |
+
+Use `--describe-agc` to print the profiles. `--preset all --agc` applies the
+corresponding profile independently to every ladder:
+
+```bash
+python audio_to_token_mel.py interview.wav \
+  --preset all \
+  --agc \
+  --output-format both \
+  --output-dir mel_out
+```
+
+The controller works on mono decoded PCM after the normal global DC removal.
+For each control block it measures RMS and peak, computes a target gain,
+limits that gain by the peak ceiling and the profile's boost/attenuation
+bounds, suppresses positive boost below the gate, and smooths gain in dB with
+separate attack and release constants. It interpolates gain through the block
+and retains a hard peak ceiling as a final safety bound. Processing is
+streamable with one control block of buffering and requires only CPU-scale
+working memory; CUDA still accelerates the mel and inverse operations. When
+`--timestep-ms` changes the hop, it also changes the AGC control interval to
+the actual sample-rounded timestep.
+
+Expert settings can be overridden when `--agc` is present:
+
+```bash
+python audio_to_token_mel.py speech.wav \
+  --preset medium \
+  --agc \
+  --agc-target-dbfs -22 \
+  --agc-attack-ms 15 \
+  --agc-release-ms 700 \
+  --agc-max-gain-db 18 \
+  --agc-max-attenuation-db 24 \
+  --agc-gate-dbfs -65 \
+  --agc-peak-dbfs -1 \
+  --output-format both
+```
+
+`--agc-max-attenuation-db` is a **nonnegative magnitude**: `24` permits the
+controller gain to fall as low as −24 dB. The target must be below the peak
+ceiling, the gate must be below the target, release must not be shorter than
+attack, and all values must be finite. Expert AGC options without `--agc` are
+rejected. The demo forwards these options only to the forward transform and
+adds `.agc` to its filenames.
+
+AGC deliberately does **not** change `top_db`, state thresholds, `K`, or mel
+band gains from one timestep to the next. A token ID must keep one fixed
+meaning throughout a dataset; adapting the quantizer range independently for
+each frame would make identical IDs represent different amplitudes and would
+damage state coverage and out-of-distribution behavior. AGC instead moves the
+broadband waveform toward the fixed quantizer range, while endpoint clipping
+still guarantees every cell is in `[0,K-1]`.
+
+The default `file_percentile` reference is still computed per file and remains
+future-dependent. For model training and deployment, first apply the chosen
+AGC configuration to representative **training data only**, estimate a
+corpus-level mel reference after that preprocessing, then freeze it and use
+`--reference-mode fixed --reference-power VALUE` everywhere. AGC reduces local
+recording-level variation; the frozen reference makes state meanings
+comparable across files and prevents validation or deployment data from
+changing the transform.
+
+AGC is intentionally lossy. The CSV and PNG record that AGC was applied and
+its configuration, but do not store a per-frame gain envelope or add a gain
+token column. Reconstructed audio therefore represents the AGC-normalized
+signal; the original absolute level and loudness envelope cannot be recovered.
+This avoids increasing columns, vocabulary, or token rate. Disable AGC if
+preserving the source's natural dynamics is more important than token
+occupancy. The inverse reports a warning when it encounters AGC metadata.
+
+The design study included the official
+[WebRTC GainController2 source](https://webrtc.googlesource.com/src/+/refs/heads/main/modules/audio_processing/gain_controller2.cc),
+which combines RMS/peak analysis, a noise estimate, headroom, and limiting,
+and WebRTC's
+[adaptive digital gain controller](https://webrtc.googlesource.com/src/+/1deb4f8adeac3cce9565c4a22ad17fa644893e18/modules/audio_processing/agc2/adaptive_digital_gain_controller.cc),
+which bounds gain and gain-change rate. Frame-wise target level, peak
+restriction, smoothing, and bounded amplification were also compared with
+FFmpeg's official
+[Dynamic Audio Normalizer documentation](https://ffmpeg.org/pipermail/ffmpeg-cvslog/2015-July/091728.html)
+and
+[current implementation](https://ffmpeg.org/doxygen/8.0/af__dynaudnorm_8c_source.html).
+This script retains the bounded gain, gate/headroom, smoothing, and limiter
+ideas in a simpler deterministic controller for token preprocessing. It does
+not implement WebRTC's noise estimator and is not bit-compatible with either
+project.
+
+## CLI: one CSV or one PNG back to audio
+
+CSV-only roundtrip:
+
+```bash
+python token_mel_to_audio.py \
+  mel_out/recording.medium.mel.csv \
+  -o recovered_from_csv.wav
+```
+
+PNG-only roundtrip:
+
+```bash
+python token_mel_to_audio.py \
+  mel_out/recording.medium.mel.png \
+  -o recovered_from_png.wav
+```
+
+For a metadata-free raw CSV, use a preset for the remaining transform
+assumptions and state the original manual geometry:
+
+```bash
+python token_mel_to_audio.py raw_states.csv \
+  -o recovered.wav \
+  --preset medium \
+  --columns-per-timestep 32 \
+  --states-per-column 48
+```
+
+These inverse flags are unnecessary for self-describing files. When supplied
+with one, they act only as assertions and fail if they disagree with embedded
+metadata. A metadata-free PNG must be an integer state raster in QMel's strip
+layout (frequency-reversed band rows, time across each strip), rather than a
+plotted spectrogram. For `K > 256`, its pixels must be direct state IDs unless
+it retains the normal QMel pixel header.
+
+CUDA, if available:
+
+```bash
+python token_mel_to_audio.py \
+  mel_out/recording.high.mel.png \
+  -o recovered.wav \
+  --device cuda
+```
+
+A faster, lower-quality CPU inversion uses a pseudoinverse and fewer phase
+iterations:
+
+```bash
+python token_mel_to_audio.py \
+  mel_out/recording.medium.mel.csv \
+  -o recovered_fast.wav \
+  --device cpu \
+  --mel-inverse pinv \
+  --griffin-lim-iters 32
+```
+
+Force a very small phase-recovery working set for a long recording:
+
+```bash
+python token_mel_to_audio.py \
+  mel_out/interview.high.mel.png \
+  -o recovered_low_ram.wav \
+  --device cpu \
+  --griffin-lim-chunk-frames 512 \
+  --griffin-lim-overlap-frames 16
+```
+
+The default uses 32 nonnegative multiplicative mel-inversion iterations and
+64 Griffin-Lim phase iterations. `--mel-batch-frames` bounds each mel inversion
+batch. Long inputs are processed in overlapping 2,048-frame phase chunks with
+32 frames of phase handoff and raised-cosine crossfading; the PCM working file
+is memory-mapped. Use `--griffin-lim-chunk-frames 0` for one global phase solve
+when memory is plentiful, or lower the chunk size to 512 for very small
+machines. Keep the chunk size greater than twice the overlap. `--force` is
+required to overwrite an existing WAV.
+
+By default, `--peak 0` retains the amplitude implied by the stored reference
+power and clips only if PCM full scale is exceeded. Use `--peak 0.95` to opt
+into peak normalization.
+State 0 is decoded as true zero power by default to prevent a silent token
+matrix from becoming broadband hiss. `--floor-mode db-floor` instead decodes
+it at the finite dB floor.
+
+## What is stored in each standalone file
+
+### CSV
+
+The first line is the normal column header. The second line is a compact
+comment beginning with:
+
+```text
+#TOKEN_MEL_CSV_V2
+```
+
+It contains the sample rate and sample count, STFT convention, mel filter
+configuration, quantizer range, reference power, shape, and CRC. Every
+remaining non-comment row is one acoustic timestep. Loaders should ignore
+comment lines; for example, NumPy can use `comments="#"`.
+
+When AGC is enabled, the compact metadata also records the controller
+algorithm, selected ladder profile, effective control interval, bounds, and
+the explicit fact that no reversible gain envelope is stored.
+
+`--include-time-columns` adds `frame_index,time_s` for inspection. Those two
+columns and the metadata comment must not be tokenized.
+
+### QMel-PNG
+
+When `K ≤ 256`, the PNG is indexed mode `P` and each acoustic pixel's palette
+index is the exact integer state ID; this covers the built-in presets through
+`high`. When `K > 256`, it uses mode `I;16`: each state is mapped bijectively
+onto a 16-bit grayscale lattice, then checked and decoded back to the exact
+integer; this covers built-in `ultra` and `max` and applies equally to custom
+overrides. Time is split into horizontal strips for long files, and high
+frequency is displayed at the top. The decoder reverses this layout back to
+the canonical `timesteps × mel_bands` matrix.
+
+Compact reconstruction metadata is stored twice:
+
+1. compressed `iTXt` under `qmel.v2`; and
+2. a complemented, compressed, checksummed pixel header.
+
+The redundant pixel header means reconstruction still works if an otherwise
+lossless PNG rewrite strips ancillary text. Header and padding pixels are
+container data, not acoustic tokens, and the inverse script removes them.
+Indexed PNG handles up to 256 states; 16-bit QMel-PNG handles up to 65,536
+states. Both directions default to an 80-million-pixel safety limit; raise
+`--png-max-pixels` explicitly on both commands for a larger trusted file.
+
+Do not crop, resize, screenshot, convert to JPEG, or convert/re-quantize a
+QMel-PNG. Those operations can destroy state IDs. A legacy plotted RGB
+spectrogram is not equivalent to QMel-PNG: axes, color mapping, interpolation,
+and unknown duration make its inversion heuristic and underdetermined.
+
+## Exact built-in state spaces
+
+All acoustic columns within a preset have the same integer range and number of
+legal states. The dB value is relative to the reference power embedded in the
+same CSV or PNG. Enabling AGC changes waveform levels before analysis, not
+these column counts, legal ranges, or state counts.
+
+| Quality | Sample rate | Window / FFT | Timestep (hop) | Frames/s | Band | Columns per timestep \(C\) | Integer range in every column | States per cell \(K\) | Dequantized dB range | dB step | Scalar tokens/s \(CF\) |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Small, lossy | 12 kHz | 40 ms / 512 | 20 ms | 50 | 50–6000 Hz | **20** | **0…15** | **16** | −48…0 | 3.2000 | **1,000** |
+| Medium | 16 kHz | 25 ms / 512 | 10 ms | 100 | 50–8000 Hz | **40** | **0…63** | **64** | −64…0 | 1.0159 | **4,000** |
+| High | 24 kHz | 25 ms / 1024 | 10 ms | 100 | 20–12000 Hz | **80** | **0…255** | **256** | −80…0 | 0.3137 | **8,000** |
+| Ultra | 32 kHz | 32 ms / 4096 | 8 ms | 125 | 20–16000 Hz | **160** | **0…1023** | **1,024** | −96…0 | 0.0938 | **20,000** |
+| Max | 48 kHz | 32 ms / 8192 | 5 ms | 200 | 20–24000 Hz | **320** | **0…4095** | **4,096** | −112…0 | 0.02735 | **64,000** |
+
+Thus the direct answer for one data row is:
+
+- small: 20 tokenized columns, each an integer in `[0,15]`, 16 possible
+  states per cell;
+- medium: 40 tokenized columns, each an integer in `[0,63]`, 64 possible
+  states per cell;
+- high: 80 tokenized columns, each an integer in `[0,255]`, 256 possible
+  states per cell;
+- ultra: 160 tokenized columns, each an integer in `[0,1023]`, 1,024 possible
+  states per cell;
+- max: 320 tokenized columns, each an integer in `[0,4095]`, 4,096 possible
+  states per cell.
+
+With inverse default `floor-mode=zero`, reconstructed power is in `[0,r]`,
+where `r` is the stored reference power. With `db-floor`, it is in
+`[r × 10^(-D/10), r]`, where `D` is 48, 64, 80, 96, or 112 dB.
+
+These are lossy acoustic feature tiers, not lossless audio codecs. All five
+downmix to mono, discard phase, integrate FFT bins into mel bands, clamp
+dynamic range, and quantize. Ultra and max add bandwidth, mel resolution,
+temporal resolution, FFT-grid density, dynamic range, and amplitude precision,
+but still cannot reproduce the source waveform exactly. Zero padding makes the
+large FFT grids denser; it does not provide the resolving power of an equally
+long analysis window.
+
+The state ladder deliberately adds two bits per tier:
+
+```text
+small  4 bits → medium 6 bits → high 8 bits
+→ ultra 10 bits → max 12 bits
+```
+
+The nominal packed payloads are approximately 4, 24, 64, 200, and 768 kb/s.
+CSV text is larger.
+
+Small now uses a 40 ms window with a 20 ms hop. This adds overlap and materially
+improves phase reconstruction without adding columns, states, frames, or
+tokens compared with a 25 ms/20 ms configuration.
+
+## Quantization and the hard OOD bound
+
+For mel power `S`, stored reference `r`, dB floor `-D`, and `K` levels:
+
+```text
+d     = 10 log10(max(S, epsilon) / r)
+d_bar = clip(d, -D, 0)
+q     = round((d_bar + D) / D × (K - 1))
+```
+
+Consequently:
+
+```text
+q ∈ {0, 1, ..., K - 1}
+```
+
+for every finite input. Extreme low or high values saturate at an endpoint
+rather than creating an out-of-range token ID. Magnitude must not be
+modulo-wrapped: wrapping an over-range loud value to a silence-like ID creates
+a discontinuity. Modulo is appropriate only for circular variables such as
+phase.
+
+The default `file_percentile` reference is the 99.5th percentile of a bounded,
+deterministic sample of mel powers. It handles arbitrary files and stores the
+chosen reference inside each output. It is not ideal for generative model
+training because utterance-level gain is removed and the transform depends on
+future samples.
+
+For train/validation/deployment consistency, estimate a reference from
+training data only, freeze it, and use:
+
+```bash
+python audio_to_token_mel.py clip.wav \
+  --preset medium \
+  --reference-mode fixed \
+  --reference-power YOUR_TRAIN_REFERENCE
+```
+
+If AGC will be enabled, estimate that training reference from audio processed
+with the same frozen AGC profile and overrides. Changing AGC after calibration
+changes the distribution presented to the quantizer.
+
+Hard clipping guarantees legal IDs, but a legal edge ID can still be rare in
+training. Track floor/ceiling rates and state histograms, train with realistic
+gain/noise/channel augmentation, and include the rare endpoints deliberately.
+
+## Vocabulary size versus sequence length
+
+There are four different state-count questions:
+
+| Quality | Shared level IDs \(K\) | Separate `(band,state)` IDs \(CK\) | Factorized band + level vectors \(C+K\) | Whole-row combinations \(K^C\) |
+|---|---:|---:|---:|---:|
+| Small | **16** | 320 | 36 | \(16^{20}=2^{80}\approx1.21\times10^{24}\) |
+| Medium | **64** | 2,560 | 104 | \(64^{40}=2^{240}\approx1.77\times10^{72}\) |
+| High | **256** | 20,480 | 336 | \(256^{80}=2^{640}\approx4.56\times10^{192}\) |
+| Ultra | **1,024** | 163,840 | 1,184 | \(1024^{160}=2^{1600}\approx4.45\times10^{481}\) |
+| Max | **4,096** | 1,310,720 | 4,416 | \(4096^{320}=2^{3840}\approx9.02\times10^{1155}\) |
+
+Do not assign one token to a complete row: almost every row would be unseen.
+If band position is known from the row structure, the same `K` amplitude token
+IDs can be shared across every band. A band-position embedding can be added:
+
+```text
+embedding(c, q) = band_embedding(c) + level_embedding(q)
+```
+
+This changes the learned vector count from `C×K` to `C+K` without increasing
+sequence length. A shared ordinal head, or an embedding generated by a small
+function of normalized `q`, can reduce independently learned parameters
+further while preserving one scalar token per cell.
+
+Factorizing a large level ID into base-4 digits can also reduce embedding
+tables if digits are predicted in parallel:
+
+| Quality | Direct factorized vectors \(C+K\) | Base-4 parallel-factor vectors \(C+4\lceil\log_4K\rceil\) |
+|---|---:|---:|
+| Small | 36 | **28** |
+| Medium | 104 | **52** |
+| High | 336 | **96** |
+| Ultra | 1,184 | **180** |
+| Max | 4,416 | **344** |
+
+Serial digit prediction increases token count by the number of digits, so it
+is counterproductive when context length is the binding constraint.
+
+## Coverage available per embedding
+
+For one corpus hour, idealized uniform occupancy gives:
+
+| Quality | Frames/hour | Mean hits per separate `(band,state)` | Mean hits per shared level state |
+|---|---:|---:|---:|
+| Small | 180,000 | 11,250 | 225,000 |
+| Medium | 360,000 | 5,625 | 225,000 |
+| High | 360,000 | 1,406 | 112,500 |
+| Ultra | 450,000 | 439 | 70,313 |
+| Max | 720,000 | 176 | 56,250 |
+
+These are optimistic because speech frames are correlated and uniform dB bins
+are not uniformly occupied. The minimum count, number of distinct speakers and
+recordings reaching a state, and train/evaluation shift matter more than the
+mean. Sharing level states across bands is the largest immediate improvement
+for embedding repetition.
+
+Ultra and max are fidelity-first rather than coverage-first tokenizations.
+Their independent `(band,state)` inventories are much too large for modest
+spoken corpora. Use shared ordered levels, an embedding generated from
+normalized state value, or parallel base-4 factors. Ultra needs five base-4
+digits per cell and max needs six; predicting those factors serially would
+multiply sequence length, so use parallel local heads if factorization is
+chosen.
+
+## Lower-state, lower-column candidates
+
+The built-ins are stable baselines. These are useful coverage-first experiments:
+
+| Target | Columns \(C\) | States/cell \(K\) | Timestep | dB range | dB step | Scalar tokens/s | Separate \(CK\) | Factorized \(C+K\) | Packed lower bound |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Aggressive small speech | 16 | 8 | 20 ms | 48 | 6.857 | **800** | 128 | 24 | 2.4 kb/s |
+| Compact medium | 32 | 32 | 10 ms | 56 | 1.806 | **3,200** | 1,024 | 64 | 16 kb/s |
+| Safer high vocabulary | 80 | 128 | 10 ms | 80 | 0.630 | 8,000 | 10,240 | 208 | 56 kb/s |
+| Compact high | 64 | 128 | 10 ms | 72 | 0.567 | **6,400** | 8,192 | 192 | 44.8 kb/s |
+
+Example compact-medium command:
+
+```bash
+python audio_to_token_mel.py speech.wav \
+  --preset medium \
+  --columns-per-timestep 32 \
+  --states-per-column 32 \
+  --top-db 56 \
+  --output-prefix speech.c32.k32 \
+  --output-format both
+```
+
+Example compact-high command:
+
+```bash
+python audio_to_token_mel.py speech.wav \
+  --preset high \
+  --columns-per-timestep 64 \
+  --states-per-column 128 \
+  --top-db 72 \
+  --output-prefix speech.c64.k128 \
+  --output-format both
+```
+
+Reducing `K` reduces vocabulary and improves state coverage but does not reduce
+scalar sequence length. Reducing mel columns or frames per second reduces
+sequence length. Choose the smallest candidate that meets held-out phoneme/WER
+and reconstruction-listening targets, not visual similarity alone.
+When increasing `--timestep-ms` to reduce frames per second, keep the window
+at least twice as long as the hop so every centered output sample remains
+covered.
+
+For an even smaller sequence, group bands and use product/vector quantization.
+For example, eight 64-way group codes per 100 Hz frame produce 800 tokens/s,
+five times fewer than medium scalar serialization and ten times fewer than
+high. Freeze the codebooks learned on training data, reserve or saturate
+fallback codes, and audit dead/rare code usage. A grouped learned decoder is
+more complex and can introduce codebook OOD, so it should follow the scalar
+baselines rather than replace them blindly.
+
+Long all-floor spans can be represented by a bounded silence/run token outside
+the mel matrix. Saturate long durations; never modulo-wrap them.
+
+## Recommended optimization order
+
+1. Start with medium `40×64`, but share level IDs across bands.
+2. Evaluate `32×32` at `top_db=56`; it is the best first coverage/quality
+   tradeoff for ordinary spoken datasets.
+3. If input gain varies substantially, compare the preset's `--agc` profile
+   against no AGC on held-out speech. Freeze the chosen AGC configuration.
+4. After that choice, freeze one training-corpus reference and measure
+   endpoint occupancy on validation microphones, speakers, noise levels, and
+   codecs.
+5. Fit per-band training quantiles if uniform dB bins leave many rare states.
+   Reserve state 0 for silence/floor and the top state for saturation; freeze
+   thresholds and reconstruct each state with its training median.
+6. Merge adjacent states until every active state clears a chosen minimum
+   count across enough distinct recordings, not just enough adjacent frames.
+7. If context length still dominates, reduce bands or increase timestep, or
+   move to grouped codes. Do not build a whole-frame vocabulary.
+8. Treat ultra and max as fidelity/vocoder or analysis tiers. For an
+   autoregressive scalar-token LM, require very large datasets or parallel
+   factorized/ordinal heads before adopting their 1,024- or 4,096-state cells.
+
+The current script implements optional waveform AGC, uniform dB quantization,
+and fixed/file-level references. Per-band quantile fitting and grouped
+codebooks are recommended next-stage experiments, not silently applied
+transforms.
+
+## Inverse method and unavoidable losses
+
+The inverse performs:
+
+```text
+integer states
+→ dequantized mel power
+→ batched nonnegative linear-frequency power estimate
+→ magnitude STFT
+→ Griffin-Lim phase estimation
+→ overlap-add PCM WAV
+```
+
+It uses the forward script's exact centered-frame convention, periodic Hann
+window, right-side FFT zero padding, mel normalization, and original decoded
+sample count. The CSV/PNG state payload roundtrip is exact and CRC-checked;
+audio reconstruction is necessarily approximate because phase, stereo,
+within-band detail, unclipped magnitude, and quantization residuals were not
+stored.
+
+If audio fidelity is the primary goal, a learned vocoder conditioned on the
+same frozen mel representation will usually outperform Griffin-Lim. It does
+not change the token-state accounting, but its training distribution must
+cover every intended preset and recording domain.
+
+## Verification performed
+
+The delivered scripts were checked on CPU with speech-like audio, silence,
+very short audio, custom 32-column/48-state and 53-column/1,000-state settings,
+metadata-free CSV/PNG fallback, and the v2.3 AGC/timestep demo path:
+
+- all five presets' CSV and PNG decoded to exactly equal state matrices;
+- ultra and max used exact 16-bit grayscale lattices with 1,024 and 4,096
+  states per cell, including pixel-lattice and CRC validation;
+- fixed-seed CSV and PNG inversions produced byte-identical WAV files;
+- the demo accepted `--hop-ms 12.5` as the timestep alias together with
+  medium AGC, every expert AGC override, and custom `C=32,K=48`; it created
+  collision-safe `.dt12.5ms.agc` names, retained the exact 1,920 samples, and
+  reconstructed byte-identical WAVs from CSV and PNG;
+- forced multi-chunk CSV and PNG inversions also produced byte-identical WAV
+  files with the exact stored sample count;
+- the default medium nonnegative inverse achieved about `0.00369` relative
+  mel reprojection error on the test clip;
+- all-zero states reconstructed to exact digital silence;
+- the custom STFT/ISTFT convention reconstructed known-phase audio with
+  relative numerical error below `9e-8`;
+- PNG inversion survived removal of `iTXt` by using its pixel header;
+- 16-bit PNG inversion also survived removal of `iTXt`;
+- a deliberately changed state pixel failed the stored CRC check;
+- CSV-only and PNG-only forward modes emitted no unwanted JSON or companion
+  representation;
+- self-describing CSV rows were parsed into compact state storage in bounded
+  batches, and long phase recovery used bounded overlapping chunks.
+
+CUDA was not available in the verification environment, so the optional
+PyTorch CUDA path was not runtime-tested there. The NumPy CPU path is the
+validated fallback.

--- a/data/mel_spectrogram/audio_to_token_mel.py
+++ b/data/mel_spectrogram/audio_to_token_mel.py
@@ -1,0 +1,2343 @@
+#!/usr/bin/env python3
+"""
+Convert audio into self-describing bounded mel-state CSV and PNG containers.
+
+The CPU path requires only NumPy and FFmpeg.  If PyTorch with CUDA is installed,
+--device auto can use a GPU for the batched FFT and mel projection.  Audio is
+decoded to a temporary memory-mapped float32 file, so long inputs do not need
+to fit in RAM.
+
+Each CSV embeds compact reconstruction metadata in a comment after its header.  Each
+QMel-PNG stores the exact same integer states in an 8-bit indexed or 16-bit
+grayscale raster and embeds the metadata both as iTXt and as a checksummed
+pixel header.  Either file can
+therefore be passed to token_mel_to_audio.py without a JSON sidecar.
+
+Examples
+--------
+    python audio_to_token_mel.py speech.m4a --preset medium
+    python audio_to_token_mel.py interview.mp4 --preset all --device auto
+    python audio_to_token_mel.py speech.wav --preset small --output-format csv
+    python audio_to_token_mel.py speech.flac --preset medium \
+        --columns-per-timestep 32 --states-per-column 32 --top-db 56
+    python audio_to_token_mel.py speech.wav --preset medium --agc
+    python audio_to_token_mel.py speech.wav --preset medium \
+        --timestep-ms 8 --columns-per-timestep 32 --states-per-column 48
+
+Every emitted mel state is an integer in [0, levels - 1].  Hard saturation
+prevents out-of-range token IDs.  It does not guarantee that every valid state,
+or every cross-band pattern, was sufficiently represented in training.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import zlib
+from contextlib import ExitStack
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+import numpy as np
+
+
+VERSION = "2.4.0"
+EPS_POWER = 1.0e-20
+CSV_METADATA_PREFIX = "#TOKEN_MEL_CSV_V2 "
+PNG_METADATA_KEY = "qmel.v2"
+PNG_PIXEL_MAGIC = b"QMELPNG2"
+MAX_HISTOGRAM_CELLS = 16_777_216
+
+
+class StoreConsistentValue(argparse.Action):
+    """Store an aliased option, rejecting contradictory repeated values."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ) -> None:
+        previous = getattr(namespace, self.dest, None)
+        if previous is not None and previous != values:
+            parser.error(
+                f"{option_string}={values} conflicts with an earlier value "
+                f"of {previous} for the same option."
+            )
+        setattr(namespace, self.dest, values)
+
+
+@dataclass(frozen=True)
+class Preset:
+    name: str
+    description: str
+    sample_rate: int
+    n_fft: int
+    win_ms: float
+    hop_ms: float
+    n_mels: int
+    fmin: float
+    fmax: float
+    top_db: float
+    levels: int
+
+    @property
+    def win_length(self) -> int:
+        return int(round(self.sample_rate * self.win_ms / 1000.0))
+
+    @property
+    def hop_length(self) -> int:
+        return int(round(self.sample_rate * self.hop_ms / 1000.0))
+
+    @property
+    def db_min(self) -> float:
+        return -self.top_db
+
+    @property
+    def db_max(self) -> float:
+        return 0.0
+
+    @property
+    def quantization_step_db(self) -> float:
+        return self.top_db / (self.levels - 1)
+
+    @property
+    def frames_per_second(self) -> float:
+        return self.sample_rate / self.hop_length
+
+
+@dataclass(frozen=True)
+class AgcConfig:
+    """Broadband waveform automatic-gain-control parameters."""
+
+    profile: str
+    target_dbfs: float
+    attack_ms: float
+    release_ms: float
+    max_gain_db: float
+    max_attenuation_db: float
+    gate_dbfs: float
+    peak_dbfs: float
+
+
+PRESETS: dict[str, Preset] = {
+    "small": Preset(
+        name="small",
+        description=(
+            "Lossy speech-content representation: 0-6 kHz, coarse spectral "
+            "and amplitude resolution, and a 20 ms hop."
+        ),
+        sample_rate=12_000,
+        n_fft=512,
+        win_ms=40.0,
+        hop_ms=20.0,
+        n_mels=20,
+        fmin=50.0,
+        fmax=6_000.0,
+        top_db=48.0,
+        levels=16,
+    ),
+    "medium": Preset(
+        name="medium",
+        description=(
+            "General speech/ASR baseline: 0-8 kHz, 40 mel bands, a 10 ms "
+            "hop, and approximately 1 dB quantization."
+        ),
+        sample_rate=16_000,
+        n_fft=512,
+        win_ms=25.0,
+        hop_ms=10.0,
+        n_mels=40,
+        fmin=50.0,
+        fmax=8_000.0,
+        top_db=64.0,
+        levels=64,
+    ),
+    "high": Preset(
+        name="high",
+        description=(
+            "High-quality speech feature representation: 0-12 kHz, 80 mel "
+            "bands, a 10 ms hop, and 8-bit amplitude states."
+        ),
+        sample_rate=24_000,
+        n_fft=1024,
+        win_ms=25.0,
+        hop_ms=10.0,
+        n_mels=80,
+        fmin=20.0,
+        fmax=12_000.0,
+        top_db=80.0,
+        levels=256,
+    ),
+    "ultra": Preset(
+        name="ultra",
+        description=(
+            "Ultra-quality wideband representation: 0-16 kHz, 160 mel bands, "
+            "an 8 ms hop, a 4096-point FFT, and 10-bit amplitude states."
+        ),
+        sample_rate=32_000,
+        n_fft=4096,
+        win_ms=32.0,
+        hop_ms=8.0,
+        n_mels=160,
+        fmin=20.0,
+        fmax=16_000.0,
+        top_db=96.0,
+        levels=1024,
+    ),
+    "max": Preset(
+        name="max",
+        description=(
+            "Maximum built-in fidelity: full 24 kHz audio bandwidth, 320 mel "
+            "bands, a 5 ms hop, an 8192-point FFT, and 12-bit states."
+        ),
+        sample_rate=48_000,
+        n_fft=8192,
+        win_ms=32.0,
+        hop_ms=5.0,
+        n_mels=320,
+        fmin=20.0,
+        fmax=24_000.0,
+        top_db=112.0,
+        levels=4096,
+    ),
+}
+
+AGC_PROFILES: dict[str, AgcConfig] = {
+    "small": AgcConfig(
+        profile="small",
+        target_dbfs=-18.0,
+        attack_ms=20.0,
+        release_ms=400.0,
+        max_gain_db=24.0,
+        max_attenuation_db=18.0,
+        gate_dbfs=-55.0,
+        peak_dbfs=-1.0,
+    ),
+    "medium": AgcConfig(
+        profile="medium",
+        target_dbfs=-20.0,
+        attack_ms=10.0,
+        release_ms=500.0,
+        max_gain_db=24.0,
+        max_attenuation_db=24.0,
+        gate_dbfs=-60.0,
+        peak_dbfs=-1.0,
+    ),
+    "high": AgcConfig(
+        profile="high",
+        target_dbfs=-22.0,
+        attack_ms=10.0,
+        release_ms=650.0,
+        max_gain_db=18.0,
+        max_attenuation_db=24.0,
+        gate_dbfs=-65.0,
+        peak_dbfs=-1.0,
+    ),
+    "ultra": AgcConfig(
+        profile="ultra",
+        target_dbfs=-23.0,
+        attack_ms=8.0,
+        release_ms=800.0,
+        max_gain_db=15.0,
+        max_attenuation_db=24.0,
+        gate_dbfs=-70.0,
+        peak_dbfs=-1.0,
+    ),
+    "max": AgcConfig(
+        profile="max",
+        target_dbfs=-24.0,
+        attack_ms=5.0,
+        release_ms=1000.0,
+        max_gain_db=12.0,
+        max_attenuation_db=24.0,
+        gate_dbfs=-75.0,
+        peak_dbfs=-1.0,
+    ),
+}
+
+
+def periodic_hann(length: int) -> np.ndarray:
+    """Return a periodic Hann window, matching common STFT frontends."""
+    if length < 2:
+        return np.ones((length,), dtype=np.float32)
+    return np.hanning(length + 1)[:-1].astype(np.float32)
+
+
+def hz_to_mel(hz: np.ndarray | float) -> np.ndarray:
+    """HTK mel conversion."""
+    return 2595.0 * np.log10(1.0 + np.asarray(hz, dtype=np.float64) / 700.0)
+
+
+def mel_to_hz(mel: np.ndarray | float) -> np.ndarray:
+    """Inverse HTK mel conversion."""
+    return 700.0 * (10.0 ** (np.asarray(mel, dtype=np.float64) / 2595.0) - 1.0)
+
+
+def make_mel_filterbank(
+    sample_rate: int,
+    n_fft: int,
+    n_mels: int,
+    fmin: float,
+    fmax: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Build unit-sum triangular mel filters.
+
+    Unit-sum filters make each band a weighted mean of FFT-bin power rather than
+    giving wider high-frequency filters automatically larger magnitudes.  This
+    is useful for a fixed, portable quantization frontend.
+    """
+    nyquist = sample_rate / 2.0
+    if not (0.0 <= fmin < fmax <= nyquist + 1.0e-9):
+        raise ValueError(
+            f"Expected 0 <= fmin < fmax <= Nyquist ({nyquist:g} Hz); "
+            f"received fmin={fmin:g}, fmax={fmax:g}."
+        )
+    if n_mels < 1:
+        raise ValueError("n_mels must be at least 1.")
+
+    fft_hz = np.linspace(0.0, nyquist, n_fft // 2 + 1, dtype=np.float64)
+    mel_edges = np.linspace(
+        float(hz_to_mel(fmin)),
+        float(hz_to_mel(fmax)),
+        n_mels + 2,
+        dtype=np.float64,
+    )
+    hz_edges = mel_to_hz(mel_edges)
+    filters = np.zeros((n_mels, fft_hz.size), dtype=np.float64)
+
+    for band in range(n_mels):
+        lower, center, upper = hz_edges[band : band + 3]
+        left = (fft_hz - lower) / max(center - lower, np.finfo(float).eps)
+        right = (upper - fft_hz) / max(upper - center, np.finfo(float).eps)
+        triangle = np.maximum(0.0, np.minimum(left, right))
+        weight_sum = float(triangle.sum())
+        if weight_sum <= 0.0:
+            raise ValueError(
+                f"Mel band {band} is empty. Increase n_fft, reduce n_mels, "
+                "or narrow the frequency range."
+            )
+        filters[band] = triangle / weight_sum
+
+    centers_hz = hz_edges[1:-1]
+    return (
+        filters.astype(np.float32),
+        centers_hz.astype(np.float64),
+        hz_edges.astype(np.float64),
+    )
+
+
+def validate_preset(preset: Preset) -> None:
+    for name in ("win_ms", "hop_ms", "fmin", "fmax", "top_db"):
+        if not math.isfinite(float(getattr(preset, name))):
+            raise ValueError(f"{name} must be finite.")
+    if preset.sample_rate < 1:
+        raise ValueError("sample_rate must be positive.")
+    if preset.win_length < 2 or preset.hop_length < 1:
+        raise ValueError("The window and hop must contain at least 2 and 1 samples.")
+    if preset.hop_length > preset.win_length // 2:
+        minimum_window_samples = 2 * preset.hop_length
+        minimum_window_ms = (
+            1000.0 * minimum_window_samples / preset.sample_rate
+        )
+        raise ValueError(
+            f"--timestep-ms {preset.hop_ms:g} gives a {preset.hop_length}-sample "
+            f"hop at {preset.sample_rate} samples/s, while --win-ms "
+            f"{preset.win_ms:g} gives a {preset.win_length}-sample window. "
+            "For complete centered-frame coverage the window must be at least "
+            f"twice the hop: use --win-ms {minimum_window_ms:g} or larger."
+        )
+    if preset.n_fft < preset.win_length:
+        suggested_n_fft = 1 << (preset.win_length - 1).bit_length()
+        raise ValueError(
+            f"n_fft ({preset.n_fft}) must be >= win_length "
+            f"({preset.win_length} samples at {preset.sample_rate} samples/s). "
+            f"Use --n-fft {suggested_n_fft} or larger."
+        )
+    if preset.n_mels < 1 or preset.n_mels > 4096:
+        raise ValueError("columns per timestep must be in [1, 4096].")
+    if preset.levels < 2 or preset.levels > 65_536:
+        raise ValueError("states per column must be in [2, 65536].")
+    histogram_cells = preset.n_mels * preset.levels
+    if histogram_cells > MAX_HISTOGRAM_CELLS:
+        raise ValueError(
+            f"columns Ã— states ({histogram_cells:,}) exceeds the "
+            f"{MAX_HISTOGRAM_CELLS:,}-cell diagnostics-memory limit. "
+            "Reduce --columns-per-timestep or --states-per-column."
+        )
+    if not math.isfinite(preset.top_db) or preset.top_db <= 0.0:
+        raise ValueError("top_db must be positive.")
+    make_mel_filterbank(
+        preset.sample_rate,
+        preset.n_fft,
+        preset.n_mels,
+        preset.fmin,
+        preset.fmax,
+    )
+
+
+def validate_agc_config(config: AgcConfig) -> None:
+    """Reject configurations that are unstable or have ambiguous semantics."""
+    numeric_fields = (
+        "target_dbfs",
+        "attack_ms",
+        "release_ms",
+        "max_gain_db",
+        "max_attenuation_db",
+        "gate_dbfs",
+        "peak_dbfs",
+    )
+    for name in numeric_fields:
+        if not math.isfinite(float(getattr(config, name))):
+            raise ValueError(f"AGC {name} must be finite.")
+    if not -120.0 <= config.gate_dbfs < config.target_dbfs:
+        raise ValueError(
+            "AGC gate_dbfs must be in [-120, target_dbfs)."
+        )
+    if not config.target_dbfs < config.peak_dbfs <= 0.0:
+        raise ValueError(
+            "AGC levels must satisfy target_dbfs < peak_dbfs <= 0."
+        )
+    if not 0.1 <= config.attack_ms <= 10_000.0:
+        raise ValueError("AGC attack_ms must be in [0.1, 10000].")
+    if not config.attack_ms <= config.release_ms <= 60_000.0:
+        raise ValueError(
+            "AGC release_ms must be in [attack_ms, 60000]."
+        )
+    if not 0.0 <= config.max_gain_db <= 60.0:
+        raise ValueError("AGC max_gain_db must be in [0, 60].")
+    if not 0.0 <= config.max_attenuation_db <= 60.0:
+        raise ValueError(
+            "AGC max_attenuation_db must be in [0, 60]."
+        )
+
+
+def get_ffmpeg_version(ffmpeg: str) -> str:
+    try:
+        result = subprocess.run(
+            [ffmpeg, "-version"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return result.stdout.splitlines()[0] if result.stdout else "unknown"
+
+
+def decode_to_f32_mono(
+    input_path: Path,
+    raw_path: Path,
+    sample_rate: int,
+    ffmpeg: str,
+) -> None:
+    """Decode the first audio stream to mono little-endian float32 PCM."""
+    if shutil.which(ffmpeg) is None:
+        raise RuntimeError(
+            f"Could not find '{ffmpeg}'. Install FFmpeg or pass --ffmpeg PATH."
+        )
+
+    command = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-nostdin",
+        "-i",
+        str(input_path),
+        "-map",
+        "0:a:0",
+        "-vn",
+        "-ac",
+        "1",
+        "-ar",
+        str(sample_rate),
+        "-acodec",
+        "pcm_f32le",
+        "-f",
+        "f32le",
+        "pipe:1",
+    ]
+    with raw_path.open("wb") as raw_file:
+        result = subprocess.run(
+            command,
+            stdout=raw_file,
+            stderr=subprocess.PIPE,
+            text=False,
+        )
+    if result.returncode != 0:
+        message = result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"FFmpeg could not decode the input audio:\n{message}")
+
+    size = raw_path.stat().st_size
+    if size == 0:
+        raise RuntimeError("FFmpeg produced no audio samples.")
+    if size % np.dtype("<f4").itemsize:
+        raise RuntimeError("Decoded PCM byte count is not a multiple of float32.")
+
+
+def mean_memmap(audio: np.memmap, chunk_samples: int = 4_000_000) -> float:
+    """Compute a float64 mean without materializing the full memory map."""
+    total = 0.0
+    count = 0
+    for start in range(0, audio.size, chunk_samples):
+        chunk = np.asarray(
+            audio[start : start + chunk_samples], dtype=np.float32
+        )
+        chunk = np.nan_to_num(
+            chunk, copy=True, nan=0.0, posinf=1.0, neginf=-1.0
+        )
+        np.clip(chunk, -1.0, 1.0, out=chunk)
+        total += float(chunk.sum(dtype=np.float64))
+        count += int(chunk.size)
+    return total / count if count else 0.0
+
+
+def _finite_dbfs(amplitude: float) -> float | None:
+    """Convert a nonnegative linear amplitude to finite dBFS or None."""
+    if not math.isfinite(amplitude) or amplitude <= 0.0:
+        return None
+    return 20.0 * math.log10(amplitude)
+
+
+def build_agc_metadata(
+    config: AgcConfig,
+    sample_rate: int,
+    control_frame_samples: int,
+) -> dict[str, Any]:
+    """Describe the lossy preprocessing needed to interpret reconstruction."""
+    return {
+        "enabled": True,
+        "algorithm": "causal_block_rms_db_v1",
+        "profile": config.profile,
+        "target_dbfs": config.target_dbfs,
+        "control_frame_samples": control_frame_samples,
+        "control_frame_ms": (
+            1000.0 * control_frame_samples / sample_rate
+        ),
+        "attack_ms": config.attack_ms,
+        "release_ms": config.release_ms,
+        "max_gain_db": config.max_gain_db,
+        "max_attenuation_db": config.max_attenuation_db,
+        "gate_dbfs": config.gate_dbfs,
+        "peak_ceiling_dbfs": config.peak_dbfs,
+        "limiter": "hard_peak_ceiling",
+        "initial_gain_db": 0.0,
+        "gain_envelope_stored": False,
+        "reversible": False,
+        "reconstruction_domain": "agc_normalized",
+    }
+
+
+def apply_waveform_agc(
+    audio: np.memmap,
+    output_path: Path,
+    sample_rate: int,
+    control_frame_samples: int,
+    config: AgcConfig,
+    dc_offset: float,
+    quiet: bool,
+) -> dict[str, Any]:
+    """
+    Apply bounded broadband AGC to decoded mono samples in a streaming pass.
+
+    The detector sees one non-overlapping control frame (the actual mel hop)
+    before emitting it. Gain is smoothed in dB and interpolated over the
+    frame. Below the gate, positive gain is forbidden. A final hard ceiling
+    contains transients while fixed mel/quantizer bin meanings remain intact.
+    The gain envelope is intentionally not serialized, so this preprocessing
+    is lossy with respect to the source's absolute loudness.
+    """
+    validate_agc_config(config)
+    if sample_rate < 1 or control_frame_samples < 1:
+        raise ValueError("AGC sample rate and control frame must be positive.")
+
+    peak_linear = 10.0 ** (config.peak_dbfs / 20.0)
+    current_gain_db = 0.0
+    minimum_gain_db = 0.0
+    maximum_gain_db = 0.0
+    weighted_gain_db = 0.0
+    input_sum_squares = 0.0
+    output_sum_squares = 0.0
+    input_peak = 0.0
+    output_peak = 0.0
+    limited_samples = 0
+    gated_frames = 0
+    frame_count = 0
+    last_percent = -10
+
+    with output_path.open("wb") as output_file:
+        for start in range(0, audio.size, control_frame_samples):
+            block = np.asarray(
+                audio[start : start + control_frame_samples],
+                dtype=np.float32,
+            )
+            block = np.nan_to_num(
+                block, copy=True, nan=0.0, posinf=1.0, neginf=-1.0
+            )
+            np.clip(block, -1.0, 1.0, out=block)
+            if dc_offset:
+                block -= np.float32(dc_offset)
+                np.clip(block, -1.0, 1.0, out=block)
+
+            block64 = block.astype(np.float64, copy=False)
+            block_peak = (
+                float(np.max(np.abs(block64))) if block.size else 0.0
+            )
+            block_sum_squares = float(np.dot(block64, block64))
+            block_rms = (
+                math.sqrt(block_sum_squares / block.size)
+                if block.size
+                else 0.0
+            )
+            rms_dbfs = _finite_dbfs(block_rms)
+            peak_dbfs = _finite_dbfs(block_peak)
+
+            if rms_dbfs is None or rms_dbfs < config.gate_dbfs:
+                gated_frames += 1
+                desired_gain_db = 0.0
+                if peak_dbfs is not None:
+                    desired_gain_db = min(
+                        desired_gain_db,
+                        config.peak_dbfs - peak_dbfs,
+                    )
+            else:
+                desired_gain_db = config.target_dbfs - rms_dbfs
+                if peak_dbfs is not None:
+                    desired_gain_db = min(
+                        desired_gain_db,
+                        config.peak_dbfs - peak_dbfs,
+                    )
+            desired_gain_db = min(
+                config.max_gain_db,
+                max(-config.max_attenuation_db, desired_gain_db),
+            )
+
+            time_constant_ms = (
+                config.attack_ms
+                if desired_gain_db < current_gain_db
+                else config.release_ms
+            )
+            block_ms = 1000.0 * block.size / sample_rate
+            smoothing = math.exp(-block_ms / time_constant_ms)
+            next_gain_db = (
+                desired_gain_db
+                + smoothing * (current_gain_db - desired_gain_db)
+            )
+            gains_db = np.linspace(
+                current_gain_db,
+                next_gain_db,
+                num=block.size,
+                endpoint=True,
+                dtype=np.float64,
+            )
+            gains_linear = np.power(10.0, gains_db / 20.0)
+            processed64 = block64 * gains_linear
+            over_ceiling = np.abs(processed64) > peak_linear
+            limited_samples += int(np.count_nonzero(over_ceiling))
+            np.clip(
+                processed64, -peak_linear, peak_linear, out=processed64
+            )
+            processed = processed64.astype("<f4")
+            output_file.write(processed.tobytes(order="C"))
+
+            input_sum_squares += block_sum_squares
+            output_sum_squares += float(np.dot(processed64, processed64))
+            input_peak = max(input_peak, block_peak)
+            if processed64.size:
+                output_peak = max(
+                    output_peak, float(np.max(np.abs(processed64)))
+                )
+            if gains_db.size:
+                minimum_gain_db = min(
+                    minimum_gain_db, float(np.min(gains_db))
+                )
+                maximum_gain_db = max(
+                    maximum_gain_db, float(np.max(gains_db))
+                )
+                weighted_gain_db += float(gains_db.sum(dtype=np.float64))
+            current_gain_db = next_gain_db
+            frame_count += 1
+            last_percent = print_progress(
+                quiet,
+                "agc",
+                min(start + block.size, audio.size),
+                int(audio.size),
+                last_percent,
+            )
+
+    sample_count = int(audio.size)
+    input_rms = (
+        math.sqrt(input_sum_squares / sample_count) if sample_count else 0.0
+    )
+    output_rms = (
+        math.sqrt(output_sum_squares / sample_count) if sample_count else 0.0
+    )
+    description = build_agc_metadata(
+        config, sample_rate, control_frame_samples
+    )
+    return {
+        **description,
+        "control_frames": frame_count,
+        "samples_processed": sample_count,
+        "gated_control_frames": gated_frames,
+        "gated_control_frame_fraction": (
+            gated_frames / frame_count if frame_count else 0.0
+        ),
+        "minimum_controller_gain_db": minimum_gain_db,
+        "maximum_controller_gain_db": maximum_gain_db,
+        "mean_controller_gain_db": (
+            weighted_gain_db / sample_count if sample_count else 0.0
+        ),
+        "final_controller_gain_db": current_gain_db,
+        "hard_limited_samples": limited_samples,
+        "hard_limited_sample_fraction": (
+            limited_samples / sample_count if sample_count else 0.0
+        ),
+        "input_rms_dbfs": _finite_dbfs(input_rms),
+        "output_rms_dbfs": _finite_dbfs(output_rms),
+        "input_peak_dbfs": _finite_dbfs(input_peak),
+        "output_peak_dbfs": _finite_dbfs(output_peak),
+        "dc_offset_removed_before_agc": dc_offset,
+    }
+
+
+def iter_centered_frames(
+    audio: np.memmap,
+    n_frames: int,
+    win_length: int,
+    hop_length: int,
+    batch_frames: int,
+    dc_offset: float,
+) -> Iterator[tuple[int, np.ndarray]]:
+    """
+    Yield centered, zero-padded frame batches.
+
+    Frame t is centered on sample t * hop_length.  There are
+    ceil(num_samples / hop_length) frames, so timestamps are always inside the
+    decoded signal.  Values outside the signal at either edge are zero.
+    """
+    half_window = win_length // 2
+    for first_frame in range(0, n_frames, batch_frames):
+        count = min(batch_frames, n_frames - first_frame)
+        virtual_start = first_frame * hop_length - half_window
+        virtual_length = (count - 1) * hop_length + win_length
+        segment = np.zeros((virtual_length,), dtype=np.float32)
+
+        source_start = max(0, virtual_start)
+        source_end = min(audio.size, virtual_start + virtual_length)
+        if source_end > source_start:
+            destination_start = source_start - virtual_start
+            values = np.asarray(audio[source_start:source_end], dtype=np.float32)
+            values = np.nan_to_num(
+                values, copy=True, nan=0.0, posinf=1.0, neginf=-1.0
+            )
+            # Float PCM full scale is conventionally [-1, 1]. Saturating
+            # pathological finite values keeps CPU and CUDA power finite.
+            np.clip(values, -1.0, 1.0, out=values)
+            segment[
+                destination_start : destination_start + values.size
+            ] = values
+
+        if dc_offset:
+            # Apply DC removal only where real samples exist; zero padding stays 0.
+            real_start = max(0, -virtual_start)
+            real_end = min(virtual_length, audio.size - virtual_start)
+            if real_end > real_start:
+                segment[real_start:real_end] -= np.float32(dc_offset)
+                np.clip(
+                    segment[real_start:real_end],
+                    -1.0,
+                    1.0,
+                    out=segment[real_start:real_end],
+                )
+
+        stride = segment.strides[0]
+        frames = np.lib.stride_tricks.as_strided(
+            segment,
+            shape=(count, win_length),
+            strides=(hop_length * stride, stride),
+            writeable=False,
+        ).copy()
+        yield first_frame, frames
+
+
+class MelBackend:
+    """NumPy CPU or PyTorch CUDA implementation of power-mel projection."""
+
+    def __init__(
+        self,
+        device_request: str,
+        window: np.ndarray,
+        n_fft: int,
+        filterbank: np.ndarray,
+    ) -> None:
+        self.n_fft = n_fft
+        self.window_np = window.astype(np.float32, copy=False)
+        self.filterbank_np = filterbank.astype(np.float32, copy=False)
+        self.power_normalizer = max(float(window.sum()) / 2.0, 1.0e-12) ** 2
+        self.kind = "numpy"
+        self.device = "cpu"
+        self.torch: Any | None = None
+        self.window_t: Any | None = None
+        self.filterbank_t: Any | None = None
+
+        requested = device_request.lower()
+        if requested == "cpu":
+            return
+        if requested != "auto" and not requested.startswith("cuda"):
+            raise ValueError("--device must be auto, cpu, cuda, or cuda:N.")
+
+        try:
+            import torch  # type: ignore
+        except ImportError as error:
+            if requested.startswith("cuda"):
+                raise RuntimeError(
+                    "CUDA was requested, but PyTorch is not installed. Install "
+                    "a CUDA-enabled PyTorch build or use --device cpu."
+                ) from error
+            return
+
+        if not torch.cuda.is_available():
+            if requested.startswith("cuda"):
+                raise RuntimeError(
+                    "CUDA was requested, but torch.cuda.is_available() is false."
+                )
+            return
+
+        device = "cuda:0" if requested in {"auto", "cuda"} else requested
+        try:
+            torch.empty((1,), device=device)
+        except Exception as error:
+            raise RuntimeError(f"Could not initialize CUDA device '{device}'.") from error
+
+        self.kind = "torch"
+        self.device = device
+        self.torch = torch
+        self.window_t = torch.as_tensor(self.window_np, device=device)
+        self.filterbank_t = torch.as_tensor(self.filterbank_np, device=device)
+
+    @property
+    def label(self) -> str:
+        return f"{self.kind}:{self.device}"
+
+    def transform(self, frames: np.ndarray) -> np.ndarray:
+        if self.kind == "numpy":
+            windowed = frames * self.window_np[None, :]
+            spectrum = np.fft.rfft(windowed, n=self.n_fft, axis=1)
+            power = (
+                spectrum.real * spectrum.real + spectrum.imag * spectrum.imag
+            ) / self.power_normalizer
+            mel = power @ self.filterbank_np.T
+            return np.maximum(mel, 0.0).astype(np.float32, copy=False)
+
+        assert self.torch is not None
+        assert self.window_t is not None
+        assert self.filterbank_t is not None
+        torch = self.torch
+        with torch.inference_mode():
+            frame_t = torch.as_tensor(frames, device=self.device)
+            spectrum_t = torch.fft.rfft(
+                frame_t * self.window_t[None, :],
+                n=self.n_fft,
+                dim=1,
+            )
+            power_t = spectrum_t.abs().square() / self.power_normalizer
+            mel_t = power_t @ self.filterbank_t.T
+            return mel_t.clamp_min_(0.0).float().cpu().numpy()
+
+
+def choose_reference(
+    mode: str,
+    max_power: float,
+    sampled_power: np.ndarray,
+    percentile: float,
+    fixed_reference_power: float | None,
+) -> tuple[float, str]:
+    if mode == "fixed":
+        if (
+            fixed_reference_power is None
+            or not math.isfinite(fixed_reference_power)
+            or fixed_reference_power <= 0.0
+        ):
+            raise ValueError(
+                "--reference-power must be positive when --reference-mode fixed."
+            )
+        return fixed_reference_power, "fixed"
+    if max_power <= EPS_POWER:
+        return 1.0, "silent_fallback"
+    if mode == "file_peak":
+        return max_power, "file_peak"
+    if mode == "file_percentile":
+        if sampled_power.size:
+            reference = float(np.percentile(sampled_power, percentile))
+        else:
+            reference = max_power
+        if not math.isfinite(reference) or reference <= EPS_POWER:
+            reference = max_power
+            return reference, "file_peak_fallback"
+        return reference, f"file_percentile_{percentile:g}"
+    raise ValueError(f"Unknown reference mode: {mode}")
+
+
+def mel_to_quantized(
+    mel_power: np.ndarray,
+    reference_power: float,
+    preset: Preset,
+    silent: bool,
+) -> tuple[np.ndarray, np.ndarray]:
+    if silent:
+        db_raw = np.full(mel_power.shape, preset.db_min, dtype=np.float32)
+    else:
+        safe = np.maximum(mel_power, np.float32(EPS_POWER))
+        db_raw = (
+            10.0
+            * (
+                np.log10(safe, dtype=np.float32)
+                - np.float32(math.log10(reference_power))
+            )
+        ).astype(np.float32, copy=False)
+    db_clipped = np.clip(db_raw, preset.db_min, preset.db_max)
+    scaled = (db_clipped - preset.db_min) * (
+        (preset.levels - 1) / preset.top_db
+    )
+    quantized = np.floor(scaled + 0.5)
+    quantized = np.clip(quantized, 0, preset.levels - 1)
+    if preset.levels <= 256:
+        quantized = quantized.astype(np.uint8)
+    elif preset.levels <= 65_536:
+        quantized = quantized.astype(np.uint16)
+    else:
+        quantized = quantized.astype(np.uint32)
+    return quantized, db_raw
+
+
+def dequantize_db(quantized: np.ndarray, preset: Preset) -> np.ndarray:
+    return (
+        preset.db_min
+        + quantized.astype(np.float32)
+        * np.float32(preset.top_db / (preset.levels - 1))
+    )
+
+
+def histogram_stats(
+    histograms: np.ndarray,
+    low_clip_count: np.ndarray,
+    high_clip_count: np.ndarray,
+    frame_count: int,
+    centers_hz: np.ndarray,
+) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for band, counts_u64 in enumerate(histograms):
+        counts = counts_u64.astype(np.float64)
+        total = float(counts.sum())
+        probabilities = counts / total if total else np.zeros_like(counts)
+        nonzero = probabilities > 0.0
+        entropy_bits = float(
+            -(probabilities[nonzero] * np.log2(probabilities[nonzero])).sum()
+        )
+        effective_states = float(2.0**entropy_bits)
+        occupied = int(np.count_nonzero(counts_u64))
+        output.append(
+            {
+                "band": band,
+                "center_hz": float(centers_hz[band]),
+                "occupied_states": occupied,
+                "total_states": int(counts_u64.size),
+                "effective_states": effective_states,
+                "normalized_effective_state_fraction": (
+                    effective_states / counts_u64.size
+                ),
+                "entropy_bits": entropy_bits,
+                "minimum_state_count": int(counts_u64.min()),
+                "maximum_state_count": int(counts_u64.max()),
+                "floor_state_fraction": (
+                    float(counts_u64[0]) / frame_count if frame_count else 0.0
+                ),
+                "ceiling_state_fraction": (
+                    float(counts_u64[-1]) / frame_count if frame_count else 0.0
+                ),
+                "preclip_below_fraction": (
+                    float(low_clip_count[band]) / frame_count
+                    if frame_count
+                    else 0.0
+                ),
+                "preclip_above_fraction": (
+                    float(high_clip_count[band]) / frame_count
+                    if frame_count
+                    else 0.0
+                ),
+                "state_counts": [int(value) for value in counts_u64],
+            }
+        )
+    return output
+
+
+def compact_json(value: dict[str, Any]) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def build_roundtrip_metadata(
+    preset: Preset,
+    sample_count: int,
+    frame_count: int,
+    include_time_columns: bool,
+    reference_power: float,
+    reference_mode: str,
+    silent: bool,
+    fft_power_normalizer: float,
+    state_crc32: int,
+    agc: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the compact transform description embedded in CSV and PNG."""
+    metadata: dict[str, Any] = {
+        "format": "bounded_quantized_mel_v2",
+        "version": 2,
+        "shape": {
+            "timesteps": frame_count,
+            "bands": preset.n_mels,
+            "axis_order": "TC",
+        },
+        "waveform": {
+            "sample_rate": preset.sample_rate,
+            "decoded_sample_count": sample_count,
+            "channels": 1,
+        },
+        "stft": {
+            "n_fft": preset.n_fft,
+            "win_length": preset.win_length,
+            "hop_length": preset.hop_length,
+            "window": "periodic_hann",
+            "frame_center": "t*hop",
+            "padding": "constant_zero",
+            "fft_zero_padding": "right",
+            "power_normalizer": fft_power_normalizer,
+        },
+        "mel": {
+            "n_mels": preset.n_mels,
+            "fmin": preset.fmin,
+            "fmax": preset.fmax,
+            "scale": "HTK",
+            "filter_shape": "triangular",
+            "filter_normalization": "unit_sum",
+        },
+        "quantizer": {
+            "kind": "uniform_db",
+            "levels": preset.levels,
+            "integer_min": 0,
+            "integer_max": preset.levels - 1,
+            "db_min": preset.db_min,
+            "db_max": preset.db_max,
+            "clip": "saturate",
+            "zero_state_semantics": "lower_censored_or_silence",
+            "reference_power": reference_power,
+            "reference_mode": reference_mode,
+            "silent": silent,
+        },
+        "csv": {
+            "time_columns_included": include_time_columns,
+            "metadata_prefix": CSV_METADATA_PREFIX.strip(),
+        },
+        "integrity": {
+            "state_order": "row_major_TC",
+            "state_dtype": "uint8" if preset.levels <= 256 else "uint16_le",
+            "state_crc32": f"{state_crc32:08x}",
+        },
+        "profile": preset.name,
+    }
+    if agc is not None:
+        metadata["preprocessing"] = {"agc": agc}
+    return metadata
+
+
+def _palette_for_levels(levels: int) -> list[int]:
+    """Build a compact inferno-like palette whose first K entries span it."""
+    stops = (
+        (0.00, (0, 0, 4)),
+        (0.20, (59, 15, 112)),
+        (0.40, (140, 41, 129)),
+        (0.60, (221, 73, 104)),
+        (0.80, (253, 159, 108)),
+        (1.00, (252, 253, 191)),
+    )
+
+    def sample(position: float) -> tuple[int, int, int]:
+        for index in range(len(stops) - 1):
+            left_x, left_rgb = stops[index]
+            right_x, right_rgb = stops[index + 1]
+            if position <= right_x:
+                fraction = (position - left_x) / max(right_x - left_x, 1.0e-12)
+                return tuple(
+                    int(round(a + fraction * (b - a)))
+                    for a, b in zip(left_rgb, right_rgb)
+                )
+        return stops[-1][1]
+
+    palette: list[int] = []
+    for index in range(256):
+        if index < levels:
+            position = index / max(levels - 1, 1)
+            rgb = sample(position)
+        else:
+            rgb = (index, index, index)
+        palette.extend(rgb)
+    return palette
+
+
+def choose_png_tile_width(
+    frame_count: int,
+    n_mels: int,
+    requested_width: int | None,
+    maximum_width: int,
+) -> int:
+    if requested_width is not None:
+        if requested_width < 1 or requested_width > maximum_width:
+            raise ValueError(
+                f"--png-tile-width must be in [1, {maximum_width}]."
+            )
+        return requested_width
+    target = int(math.ceil(math.sqrt(frame_count * n_mels)))
+    rounded = max(128, ((target + 63) // 64) * 64)
+    return min(maximum_width, rounded)
+
+
+def encode_scaled_u16_states(
+    states: np.ndarray,
+    levels: int,
+) -> np.ndarray:
+    """Map q in [0,K-1] bijectively onto a visible 16-bit grayscale lattice."""
+    values = np.asarray(states, dtype=np.uint64)
+    encoded = (
+        values * np.uint64(65_535) + np.uint64((levels - 1) // 2)
+    ) // np.uint64(levels - 1)
+    return encoded.astype(np.uint16)
+
+
+def write_state_png(
+    output_path: Path,
+    state_path: Path,
+    roundtrip_metadata: dict[str, Any],
+    frame_count: int,
+    n_mels: int,
+    levels: int,
+    tile_width: int | None,
+    maximum_width: int,
+    maximum_pixels: int,
+) -> dict[str, Any]:
+    """
+    Write exact q states as an 8-bit indexed or 16-bit grayscale PNG.
+
+    The canonical JSON is stored in a compressed iTXt chunk and redundantly in
+    a paired-byte pixel header. Removing ancillary PNG metadata therefore does
+    not prevent decoding as long as the integer state pixels remain unchanged.
+    """
+    try:
+        from PIL import Image, PngImagePlugin  # type: ignore
+    except ImportError as error:
+        raise RuntimeError(
+            "PNG output requires Pillow. Install it with "
+            "'python -m pip install pillow'."
+        ) from error
+
+    width = choose_png_tile_width(
+        frame_count, n_mels, tile_width, maximum_width
+    )
+    sixteen_bit = levels > 256
+    png_mode = "I;16" if sixteen_bit else "P"
+    state_pixel_codec = (
+        "scaled_u16_state_lattice_v1"
+        if sixteen_bit
+        else "palette_index_equals_state"
+    )
+    png_metadata = json.loads(compact_json(roundtrip_metadata))
+    png_metadata["png"] = {
+        "format": "QMel-PNG",
+        "version": 2,
+        "mode": png_mode,
+        "layout": "frequency_flipped_strip_stack",
+        "tile_width": width,
+        "state_pixel_codec": state_pixel_codec,
+        "pixel_header_codec": "paired_zlib_json_v1",
+        "metadata_key": PNG_METADATA_KEY,
+    }
+    canonical = compact_json(png_metadata)
+    compressed = zlib.compress(canonical.encode("utf-8"), level=9)
+    compressed_crc = zlib.crc32(compressed) & 0xFFFFFFFF
+    raw_header = (
+        PNG_PIXEL_MAGIC
+        + struct.pack(">II", len(compressed), compressed_crc)
+        + compressed
+    )
+    paired_header = np.empty((2 * len(raw_header),), dtype=np.uint8)
+    header_bytes = np.frombuffer(raw_header, dtype=np.uint8)
+    paired_header[0::2] = header_bytes
+    paired_header[1::2] = 255 - header_bytes
+    header_rows = int(math.ceil(paired_header.size / width))
+    strips = int(math.ceil(frame_count / width))
+    height = header_rows + strips * n_mels
+    pixel_count = width * height
+    if pixel_count > maximum_pixels:
+        raise ValueError(
+            f"PNG would require {pixel_count:,} pixels, exceeding "
+            f"--png-max-pixels={maximum_pixels:,}. Use CSV or raise the limit."
+        )
+
+    canvas_dtype = np.uint16 if sixteen_bit else np.uint8
+    state_dtype = "<u2" if sixteen_bit else np.uint8
+    canvas = np.zeros((height, width), dtype=canvas_dtype)
+    canvas.reshape(-1)[: paired_header.size] = paired_header
+    states = np.memmap(
+        state_path,
+        dtype=state_dtype,
+        mode="r",
+        shape=(frame_count, n_mels),
+    )
+    for strip_index in range(strips):
+        start = strip_index * width
+        end = min(frame_count, start + width)
+        rows = slice(
+            header_rows + strip_index * n_mels,
+            header_rows + (strip_index + 1) * n_mels,
+        )
+        payload = states[start:end].T[::-1, :]
+        if sixteen_bit:
+            payload = encode_scaled_u16_states(payload, levels)
+        canvas[rows, : end - start] = payload
+
+    if sixteen_bit:
+        image = Image.fromarray(canvas)
+    else:
+        image = Image.frombytes(
+            "P", (width, height), canvas.tobytes(order="C")
+        )
+        image.putpalette(_palette_for_levels(levels))
+    pnginfo = PngImagePlugin.PngInfo()
+    pnginfo.add_itxt(PNG_METADATA_KEY, canonical, zip=True)
+    image.save(
+        output_path,
+        format="PNG",
+        pnginfo=pnginfo,
+        compress_level=9,
+        optimize=False,
+    )
+    del states
+    return {
+        "kind": "exact_state_raster",
+        "mode": png_mode,
+        "state_pixel_codec": state_pixel_codec,
+        "width": width,
+        "height": height,
+        "header_rows": header_rows,
+        "strips": strips,
+        "payload_cells": frame_count * n_mels,
+        "container_pixels": pixel_count,
+        "frequency_flipped_for_display": True,
+        "time_continues_in_strips_top_to_bottom": True,
+    }
+
+
+def write_self_describing_csv(
+    output_path: Path,
+    body_path: Path,
+    roundtrip_metadata: dict[str, Any],
+) -> None:
+    with body_path.open("rb") as body_file, output_path.open("wb") as output_file:
+        header = body_file.readline()
+        if not header:
+            raise RuntimeError("CSV body is missing its header.")
+        output_file.write(header)
+        metadata_line = (
+            CSV_METADATA_PREFIX + compact_json(roundtrip_metadata) + "\n"
+        ).encode("utf-8")
+        output_file.write(metadata_line)
+        shutil.copyfileobj(body_file, output_file, length=1024 * 1024)
+
+
+def output_paths(
+    input_path: Path,
+    output_dir: Path,
+    output_prefix: str | None,
+    preset_name: str,
+) -> dict[str, Path]:
+    prefix = output_prefix if output_prefix else input_path.stem
+    base = f"{prefix}.{preset_name}.mel"
+    return {
+        "csv": output_dir / f"{base}.csv",
+        "png": output_dir / f"{base}.png",
+        "json": output_dir / f"{base}.json",
+    }
+
+
+def check_outputs(
+    paths: dict[str, Path],
+    make_csv: bool,
+    make_png: bool,
+    make_json: bool,
+    force: bool,
+) -> None:
+    selected: list[Path] = []
+    if make_csv:
+        selected.append(paths["csv"])
+    if make_png:
+        selected.append(paths["png"])
+    if make_json:
+        selected.append(paths["json"])
+    existing = [path for path in selected if path.exists()]
+    if existing and not force:
+        joined = "\n".join(f"  {path}" for path in existing)
+        raise FileExistsError(
+            "Refusing to overwrite existing output(s); pass --force:\n" + joined
+        )
+
+
+def print_progress(
+    quiet: bool,
+    stage: str,
+    completed: int,
+    total: int,
+    last_percent: int,
+) -> int:
+    if quiet or total <= 0:
+        return last_percent
+    percent = int(100 * completed / total)
+    if percent >= last_percent + 10 or completed == total:
+        print(f"[{stage}] {min(percent, 100):3d}%", file=sys.stderr)
+        return percent
+    return last_percent
+
+
+def convert_one(
+    input_path: Path,
+    output_dir: Path,
+    output_prefix: str | None,
+    preset: Preset,
+    device: str,
+    ffmpeg: str,
+    batch_frames: int,
+    reference_mode: str,
+    reference_percentile: float,
+    fixed_reference_power: float | None,
+    max_reference_values: int,
+    include_time_columns: bool,
+    output_format: str,
+    write_json: bool,
+    png_tile_width: int | None,
+    png_max_width: int,
+    png_max_pixels: int,
+    remove_dc: bool,
+    agc_config: AgcConfig | None,
+    force: bool,
+    quiet: bool,
+) -> dict[str, Any]:
+    """Convert one file/preset to standalone CSV and/or exact-state PNG."""
+    validate_preset(preset)
+    if max_reference_values < preset.n_mels:
+        raise ValueError(
+            "--max-reference-values must be at least the number of mel bands "
+            f"({preset.n_mels}) so every sampled reference frame is complete."
+        )
+    make_csv = output_format in {"csv", "both"}
+    make_png = output_format in {"png", "both"}
+    if not make_csv and not make_png:
+        raise ValueError("--output-format must be csv, png, or both.")
+    paths = output_paths(input_path, output_dir, output_prefix, preset.name)
+    check_outputs(
+        paths,
+        make_csv=make_csv,
+        make_png=make_png,
+        make_json=write_json,
+        force=force,
+    )
+
+    filterbank, centers_hz, mel_edges_hz = make_mel_filterbank(
+        preset.sample_rate,
+        preset.n_fft,
+        preset.n_mels,
+        preset.fmin,
+        preset.fmax,
+    )
+    window = periodic_hann(preset.win_length)
+    backend = MelBackend(device, window, preset.n_fft, filterbank)
+    if batch_frames < 1:
+        raise ValueError("--batch-frames must be positive.")
+
+    temp_csv = paths["csv"].with_suffix(paths["csv"].suffix + ".part")
+    temp_json = paths["json"].with_suffix(paths["json"].suffix + ".part")
+    temp_png = paths["png"].with_suffix(paths["png"].suffix + ".part")
+    temp_files = [temp_csv, temp_json, temp_png]
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="audio_to_token_mel_") as temp_dir:
+            temp_directory = Path(temp_dir)
+            raw_path = temp_directory / "decoded.f32le"
+            agc_path = temp_directory / "agc.f32le"
+            csv_body_path = temp_directory / "states_body.csv"
+            state_path = temp_directory / "states.bin"
+
+            if not quiet:
+                print(
+                    f"[decode] {input_path.name} -> mono {preset.sample_rate} Hz",
+                    file=sys.stderr,
+                )
+            decode_to_f32_mono(input_path, raw_path, preset.sample_rate, ffmpeg)
+            sample_count = raw_path.stat().st_size // np.dtype("<f4").itemsize
+            decoded_audio = np.memmap(
+                raw_path, dtype="<f4", mode="r", shape=(sample_count,)
+            )
+            duration_seconds = sample_count / preset.sample_rate
+            n_frames = max(1, math.ceil(sample_count / preset.hop_length))
+            dc_offset = mean_memmap(decoded_audio) if remove_dc else 0.0
+            agc_diagnostics: dict[str, Any] | None = None
+            if agc_config is not None:
+                agc_diagnostics = apply_waveform_agc(
+                    audio=decoded_audio,
+                    output_path=agc_path,
+                    sample_rate=preset.sample_rate,
+                    control_frame_samples=preset.hop_length,
+                    config=agc_config,
+                    dc_offset=dc_offset,
+                    quiet=quiet,
+                )
+                del decoded_audio
+                audio = np.memmap(
+                    agc_path,
+                    dtype="<f4",
+                    mode="r",
+                    shape=(sample_count,),
+                )
+                frame_dc_offset = 0.0
+            else:
+                audio = decoded_audio
+                frame_dc_offset = dc_offset
+
+            max_sample_frames = max(1, max_reference_values // preset.n_mels)
+            reference_frame_stride = max(
+                1, math.ceil(n_frames / max_sample_frames)
+            )
+            sampled_batches: list[np.ndarray] = []
+            max_power = 0.0
+            last_percent = -10
+
+            for first, frames in iter_centered_frames(
+                audio,
+                n_frames,
+                preset.win_length,
+                preset.hop_length,
+                batch_frames,
+                frame_dc_offset,
+            ):
+                mel_power = backend.transform(frames)
+                batch_max = float(np.max(mel_power))
+                if math.isfinite(batch_max):
+                    max_power = max(max_power, batch_max)
+
+                if reference_mode == "file_percentile":
+                    global_indices = np.arange(
+                        first, first + mel_power.shape[0], dtype=np.int64
+                    )
+                    selected = global_indices % reference_frame_stride == 0
+                    if selected.any():
+                        sampled_batches.append(
+                            mel_power[selected]
+                            .astype(np.float32, copy=True)
+                            .reshape(-1)
+                        )
+                last_percent = print_progress(
+                    quiet,
+                    "reference",
+                    first + frames.shape[0],
+                    n_frames,
+                    last_percent,
+                )
+
+            sampled_power = (
+                np.concatenate(sampled_batches)
+                if sampled_batches
+                else np.empty((0,), dtype=np.float32)
+            )
+            reference_power, reference_label = choose_reference(
+                reference_mode,
+                max_power,
+                sampled_power,
+                reference_percentile,
+                fixed_reference_power,
+            )
+            silent = max_power <= EPS_POWER
+            del sampled_batches, sampled_power
+
+            histograms = np.zeros(
+                (preset.n_mels, preset.levels), dtype=np.uint64
+            )
+            low_clip_count = np.zeros((preset.n_mels,), dtype=np.uint64)
+            high_clip_count = np.zeros((preset.n_mels,), dtype=np.uint64)
+            aggregate_low = 0
+            aggregate_high = 0
+            state_crc32 = 0
+
+            with ExitStack() as stack:
+                csv_file = (
+                    stack.enter_context(
+                        csv_body_path.open("w", encoding="utf-8", newline="")
+                    )
+                    if make_csv
+                    else None
+                )
+                state_file = (
+                    stack.enter_context(state_path.open("wb"))
+                    if make_png
+                    else None
+                )
+                feature_names = [
+                    f"mel_{band:03d}_q" for band in range(preset.n_mels)
+                ]
+                if csv_file is not None:
+                    header = (
+                        ["frame_index", "time_s"] + feature_names
+                        if include_time_columns
+                        else feature_names
+                    )
+                    csv_file.write(",".join(header) + "\n")
+
+                last_percent = -10
+                for first, frames in iter_centered_frames(
+                    audio,
+                    n_frames,
+                    preset.win_length,
+                    preset.hop_length,
+                    batch_frames,
+                    frame_dc_offset,
+                ):
+                    mel_power = backend.transform(frames)
+                    quantized, db_raw = mel_to_quantized(
+                        mel_power, reference_power, preset, silent
+                    )
+                    count = quantized.shape[0]
+
+                    if csv_file is not None:
+                        if include_time_columns:
+                            indices = np.arange(
+                                first, first + count, dtype=np.int64
+                            )
+                            times = (
+                                indices.astype(np.float64)
+                                * preset.hop_length
+                                / preset.sample_rate
+                            )
+                            table = np.column_stack((indices, times, quantized))
+                            formats: Sequence[str] = (
+                                ["%d", "%.9f"] + ["%d"] * preset.n_mels
+                            )
+                            np.savetxt(
+                                csv_file, table, delimiter=",", fmt=formats
+                            )
+                        else:
+                            np.savetxt(
+                                csv_file, quantized, delimiter=",", fmt="%d"
+                            )
+
+                    if preset.levels <= 256:
+                        canonical_states = np.ascontiguousarray(
+                            quantized, dtype=np.uint8
+                        )
+                    else:
+                        canonical_states = np.ascontiguousarray(
+                            quantized, dtype="<u2"
+                        )
+                    state_crc32 = zlib.crc32(
+                        canonical_states.tobytes(order="C"), state_crc32
+                    )
+                    if state_file is not None:
+                        state_file.write(canonical_states.tobytes(order="C"))
+
+                    for band in range(preset.n_mels):
+                        histograms[band] += np.bincount(
+                            quantized[:, band].astype(np.int64),
+                            minlength=preset.levels,
+                        ).astype(np.uint64)
+
+                    low = db_raw < preset.db_min
+                    high = db_raw > preset.db_max
+                    low_clip_count += low.sum(axis=0, dtype=np.uint64)
+                    high_clip_count += high.sum(axis=0, dtype=np.uint64)
+                    aggregate_low += int(low.sum())
+                    aggregate_high += int(high.sum())
+
+                    last_percent = print_progress(
+                        quiet,
+                        "write",
+                        first + count,
+                        n_frames,
+                        last_percent,
+                    )
+
+            state_crc32 &= 0xFFFFFFFF
+            roundtrip_metadata = build_roundtrip_metadata(
+                preset=preset,
+                sample_count=sample_count,
+                frame_count=n_frames,
+                include_time_columns=include_time_columns,
+                reference_power=reference_power,
+                reference_mode=reference_label,
+                silent=silent,
+                fft_power_normalizer=backend.power_normalizer,
+                state_crc32=state_crc32,
+                agc=(
+                    build_agc_metadata(
+                        agc_config,
+                        preset.sample_rate,
+                        preset.hop_length,
+                    )
+                    if agc_config is not None
+                    else None
+                ),
+            )
+
+            if make_csv:
+                write_self_describing_csv(
+                    temp_csv, csv_body_path, roundtrip_metadata
+                )
+
+            png_description: dict[str, Any] | None = None
+            if make_png:
+                png_description = write_state_png(
+                    output_path=temp_png,
+                    state_path=state_path,
+                    roundtrip_metadata=roundtrip_metadata,
+                    frame_count=n_frames,
+                    n_mels=preset.n_mels,
+                    levels=preset.levels,
+                    tile_width=png_tile_width,
+                    maximum_width=png_max_width,
+                    maximum_pixels=png_max_pixels,
+                )
+
+            per_band_stats = histogram_stats(
+                histograms,
+                low_clip_count,
+                high_clip_count,
+                n_frames,
+                centers_hz,
+            )
+            aggregate_histogram = histograms.sum(axis=0, dtype=np.uint64)
+            total_cells = n_frames * preset.n_mels
+            physical_columns = preset.n_mels + (
+                2 if include_time_columns else 0
+            )
+            metadata: dict[str, Any] = {
+                "format": "bounded_quantized_mel_v2",
+                "generator": {
+                    "name": Path(__file__).name,
+                    "version": VERSION,
+                },
+                "input": {
+                    "file_name": input_path.name,
+                    "file_size_bytes": input_path.stat().st_size,
+                    "decoded_sample_count": sample_count,
+                    "decoded_duration_seconds": duration_seconds,
+                    "decoded_channels": 1,
+                    "decoded_waveform_saturation_range": [-1.0, 1.0],
+                    "dc_offset_removed": dc_offset if remove_dc else 0.0,
+                    "dc_removal_uses_whole_file_mean": remove_dc,
+                },
+                "preprocessing": {
+                    "agc": (
+                        agc_diagnostics
+                        if agc_diagnostics is not None
+                        else {"enabled": False}
+                    )
+                },
+                "outputs": {
+                    "csv": paths["csv"].name if make_csv else None,
+                    "png": paths["png"].name if make_png else None,
+                    "metadata_json": paths["json"].name if write_json else None,
+                },
+                "roundtrip_metadata": roundtrip_metadata,
+                "visualization": png_description,
+                "preset": {
+                    **asdict(preset),
+                    "win_length_samples": preset.win_length,
+                    "hop_length_samples": preset.hop_length,
+                    "timestep_ms": (
+                        1000.0
+                        * preset.hop_length
+                        / preset.sample_rate
+                    ),
+                    "timesteps_per_second": preset.frames_per_second,
+                    "frames_per_second": preset.frames_per_second,
+                    "db_min": preset.db_min,
+                    "db_max": preset.db_max,
+                    "quantization_step_db": preset.quantization_step_db,
+                },
+                "framing": {
+                    "frame_count": n_frames,
+                    "centered": True,
+                    "padding": "constant_zero",
+                    "frame_time_seconds": (
+                        "frame_index * hop_length / sample_rate"
+                    ),
+                    "frame_count_formula": "ceil(decoded_samples / hop_length)",
+                    "timestep_ms": (
+                        1000.0
+                        * preset.hop_length
+                        / preset.sample_rate
+                    ),
+                    "timesteps_per_second": preset.frames_per_second,
+                    "window": "periodic_hann",
+                    "lookahead_samples": preset.win_length // 2,
+                },
+                "mel": {
+                    "scale": "HTK",
+                    "filter_shape": "triangular",
+                    "filter_normalization": "unit_sum",
+                    "power_spectrogram": True,
+                    "fft_power_normalizer": backend.power_normalizer,
+                    "fft_power_formula": (
+                        "|RFFT(window * frame)|^2 / (sum(window)/2)^2"
+                    ),
+                    "one_sided_power_convention": (
+                        "rfft bins are not doubled at interior frequencies"
+                    ),
+                    "minimum_power_before_log10": EPS_POWER,
+                    "band_centers_hz": [float(value) for value in centers_hz],
+                    "band_edges_hz": [float(value) for value in mel_edges_hz],
+                },
+                "reference": {
+                    "requested_mode": reference_mode,
+                    "effective_mode": reference_label,
+                    "reference_power": reference_power,
+                    "reference_percentile": (
+                        reference_percentile
+                        if reference_mode == "file_percentile"
+                        else None
+                    ),
+                    "maximum_observed_mel_power": max_power,
+                    "silent": silent,
+                    "future_dependent": reference_mode
+                    in {"file_percentile", "file_peak"},
+                },
+                "causality": {
+                    "zero_lookahead": False,
+                    "future_dependent": True,
+                    "reasons": [
+                        reason
+                        for condition, reason in (
+                            (
+                                reference_mode
+                                in {"file_percentile", "file_peak"},
+                                "whole-file spectral reference",
+                            ),
+                            (remove_dc, "whole-file waveform mean removal"),
+                            (
+                                agc_config is not None,
+                                "AGC buffers one control frame",
+                            ),
+                            (True, "centered window uses half-window lookahead"),
+                        )
+                        if condition
+                    ],
+                },
+                "quantization": {
+                    "formula": (
+                        "q=floor(clip((dB-db_min)*(levels-1)/"
+                        "(db_max-db_min),0,levels-1)+0.5)"
+                    ),
+                    "inverse_formula": (
+                        "dB_hat=db_min+q*(db_max-db_min)/(levels-1)"
+                    ),
+                    "integer_min": 0,
+                    "integer_max": preset.levels - 1,
+                    "states_per_mel_cell": preset.levels,
+                    "state_crc32": f"{state_crc32:08x}",
+                    "aggregate_state_counts": [
+                        int(value) for value in aggregate_histogram
+                    ],
+                    "aggregate_preclip_below_fraction": (
+                        aggregate_low / total_cells if total_cells else 0.0
+                    ),
+                    "aggregate_preclip_above_fraction": (
+                        aggregate_high / total_cells if total_cells else 0.0
+                    ),
+                    "per_band": per_band_stats,
+                },
+                "csv_schema": {
+                    "rows": n_frames,
+                    "mel_feature_columns": preset.n_mels,
+                    "physical_columns": physical_columns,
+                    "time_columns_included": include_time_columns,
+                    "self_describing": True,
+                    "metadata_position": "comment_after_header",
+                    "tokenize_only_columns_matching": "mel_*_q",
+                },
+                "state_space": {
+                    "states_per_cell": preset.levels,
+                    "independent_band_state_embeddings": (
+                        preset.n_mels * preset.levels
+                    ),
+                    "factorized_band_plus_level_embeddings": (
+                        preset.n_mels + preset.levels
+                    ),
+                    "nominal_frame_state_space": (
+                        f"{preset.levels}^{preset.n_mels}"
+                    ),
+                    "nominal_frame_state_bits": (
+                        preset.n_mels * math.log2(preset.levels)
+                    ),
+                    "serialized_scalar_cells_per_second": (
+                        preset.n_mels * preset.frames_per_second
+                    ),
+                },
+                "runtime": {
+                    "backend": backend.label,
+                    "batch_frames": batch_frames,
+                    "ffmpeg": get_ffmpeg_version(ffmpeg),
+                },
+            }
+
+            if write_json:
+                with temp_json.open("w", encoding="utf-8") as metadata_file:
+                    json.dump(metadata, metadata_file, indent=2, sort_keys=True)
+                    metadata_file.write("\n")
+
+            del audio
+
+        if make_csv:
+            os.replace(temp_csv, paths["csv"])
+        if make_png:
+            os.replace(temp_png, paths["png"])
+        if write_json:
+            os.replace(temp_json, paths["json"])
+        return metadata
+    except Exception:
+        for path in temp_files:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+        raise
+
+
+def apply_overrides(preset: Preset, args: argparse.Namespace) -> Preset:
+    replacements: dict[str, Any] = {}
+    mapping = {
+        "sample_rate": args.sample_rate,
+        "n_fft": args.n_fft,
+        "win_ms": args.win_ms,
+        "hop_ms": args.hop_ms,
+        "n_mels": args.n_mels,
+        "fmin": args.fmin,
+        "fmax": args.fmax,
+        "top_db": args.top_db,
+        "levels": args.levels,
+    }
+    for key, value in mapping.items():
+        if value is not None:
+            replacements[key] = value
+    return dataclasses.replace(preset, **replacements)
+
+
+def resolve_agc_config(
+    preset_name: str,
+    args: argparse.Namespace,
+) -> AgcConfig | None:
+    """Apply optional expert overrides to one ladder's AGC profile."""
+    if not args.agc:
+        return None
+    replacements: dict[str, float] = {}
+    mapping = {
+        "target_dbfs": args.agc_target_dbfs,
+        "attack_ms": args.agc_attack_ms,
+        "release_ms": args.agc_release_ms,
+        "max_gain_db": args.agc_max_gain_db,
+        "max_attenuation_db": args.agc_max_attenuation_db,
+        "gate_dbfs": args.agc_gate_dbfs,
+        "peak_dbfs": args.agc_peak_dbfs,
+    }
+    for key, value in mapping.items():
+        if value is not None:
+            replacements[key] = value
+    config = dataclasses.replace(AGC_PROFILES[preset_name], **replacements)
+    validate_agc_config(config)
+    return config
+
+
+def describe_presets() -> None:
+    print(
+        "preset  sr(Hz)  win/step(ms) mels  dB range    levels/range  "
+        "dB step  cells/s"
+    )
+    for preset in PRESETS.values():
+        print(
+            f"{preset.name:<7} "
+            f"{preset.sample_rate:>6}  "
+            f"{preset.win_ms:g}/{preset.hop_ms:g}".ljust(14)
+            + f"{preset.n_mels:>4}  "
+            f"[{-preset.top_db:g},0]".ljust(12)
+            + f"{preset.levels:>5} / 0..{preset.levels - 1:<4}  "
+            f"{preset.quantization_step_db:>7.4f}  "
+            f"{preset.n_mels * preset.frames_per_second:>7.0f}"
+        )
+
+
+def describe_agc_profiles() -> None:
+    print(
+        "preset   target  attack  release  max boost/atten  gate   peak  "
+        "control interval"
+    )
+    for preset_name, config in AGC_PROFILES.items():
+        preset = PRESETS[preset_name]
+        print(
+            f"{preset_name:<7} "
+            f"{config.target_dbfs:>6g}  "
+            f"{config.attack_ms:>6g}  "
+            f"{config.release_ms:>7g}  "
+            f"{config.max_gain_db:>6g}/{config.max_attenuation_db:<6g}  "
+            f"{config.gate_dbfs:>5g}  "
+            f"{config.peak_dbfs:>5g}  "
+            f"{preset.hop_ms:g} ms (selected timestep)"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Decode any FFmpeg-supported audio file and write self-describing "
+            "bounded mel-state CSV and/or exact-state PNG containers."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {VERSION}"
+    )
+    parser.add_argument("input", nargs="?", type=Path, help="Input audio/video file.")
+    parser.add_argument(
+        "--preset",
+        choices=[*PRESETS, "all"],
+        default="medium",
+        help="Quality/state-space preset.",
+    )
+    parser.add_argument(
+        "--describe-presets",
+        action="store_true",
+        help="Print the built-in preset table and exit.",
+    )
+    parser.add_argument(
+        "--describe-agc",
+        action="store_true",
+        help="Print the five built-in AGC profiles and exit.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("."),
+        help="Directory for generated outputs.",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        help="Output basename prefix; defaults to the input filename stem.",
+    )
+    parser.add_argument(
+        "--device",
+        default="auto",
+        help="auto, cpu, cuda, or cuda:N. CPU uses NumPy.",
+    )
+    parser.add_argument(
+        "--ffmpeg",
+        default="ffmpeg",
+        help="FFmpeg executable name or path.",
+    )
+    parser.add_argument(
+        "--batch-frames",
+        type=int,
+        default=512,
+        help="Frames per FFT batch; lower this to reduce peak memory.",
+    )
+    parser.add_argument(
+        "--reference-mode",
+        choices=["file_percentile", "file_peak", "fixed"],
+        default="file_percentile",
+        help=(
+            "Spectral gain reference. file_* is gain-invariant but "
+            "future-dependent; fixed is corpus/deployment comparable."
+        ),
+    )
+    parser.add_argument(
+        "--reference-percentile",
+        type=float,
+        default=99.5,
+        help="Percentile used by file_percentile reference mode.",
+    )
+    parser.add_argument(
+        "--reference-power",
+        type=float,
+        help="Positive frozen reference used by --reference-mode fixed.",
+    )
+    parser.add_argument(
+        "--max-reference-values",
+        type=int,
+        default=262_144,
+        help="Bounded deterministic sample size for percentile estimation.",
+    )
+    parser.add_argument(
+        "--include-time-columns",
+        action="store_true",
+        help="Prepend frame_index,time_s to the CSV (do not tokenize them).",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["csv", "png", "both"],
+        default="both",
+        help="Generate a standalone CSV, standalone PNG, or both.",
+    )
+    parser.add_argument(
+        "--write-json",
+        action="store_true",
+        help="Also write the verbose diagnostics JSON sidecar.",
+    )
+    parser.add_argument(
+        "--no-png",
+        action="store_true",
+        help="Deprecated alias for --output-format csv.",
+    )
+    parser.add_argument(
+        "--png-tile-width",
+        type=int,
+        help="Frames per horizontal PNG strip; automatic when omitted.",
+    )
+    parser.add_argument(
+        "--png-max-width",
+        type=int,
+        default=8192,
+        help="Maximum automatic or explicit PNG strip width.",
+    )
+    parser.add_argument(
+        "--png-max-pixels",
+        type=int,
+        default=80_000_000,
+        help="Safety limit for the exact-state PNG raster.",
+    )
+    parser.add_argument(
+        "--keep-dc",
+        action="store_true",
+        help="Do not remove the decoded file's global DC offset.",
+    )
+    agc = parser.add_argument_group(
+        "optional broadband waveform AGC (fixed mel token bins are unchanged)"
+    )
+    agc.add_argument(
+        "--agc",
+        action="store_true",
+        help=(
+            "Enable the selected quality ladder's lossy waveform AGC. "
+            "With --preset all, each ladder uses its own profile."
+        ),
+    )
+    agc.add_argument(
+        "--agc-target-dbfs",
+        type=float,
+        help="Override the ladder's RMS target in dBFS.",
+    )
+    agc.add_argument(
+        "--agc-attack-ms",
+        type=float,
+        help="Override the gain-reduction time constant in milliseconds.",
+    )
+    agc.add_argument(
+        "--agc-release-ms",
+        type=float,
+        help="Override the gain-increase time constant in milliseconds.",
+    )
+    agc.add_argument(
+        "--agc-max-gain-db",
+        type=float,
+        help="Override the maximum positive controller gain.",
+    )
+    agc.add_argument(
+        "--agc-max-attenuation-db",
+        type=float,
+        help="Override the maximum controller attenuation.",
+    )
+    agc.add_argument(
+        "--agc-gate-dbfs",
+        type=float,
+        help="Override the RMS gate; gated frames receive no positive boost.",
+    )
+    agc.add_argument(
+        "--agc-peak-dbfs",
+        type=float,
+        help="Override the final hard peak ceiling in dBFS.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing outputs.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress progress messages.",
+    )
+
+    custom = parser.add_argument_group(
+        "preset overrides (use one built-in preset as the starting point)"
+    )
+    custom.add_argument(
+        "--sample-rate",
+        "--samples-per-second",
+        dest="sample_rate",
+        type=int,
+        action=StoreConsistentValue,
+        metavar="HZ",
+        help=(
+            "Decoded waveform samples per second. This sets audio bandwidth "
+            "and converts --win-ms/--timestep-ms into integer sample counts; "
+            "fmax may not exceed half this value."
+        ),
+    )
+    custom.add_argument("--n-fft", type=int)
+    custom.add_argument("--win-ms", type=float)
+    custom.add_argument(
+        "--timestep-ms",
+        "--hop-ms",
+        dest="hop_ms",
+        type=float,
+        action=StoreConsistentValue,
+        metavar="MS",
+        help=(
+            "Time between mel rows in milliseconds. --hop-ms is an exact "
+            "alias; the rounded sample hop is embedded for reconstruction."
+        ),
+    )
+    custom.add_argument(
+        "--columns-per-timestep",
+        "--n-mels",
+        dest="n_mels",
+        type=int,
+        action=StoreConsistentValue,
+        metavar="C",
+        help=(
+            "Tokenized mel columns in every row. --n-mels is an exact alias."
+        ),
+    )
+    custom.add_argument("--fmin", type=float)
+    custom.add_argument("--fmax", type=float)
+    custom.add_argument("--top-db", type=float)
+    custom.add_argument(
+        "--states-per-column",
+        "--levels",
+        dest="levels",
+        type=int,
+        action=StoreConsistentValue,
+        metavar="K",
+        help=(
+            "Legal integer states per mel column; need not be a power of 2. "
+            "--levels is an exact alias."
+        ),
+    )
+    return parser
+
+
+def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    if args.describe_presets or args.describe_agc:
+        return
+    if args.input is None:
+        parser.error(
+            "input is required unless --describe-presets or --describe-agc "
+            "is used."
+        )
+    if not args.input.is_file():
+        parser.error(f"input is not a readable file: {args.input}")
+    if not (0.0 < args.reference_percentile <= 100.0):
+        parser.error("--reference-percentile must be in (0, 100].")
+    if args.max_reference_values < 1:
+        parser.error("--max-reference-values must be positive.")
+    if args.png_tile_width is not None and args.png_tile_width < 1:
+        parser.error("--png-tile-width must be positive.")
+    if args.png_max_width < 1:
+        parser.error("--png-max-width must be positive.")
+    if args.png_max_pixels < 1:
+        parser.error("--png-max-pixels must be positive.")
+    if args.n_mels is not None and not 1 <= args.n_mels <= 4096:
+        parser.error("--columns-per-timestep must be in [1, 4096].")
+    if args.levels is not None and not 2 <= args.levels <= 65_536:
+        parser.error("--states-per-column must be in [2, 65536].")
+    if args.sample_rate is not None and args.sample_rate < 1:
+        parser.error("--samples-per-second must be positive.")
+    if args.hop_ms is not None and (
+        not math.isfinite(args.hop_ms) or args.hop_ms <= 0.0
+    ):
+        parser.error("--timestep-ms must be finite and positive.")
+    if (
+        args.png_tile_width is not None
+        and args.png_tile_width > args.png_max_width
+    ):
+        parser.error("--png-tile-width cannot exceed --png-max-width.")
+    if args.reference_mode == "fixed" and (
+        args.reference_power is None
+        or not math.isfinite(args.reference_power)
+        or args.reference_power <= 0.0
+    ):
+        parser.error(
+            "--reference-mode fixed requires a positive --reference-power."
+        )
+    agc_override_names = (
+        "agc_target_dbfs",
+        "agc_attack_ms",
+        "agc_release_ms",
+        "agc_max_gain_db",
+        "agc_max_attenuation_db",
+        "agc_gate_dbfs",
+        "agc_peak_dbfs",
+    )
+    if not args.agc and any(
+        getattr(args, name) is not None for name in agc_override_names
+    ):
+        parser.error("AGC parameter overrides require --agc.")
+    override_names = (
+        "sample_rate",
+        "n_fft",
+        "win_ms",
+        "hop_ms",
+        "n_mels",
+        "fmin",
+        "fmax",
+        "top_db",
+        "levels",
+    )
+    if args.preset == "all" and any(
+        getattr(args, name) is not None for name in override_names
+    ):
+        parser.error("Preset overrides cannot be combined with --preset all.")
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    validate_args(parser, args)
+    if args.describe_presets:
+        describe_presets()
+    if args.describe_agc:
+        describe_agc_profiles()
+    if args.describe_presets or args.describe_agc:
+        return 0
+
+    assert args.input is not None
+    input_path = args.input.resolve()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = args.output_dir.resolve()
+    preset_names = list(PRESETS) if args.preset == "all" else [args.preset]
+    summaries: list[dict[str, Any]] = []
+    output_format = "csv" if args.no_png else args.output_format
+
+    try:
+        for preset_name in preset_names:
+            preset = apply_overrides(PRESETS[preset_name], args)
+            agc_config = resolve_agc_config(preset_name, args)
+            metadata = convert_one(
+                input_path=input_path,
+                output_dir=output_dir,
+                output_prefix=args.output_prefix,
+                preset=preset,
+                device=args.device,
+                ffmpeg=args.ffmpeg,
+                batch_frames=args.batch_frames,
+                reference_mode=args.reference_mode,
+                reference_percentile=args.reference_percentile,
+                fixed_reference_power=args.reference_power,
+                max_reference_values=args.max_reference_values,
+                include_time_columns=args.include_time_columns,
+                output_format=output_format,
+                write_json=args.write_json,
+                png_tile_width=args.png_tile_width,
+                png_max_width=args.png_max_width,
+                png_max_pixels=args.png_max_pixels,
+                remove_dc=not args.keep_dc,
+                agc_config=agc_config,
+                force=args.force,
+                quiet=args.quiet,
+            )
+            summaries.append(
+                {
+                    "preset": preset.name,
+                    "csv": (
+                        str(
+                            output_paths(
+                                input_path,
+                                output_dir,
+                                args.output_prefix,
+                                preset.name,
+                            )["csv"]
+                        )
+                        if output_format in {"csv", "both"}
+                        else None
+                    ),
+                    "png": (
+                        str(
+                            output_paths(
+                                input_path,
+                                output_dir,
+                                args.output_prefix,
+                                preset.name,
+                            )["png"]
+                        )
+                        if output_format in {"png", "both"}
+                        else None
+                    ),
+                    "rows": metadata["csv_schema"]["rows"],
+                    "mel_columns": metadata["csv_schema"]["mel_feature_columns"],
+                    "columns_per_timestep": metadata["csv_schema"][
+                        "mel_feature_columns"
+                    ],
+                    "states_per_cell": metadata["quantization"][
+                        "states_per_mel_cell"
+                    ],
+                    "states_per_column": metadata["quantization"][
+                        "states_per_mel_cell"
+                    ],
+                    "sample_rate": preset.sample_rate,
+                    "samples_per_second": preset.sample_rate,
+                    "nyquist_hz": preset.sample_rate / 2.0,
+                    "n_fft": preset.n_fft,
+                    "window_ms": preset.win_ms,
+                    "window_samples": preset.win_length,
+                    "hop_samples": preset.hop_length,
+                    "timestep_ms": metadata["framing"]["timestep_ms"],
+                    "timesteps_per_second": metadata["framing"][
+                        "timesteps_per_second"
+                    ],
+                    "agc_enabled": metadata["preprocessing"]["agc"][
+                        "enabled"
+                    ],
+                    "agc_profile": (
+                        metadata["preprocessing"]["agc"].get("profile")
+                    ),
+                    "backend": metadata["runtime"]["backend"],
+                }
+            )
+    except (OSError, ValueError, RuntimeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    print(json.dumps({"outputs": summaries}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/data/mel_spectrogram/demo.sh
+++ b/data/mel_spectrogram/demo.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: bash demo.sh INPUT [PRESET] [DEVICE] [OUTPUT_DIR] [OPTIONS]"
+    echo
+    echo "PRESET: small, medium, high, ultra, or max"
+    echo "DEVICE: auto, cpu, cuda, or cuda:N"
+    echo "OPTIONS:"
+    echo "  --columns-per-timestep C   Alias: --n-mels"
+    echo "  --states-per-column K      Alias: --levels"
+    echo "  --timestep-ms MS           Alias: --hop-ms"
+    echo "  --agc                      Enable the selected preset's AGC profile"
+    echo "  --agc-target-dbfs DB"
+    echo "  --agc-attack-ms MS"
+    echo "  --agc-release-ms MS"
+    echo "  --agc-max-gain-db DB"
+    echo "  --agc-max-attenuation-db DB"
+    echo "  --agc-gate-dbfs DB"
+    echo "  --agc-peak-dbfs DB"
+}
+
+if [[ $# -lt 1 || "$1" == "--help" || "$1" == "-h" ]]; then
+    usage
+    [[ $# -ge 1 ]] && exit 0
+    exit 1
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+input="$1"
+shift
+
+preset="medium"
+device="auto"
+output_dir="mel_out"
+if [[ $# -gt 0 && "$1" != --* ]]; then
+    preset="$1"
+    shift
+fi
+if [[ $# -gt 0 && "$1" != --* ]]; then
+    device="$1"
+    shift
+fi
+if [[ $# -gt 0 && "$1" != --* ]]; then
+    output_dir="$1"
+    shift
+fi
+
+columns=""
+states=""
+timestep_ms=""
+agc_enabled=0
+agc_override_seen=0
+agc_args=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --columns-per-timestep|--n-mels)
+            [[ $# -ge 2 ]] || {
+                echo "$1 requires an integer value." >&2
+                exit 1
+            }
+            if [[ -n "$columns" && "$columns" != "$2" ]]; then
+                echo "$1=$2 conflicts with the earlier column value $columns." >&2
+                exit 1
+            fi
+            columns="$2"
+            shift 2
+            ;;
+        --states-per-column|--levels)
+            [[ $# -ge 2 ]] || {
+                echo "$1 requires an integer value." >&2
+                exit 1
+            }
+            if [[ -n "$states" && "$states" != "$2" ]]; then
+                echo "$1=$2 conflicts with the earlier state value $states." >&2
+                exit 1
+            fi
+            states="$2"
+            shift 2
+            ;;
+        --timestep-ms|--hop-ms)
+            [[ $# -ge 2 ]] || {
+                echo "$1 requires a positive millisecond value." >&2
+                exit 1
+            }
+            if [[ -n "$timestep_ms" && "$timestep_ms" != "$2" ]]; then
+                echo "$1=$2 conflicts with the earlier timestep value $timestep_ms." >&2
+                exit 1
+            fi
+            timestep_ms="$2"
+            shift 2
+            ;;
+        --agc)
+            agc_enabled=1
+            shift
+            ;;
+        --agc-target-dbfs|--agc-attack-ms|--agc-release-ms|\
+        --agc-max-gain-db|--agc-max-attenuation-db|\
+        --agc-gate-dbfs|--agc-peak-dbfs)
+            [[ $# -ge 2 ]] || {
+                echo "$1 requires a numeric value." >&2
+                exit 1
+            }
+            agc_override_seen=1
+            agc_args+=("$1" "$2")
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -f "$input" ]]; then
+    echo "Input does not exist: $input" >&2
+    exit 1
+fi
+
+case "$preset" in
+    small|medium|high|ultra|max) ;;
+    *)
+        echo "Preset must be small, medium, high, ultra, or max." >&2
+        exit 1
+        ;;
+esac
+
+case "$preset" in
+    small) base_columns=20; base_states=16 ;;
+    medium) base_columns=40; base_states=64 ;;
+    high) base_columns=80; base_states=256 ;;
+    ultra) base_columns=160; base_states=1024 ;;
+    max) base_columns=320; base_states=4096 ;;
+esac
+
+if [[ ! "$device" =~ ^(auto|cpu|cuda|cuda:[0-9]+)$ ]]; then
+    echo "Device must be auto, cpu, cuda, or cuda:N." >&2
+    exit 1
+fi
+
+if [[ -n "$columns" ]]; then
+    if [[ ! "$columns" =~ ^[0-9]{1,4}$ ]] \
+        || (( 10#$columns < 1 || 10#$columns > 4096 )); then
+        echo "Columns per timestep must be an integer in [1, 4096]." >&2
+        exit 1
+    fi
+fi
+if [[ -n "$states" ]]; then
+    if [[ ! "$states" =~ ^[0-9]{1,5}$ ]] \
+        || (( 10#$states < 2 || 10#$states > 65536 )); then
+        echo "States per column must be an integer in [2, 65536]." >&2
+        exit 1
+    fi
+fi
+if [[ -n "$timestep_ms" ]] \
+    && [[ ! "$timestep_ms" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][-+]?[0-9]+)?$ ]]; then
+    echo "Timestep must be a positive finite number of milliseconds." >&2
+    exit 1
+fi
+if (( agc_override_seen == 1 && agc_enabled == 0 )); then
+    echo "AGC expert overrides require --agc." >&2
+    exit 1
+fi
+
+filename="${input##*/}"
+stem="${filename%.*}"
+if [[ -z "$stem" ]]; then
+    stem="$filename"
+fi
+
+output_prefix="$stem"
+forward_args=()
+if [[ -n "$columns" || -n "$states" ]]; then
+    effective_columns="${columns:-$base_columns}"
+    effective_states="${states:-$base_states}"
+    output_prefix="$stem.c$effective_columns.k$effective_states"
+fi
+if [[ -n "$columns" ]]; then
+    forward_args+=(--columns-per-timestep "$columns")
+fi
+if [[ -n "$states" ]]; then
+    forward_args+=(--states-per-column "$states")
+fi
+if [[ -n "$timestep_ms" ]]; then
+    timestep_label="${timestep_ms//E/e}"
+    output_prefix="$output_prefix.dt${timestep_label}ms"
+    forward_args+=(--timestep-ms "$timestep_ms")
+fi
+if (( agc_enabled == 1 )); then
+    output_prefix="$output_prefix.agc"
+    forward_args+=(--agc)
+    forward_args+=("${agc_args[@]}")
+fi
+
+csv_path="$output_dir/$output_prefix.$preset.mel.csv"
+png_path="$output_dir/$output_prefix.$preset.mel.png"
+csv_audio="$output_dir/$output_prefix.$preset.from_csv.wav"
+png_audio="$output_dir/$output_prefix.$preset.from_png.wav"
+
+python3 "$script_dir/audio_to_token_mel.py" "$input" \
+    --preset "$preset" \
+    --output-format both \
+    --output-dir "$output_dir" \
+    --output-prefix "$output_prefix" \
+    --device "$device" \
+    "${forward_args[@]}" \
+    --force
+
+python3 "$script_dir/token_mel_to_audio.py" "$csv_path" \
+    --output "$csv_audio" \
+    --device "$device" \
+    --force
+
+python3 "$script_dir/token_mel_to_audio.py" "$png_path" \
+    --output "$png_audio" \
+    --device "$device" \
+    --force
+
+echo
+echo "Created:"
+echo "  CSV:       $csv_path"
+echo "  PNG:       $png_path"
+echo "  CSV audio: $csv_audio"
+echo "  PNG audio: $png_audio"

--- a/data/mel_spectrogram/helpers/convert_to_wav.sh
+++ b/data/mel_spectrogram/helpers/convert_to_wav.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# convert flac to wav
+ffmpeg -i "${1}" "${1%%.flac}.wav"
+

--- a/data/mel_spectrogram/run.sh
+++ b/data/mel_spectrogram/run.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -x
+
+# point this at an flac or wav file
+
+bash helpers/convert_to_wav.sh "${1}"
+
+python audio_to_token_mel.py "${1%%.flac}.wav" --force \
+  --preset max \
+  --samples-per-second 48000 \
+  --fmin 10 \
+  --fmax 20000 \
+  --columns-per-timestep 384 \
+  --states-per-column 64 \
+  --timestep-ms 15 \
+  --win-ms 60 \
+  --n-fft 8192 \
+  --top-db 96 \
+  --reference-mode file_percentile \
+  --output-format both \
+  --output-dir mel_out
+
+
+python token_mel_to_audio.py \
+  "mel_out/${1%%.flac}.max.mel.csv" \
+  -o out.wav \
+  --griffin-lim-iters 128 \
+  --griffin-lim-chunk-frames 0 \
+  --peak 1.0 \
+  --force ; mpv out.wav
+

--- a/data/mel_spectrogram/token_mel_to_audio.py
+++ b/data/mel_spectrogram/token_mel_to_audio.py
@@ -1,0 +1,1952 @@
+#!/usr/bin/env python3
+"""
+Reconstruct best-effort WAV audio from one self-describing mel CSV or PNG.
+
+No JSON sidecar is required.  Version-2 CSV files contain compact metadata in a
+comment after the header.  QMel-PNG version 2 stores exact state IDs as palette
+indices or on an exact 16-bit grayscale lattice and carries the same metadata
+in both iTXt and a checksummed pixel header.
+
+The result cannot equal the source waveform: mel projection, saturation,
+quantization, mono downmixing, and discarded phase are intrinsically lossy.
+This script uses nonnegative mel inversion followed by a custom Griffin-Lim
+implementation matching audio_to_token_mel.py's framing convention.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import re
+import struct
+import sys
+import tempfile
+import wave
+import zlib
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from audio_to_token_mel import (
+    CSV_METADATA_PREFIX,
+    PNG_METADATA_KEY,
+    PNG_PIXEL_MAGIC,
+    PRESETS,
+    Preset,
+    StoreConsistentValue,
+    compact_json,
+    encode_scaled_u16_states,
+    make_mel_filterbank,
+    periodic_hann,
+    validate_preset,
+)
+
+
+VERSION = "2.4.0"
+MAX_EMBEDDED_METADATA_BYTES = 1_000_000
+AGC_LOSS_WARNING = (
+    "Source was normalized with lossy AGC; original absolute level and "
+    "loudness envelope cannot be recovered because the gain envelope was "
+    "not stored."
+)
+
+
+@dataclass
+class MelContainer:
+    states: np.ndarray
+    metadata: dict[str, Any]
+    source_kind: str
+    metadata_origin: str
+    warnings: list[str]
+
+
+def canonical_state_crc(states: np.ndarray, levels: int) -> int:
+    if levels <= 256:
+        canonical = np.ascontiguousarray(states, dtype=np.uint8)
+    else:
+        canonical = np.ascontiguousarray(states, dtype="<u2")
+    return zlib.crc32(canonical.tobytes(order="C")) & 0xFFFFFFFF
+
+
+def parse_crc(value: str | int) -> int:
+    if isinstance(value, int):
+        return value
+    return int(value, 16)
+
+
+def bounded_zlib_decompress(
+    compressed: bytes,
+    maximum_output_bytes: int = MAX_EMBEDDED_METADATA_BYTES,
+) -> bytes:
+    decoder = zlib.decompressobj()
+    output = decoder.decompress(compressed, maximum_output_bytes + 1)
+    if (
+        len(output) > maximum_output_bytes
+        or decoder.unconsumed_tail
+        or not decoder.eof
+    ):
+        raise ValueError("QMel metadata exceeds the decompression safety limit.")
+    output += decoder.flush()
+    if len(output) > maximum_output_bytes:
+        raise ValueError("QMel metadata exceeds the decompression safety limit.")
+    return output
+
+
+def validate_roundtrip_metadata(metadata: dict[str, Any]) -> None:
+    """Reject metadata that this inverse cannot safely or faithfully apply."""
+    format_name = metadata.get("format")
+    version = int(metadata.get("version", -1))
+    if not (
+        (format_name == "bounded_quantized_mel_v2" and version == 2)
+        or (format_name == "metadata_free_best_effort" and version == 0)
+    ):
+        raise ValueError(
+            f"Unsupported mel container format/version: {format_name!r}/{version}."
+        )
+    shape = metadata["shape"]
+    waveform = metadata["waveform"]
+    stft = metadata["stft"]
+    mel = metadata["mel"]
+    quantizer = metadata["quantizer"]
+
+    timesteps = int(shape["timesteps"])
+    bands = int(shape["bands"])
+    sample_rate = int(waveform["sample_rate"])
+    sample_count = int(waveform["decoded_sample_count"])
+    n_fft = int(stft["n_fft"])
+    win_length = int(stft["win_length"])
+    hop_length = int(stft["hop_length"])
+    n_mels = int(mel["n_mels"])
+    levels = int(quantizer["levels"])
+    integer_min = int(quantizer.get("integer_min", 0))
+    integer_max = int(quantizer.get("integer_max", levels - 1))
+
+    if shape.get("axis_order") != "TC":
+        raise ValueError("Only timesteps-by-columns (TC) metadata is supported.")
+    if timesteps < 1 or bands < 1 or bands > 4096:
+        raise ValueError("Metadata shape dimensions must be positive.")
+    if sample_rate < 1 or sample_rate > 768_000 or sample_count < 1:
+        raise ValueError("Metadata sample rate and sample count must be positive.")
+    if (
+        win_length < 2
+        or hop_length < 1
+        or n_fft < win_length
+        or n_fft > 262_144
+    ):
+        raise ValueError("Metadata contains an invalid STFT size or hop.")
+    if hop_length > win_length // 2:
+        raise ValueError(
+            "Metadata hop length exceeds half the centered window."
+        )
+    if math.ceil(sample_count / hop_length) != timesteps:
+        raise ValueError(
+            "Metadata sample count, hop length, and timestep count disagree."
+        )
+    if n_mels != bands:
+        raise ValueError("Metadata mel-band count disagrees with its shape.")
+    fmin = float(mel["fmin"])
+    fmax = float(mel["fmax"])
+    if not (
+        math.isfinite(fmin)
+        and math.isfinite(fmax)
+        and 0.0 <= fmin < fmax <= sample_rate / 2.0 + 1.0e-9
+    ):
+        raise ValueError("Metadata contains an invalid mel frequency range.")
+    if levels < 2 or levels > 65_536:
+        raise ValueError("Metadata quantizer levels must be in [2,65536].")
+    if integer_min != 0 or integer_max != levels - 1:
+        raise ValueError("Only contiguous zero-based quantizer states are supported.")
+    db_min = float(quantizer["db_min"])
+    db_max = float(quantizer["db_max"])
+    reference = float(quantizer["reference_power"])
+    normalizer = float(stft["power_normalizer"])
+    if not (
+        math.isfinite(db_min)
+        and math.isfinite(db_max)
+        and db_min < db_max
+    ):
+        raise ValueError("Metadata contains an invalid dB interval.")
+    if not math.isfinite(reference) or reference <= 0.0:
+        raise ValueError("Metadata reference power must be positive and finite.")
+    if not math.isfinite(normalizer) or normalizer <= 0.0:
+        raise ValueError("Metadata STFT power normalizer must be positive.")
+    expected_conventions = {
+        "window": "periodic_hann",
+        "frame_center": "t*hop",
+        "padding": "constant_zero",
+        "fft_zero_padding": "right",
+    }
+    for key, expected in expected_conventions.items():
+        if stft.get(key) != expected:
+            raise ValueError(
+                f"Unsupported STFT {key}={stft.get(key)!r}; expected {expected!r}."
+            )
+    if (
+        mel.get("scale") != "HTK"
+        or mel.get("filter_shape") != "triangular"
+        or mel.get("filter_normalization") != "unit_sum"
+    ):
+        raise ValueError("Only HTK, unit-sum mel metadata is supported.")
+
+    preprocessing = metadata.get("preprocessing")
+    if preprocessing is not None:
+        if not isinstance(preprocessing, dict):
+            raise ValueError("Metadata preprocessing must be an object.")
+        agc = preprocessing.get("agc")
+        if agc is not None:
+            validate_agc_metadata(agc)
+            if (
+                agc.get("enabled") is True
+                and int(agc["control_frame_samples"]) != hop_length
+            ):
+                raise ValueError(
+                    "Metadata AGC control frame must equal the STFT hop length."
+                )
+            if agc.get("enabled") is True:
+                expected_control_ms = 1000.0 * hop_length / sample_rate
+                if not math.isclose(
+                    float(agc["control_frame_ms"]),
+                    expected_control_ms,
+                    rel_tol=1.0e-12,
+                    abs_tol=1.0e-9,
+                ):
+                    raise ValueError(
+                        "Metadata AGC control-frame milliseconds disagree "
+                        "with its sample rate and hop length."
+                    )
+
+
+def validate_agc_metadata(agc: Any) -> None:
+    """Validate optional v2.3 AGC provenance without requiring it for v2.2."""
+    if not isinstance(agc, dict):
+        raise ValueError("Metadata preprocessing.agc must be an object.")
+    enabled = agc.get("enabled")
+    if not isinstance(enabled, bool):
+        raise ValueError("Metadata preprocessing.agc.enabled must be boolean.")
+    if not enabled:
+        return
+
+    if agc.get("algorithm") != "causal_block_rms_db_v1":
+        raise ValueError("Metadata contains an unsupported AGC algorithm.")
+    profile = agc.get("profile")
+    if not isinstance(profile, str) or not profile:
+        raise ValueError("Metadata AGC profile must be a nonempty string.")
+    if agc.get("gain_envelope_stored") is not False:
+        raise ValueError("AGC metadata must declare that no gain envelope is stored.")
+    if agc.get("reversible") is not False:
+        raise ValueError("AGC metadata must declare the preprocessing irreversible.")
+    if agc.get("reconstruction_domain") != "agc_normalized":
+        raise ValueError("Metadata contains an unsupported AGC reconstruction domain.")
+    if agc.get("limiter") != "hard_peak_ceiling":
+        raise ValueError("Metadata contains an unsupported AGC limiter.")
+
+    numeric_fields = (
+        "target_dbfs",
+        "control_frame_ms",
+        "attack_ms",
+        "release_ms",
+        "max_gain_db",
+        "max_attenuation_db",
+        "gate_dbfs",
+        "peak_ceiling_dbfs",
+        "initial_gain_db",
+    )
+    values: dict[str, float] = {}
+    for field in numeric_fields:
+        value = agc.get(field)
+        if isinstance(value, bool):
+            raise ValueError(f"Metadata AGC {field} must be finite.")
+        try:
+            values[field] = float(value)
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"Metadata AGC {field} must be finite.") from error
+        if not math.isfinite(values[field]):
+            raise ValueError(f"Metadata AGC {field} must be finite.")
+
+    control_frame_samples = agc.get("control_frame_samples")
+    if (
+        isinstance(control_frame_samples, bool)
+        or not isinstance(control_frame_samples, int)
+        or control_frame_samples < 1
+    ):
+        raise ValueError(
+            "Metadata AGC control_frame_samples must be a positive integer."
+        )
+    if values["control_frame_ms"] <= 0.0:
+        raise ValueError("Metadata AGC control_frame_ms must be positive.")
+    if not 0.1 <= values["attack_ms"] <= 10_000.0:
+        raise ValueError("Metadata AGC attack must be in [0.1,10000] ms.")
+    if not values["attack_ms"] <= values["release_ms"] <= 60_000.0:
+        raise ValueError(
+            "Metadata AGC release must be in [attack_ms,60000] ms."
+        )
+    if not (
+        0.0 <= values["max_gain_db"] <= 60.0
+        and 0.0 <= values["max_attenuation_db"] <= 60.0
+    ):
+        raise ValueError("Metadata AGC gain limits must be in [0,60] dB.")
+    if not (
+        -120.0
+        <= values["gate_dbfs"]
+        < values["target_dbfs"]
+        < values["peak_ceiling_dbfs"]
+        <= 0.0
+    ):
+        raise ValueError(
+            "Metadata AGC gate, target, and peak ceiling are inconsistent."
+        )
+
+
+def verify_states(
+    states: np.ndarray,
+    metadata: dict[str, Any],
+    *,
+    verify_crc: bool = True,
+) -> np.ndarray:
+    validate_roundtrip_metadata(metadata)
+    if states.ndim != 2 or states.shape[0] < 1 or states.shape[1] < 1:
+        raise ValueError("State matrix must have shape timesteps x mel_bands.")
+    if not np.isfinite(states).all():
+        raise ValueError("State matrix contains NaN or infinity.")
+    if np.issubdtype(states.dtype, np.integer):
+        states_i64 = states.astype(np.int64, copy=False)
+    else:
+        rounded = np.rint(states)
+        if not np.allclose(states, rounded, rtol=0.0, atol=1.0e-7):
+            raise ValueError("State matrix contains non-integer values.")
+        states_i64 = rounded.astype(np.int64)
+
+    shape = metadata["shape"]
+    levels = int(metadata["quantizer"]["levels"])
+    expected = (int(shape["timesteps"]), int(shape["bands"]))
+    if states_i64.shape != expected:
+        raise ValueError(
+            f"State shape {states_i64.shape} does not match metadata {expected}."
+        )
+    if int(states_i64.min()) < 0 or int(states_i64.max()) >= levels:
+        raise ValueError(
+            f"State IDs must be in [0, {levels - 1}], received "
+            f"[{states_i64.min()}, {states_i64.max()}]."
+        )
+
+    integrity = metadata.get("integrity", {})
+    expected_crc = integrity.get("state_crc32")
+    if verify_crc and expected_crc is not None:
+        actual_crc = canonical_state_crc(states_i64, levels)
+        if actual_crc != parse_crc(expected_crc):
+            raise ValueError(
+                f"State CRC mismatch: expected {expected_crc}, "
+                f"calculated {actual_crc:08x}."
+            )
+    compact_dtype = np.uint8 if levels <= 256 else np.uint16
+    return states_i64.astype(compact_dtype, copy=False)
+
+
+def read_csv_container(path: Path) -> MelContainer:
+    metadata: dict[str, Any] | None = None
+    header_line: str | None = None
+    header_index: int | None = None
+
+    with path.open("r", encoding="utf-8", newline="") as input_file:
+        for line_index, line in enumerate(input_file):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.startswith(CSV_METADATA_PREFIX):
+                metadata = json.loads(stripped[len(CSV_METADATA_PREFIX) :])
+                if header_line is not None:
+                    break
+                continue
+            if stripped.startswith("#"):
+                continue
+            if header_line is None:
+                header_line = line
+                header_index = line_index
+            else:
+                # In v2 the metadata comment precedes every data row. Reaching
+                # data here establishes the metadata-free fallback promptly.
+                break
+
+    if header_line is None or header_index is None:
+        raise ValueError("CSV has no header.")
+    header = next(csv.reader([header_line]))
+    feature_indices = [
+        index
+        for index, name in enumerate(header)
+        if re.fullmatch(r"mel_\d+_q", name.strip())
+    ]
+    warnings: list[str] = []
+    if metadata is None:
+        try:
+            states = np.loadtxt(
+                path,
+                delimiter=",",
+                comments="#",
+                skiprows=header_index + 1,
+                usecols=feature_indices or None,
+                ndmin=2,
+                dtype=np.int64,
+            )
+        except ValueError as error:
+            raise ValueError(
+                f"Could not parse rectangular numeric CSV data: {error}"
+            ) from error
+        warnings.append(
+            "CSV has no embedded v2 metadata; preset/configuration must be inferred."
+        )
+        return MelContainer(
+            states=states,
+            metadata={},
+            source_kind="csv",
+            metadata_origin="none",
+            warnings=warnings,
+        )
+
+    validate_roundtrip_metadata(metadata)
+    expected_rows = int(metadata["shape"]["timesteps"])
+    expected_columns = int(metadata["shape"]["bands"])
+    levels = int(metadata["quantizer"]["levels"])
+    if len(feature_indices) != expected_columns:
+        raise ValueError(
+            f"CSV header contains {len(feature_indices)} mel columns; "
+            f"metadata declares {expected_columns}."
+        )
+    if expected_rows * expected_columns > path.stat().st_size:
+        raise ValueError("CSV metadata declares more state cells than the file can hold.")
+    compact_dtype = np.uint8 if levels <= 256 else np.uint16
+    states = np.empty(
+        (expected_rows, expected_columns), dtype=compact_dtype
+    )
+    row_count = 0
+    pending_lines: list[str] = []
+
+    def consume_pending() -> None:
+        nonlocal row_count
+        if not pending_lines:
+            return
+        try:
+            values = np.loadtxt(
+                pending_lines,
+                delimiter=",",
+                usecols=feature_indices,
+                ndmin=2,
+                dtype=np.int64,
+            )
+        except ValueError as error:
+            raise ValueError(
+                f"Could not parse rectangular integer CSV data: {error}"
+            ) from error
+        end = row_count + values.shape[0]
+        if end > expected_rows:
+            raise ValueError("CSV contains more data rows than its metadata declares.")
+        if (
+            values.shape[1] != expected_columns
+            or int(values.min()) < 0
+            or int(values.max()) >= levels
+        ):
+            raise ValueError(
+                f"CSV state rows must have {expected_columns} integers in "
+                f"[0,{levels - 1}]."
+            )
+        states[row_count:end] = values
+        row_count = end
+        pending_lines.clear()
+
+    with path.open("r", encoding="utf-8", newline="") as input_file:
+        for line_index, line in enumerate(input_file):
+            if line_index <= header_index:
+                continue
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            pending_lines.append(line)
+            if len(pending_lines) >= 4096:
+                consume_pending()
+    consume_pending()
+    if row_count != expected_rows:
+        raise ValueError(
+            f"CSV contains {row_count} data rows; metadata declares "
+            f"{expected_rows}."
+        )
+    states = verify_states(states, metadata)
+    return MelContainer(
+        states=states,
+        metadata=metadata,
+        source_kind="csv",
+        metadata_origin="csv_comment",
+        warnings=warnings,
+    )
+
+
+def decode_paired_pixel_header(
+    pixels: np.ndarray,
+) -> tuple[dict[str, Any], int]:
+    flat = np.asarray(pixels).reshape(-1)
+    minimum_pixels = 2 * (len(PNG_PIXEL_MAGIC) + 8)
+    if flat.size < minimum_pixels:
+        raise ValueError("PNG is too small to contain a QMel pixel header.")
+
+    first_pairs = flat[:minimum_pixels].reshape(-1, 2)
+    if np.any(first_pairs > 255) or np.any(first_pairs < 0):
+        raise ValueError("QMel pixel header contains non-byte values.")
+    if not np.all(
+        first_pairs[:, 0].astype(np.uint32)
+        + first_pairs[:, 1].astype(np.uint32)
+        == 255
+    ):
+        raise ValueError("QMel pixel-header complement check failed.")
+    fixed = first_pairs[:, 0].astype(np.uint8).tobytes()
+    if fixed[: len(PNG_PIXEL_MAGIC)] != PNG_PIXEL_MAGIC:
+        raise ValueError("QMel pixel-header magic is absent.")
+    compressed_length, compressed_crc = struct.unpack(
+        ">II", fixed[len(PNG_PIXEL_MAGIC) : len(PNG_PIXEL_MAGIC) + 8]
+    )
+    if compressed_length < 1 or compressed_length > MAX_EMBEDDED_METADATA_BYTES:
+        raise ValueError("QMel compressed metadata length is unreasonable.")
+
+    raw_length = len(PNG_PIXEL_MAGIC) + 8 + compressed_length
+    encoded_length = 2 * raw_length
+    if encoded_length > flat.size:
+        raise ValueError("PNG is truncated inside its QMel pixel header.")
+    pairs = flat[:encoded_length].reshape(-1, 2)
+    if np.any(pairs > 255) or np.any(pairs < 0):
+        raise ValueError("QMel metadata header contains non-byte values.")
+    if not np.all(
+        pairs[:, 0].astype(np.uint32)
+        + pairs[:, 1].astype(np.uint32)
+        == 255
+    ):
+        raise ValueError("QMel metadata complement check failed.")
+    raw = pairs[:, 0].astype(np.uint8).tobytes()
+    compressed = raw[len(PNG_PIXEL_MAGIC) + 8 :]
+    if zlib.crc32(compressed) & 0xFFFFFFFF != compressed_crc:
+        raise ValueError("QMel compressed-metadata CRC mismatch.")
+    try:
+        metadata = json.loads(
+            bounded_zlib_decompress(compressed).decode("utf-8")
+        )
+    except (zlib.error, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("QMel pixel metadata cannot be decoded.") from error
+    header_rows = int(math.ceil(encoded_length / pixels.shape[1]))
+    return metadata, header_rows
+
+
+def decode_scaled_u16_states(
+    encoded_pixels: np.ndarray,
+    levels: int,
+) -> np.ndarray:
+    values = np.asarray(encoded_pixels)
+    if np.any(values < 0) or np.any(values > 65_535):
+        raise ValueError("16-bit QMel payload contains out-of-range pixels.")
+    decoded = (
+        values.astype(np.uint64) * np.uint64(levels - 1)
+        + np.uint64(32_767)
+    ) // np.uint64(65_535)
+    compact_dtype = np.uint8 if levels <= 256 else np.uint16
+    states = decoded.astype(compact_dtype)
+    if not np.array_equal(
+        encode_scaled_u16_states(states, levels),
+        values.astype(np.uint16),
+    ):
+        raise ValueError(
+            "16-bit QMel payload contains pixels outside the state lattice."
+        )
+    return states
+
+
+def extract_png_states(
+    pixels: np.ndarray,
+    metadata: dict[str, Any],
+    data_y0: int,
+) -> np.ndarray:
+    shape = metadata["shape"]
+    frame_count = int(shape["timesteps"])
+    n_mels = int(shape["bands"])
+    width = int(metadata["png"]["tile_width"])
+    if width != pixels.shape[1]:
+        raise ValueError(
+            f"PNG width {pixels.shape[1]} does not match metadata width {width}."
+        )
+    strips = int(math.ceil(frame_count / width))
+    required_height = data_y0 + strips * n_mels
+    if pixels.shape[0] < required_height:
+        raise ValueError(
+            f"PNG height {pixels.shape[0]} is below required {required_height}."
+        )
+
+    levels = int(metadata["quantizer"]["levels"])
+    pixel_codec = metadata["png"]["state_pixel_codec"]
+    compact_dtype = np.uint8 if levels <= 256 else np.uint16
+    states = np.empty((frame_count, n_mels), dtype=compact_dtype)
+    for strip_index in range(strips):
+        start = strip_index * width
+        end = min(frame_count, start + width)
+        rows = slice(
+            data_y0 + strip_index * n_mels,
+            data_y0 + (strip_index + 1) * n_mels,
+        )
+        payload = pixels[rows, : end - start][::-1, :].T
+        if pixel_codec == "palette_index_equals_state":
+            if np.any(payload < 0) or np.any(payload >= levels):
+                raise ValueError("Indexed QMel payload has an invalid state ID.")
+            decoded = payload.astype(compact_dtype)
+        elif pixel_codec == "scaled_u16_state_lattice_v1":
+            decoded = decode_scaled_u16_states(payload, levels)
+        else:
+            raise ValueError(f"Unsupported QMel state pixel codec: {pixel_codec!r}.")
+        states[start:end] = decoded
+    return states
+
+
+def read_png_container(
+    path: Path,
+    maximum_pixels: int = 80_000_000,
+) -> MelContainer:
+    try:
+        from PIL import Image  # type: ignore
+    except ImportError as error:
+        raise RuntimeError(
+            "PNG input requires Pillow: python -m pip install pillow"
+        ) from error
+
+    with path.open("rb") as raw_file:
+        header = raw_file.read(24)
+    if (
+        len(header) != 24
+        or header[:8] != b"\x89PNG\r\n\x1a\n"
+        or header[12:16] != b"IHDR"
+    ):
+        raise ValueError("Input does not contain a valid PNG IHDR.")
+    width, height = struct.unpack(">II", header[16:24])
+    pixel_count = width * height
+    if width < 1 or height < 1 or pixel_count > maximum_pixels:
+        raise ValueError(
+            f"PNG dimensions {width}x{height} exceed "
+            f"--png-max-pixels={maximum_pixels:,}."
+        )
+
+    previous_limit = Image.MAX_IMAGE_PIXELS
+    Image.MAX_IMAGE_PIXELS = maximum_pixels
+    try:
+        with Image.open(path) as image:
+            if image.size != (width, height):
+                raise ValueError("PNG dimensions disagree with its IHDR.")
+            if getattr(image, "n_frames", 1) != 1:
+                raise ValueError("Animated PNG is unsupported.")
+            ancillary_text = image.info.get(PNG_METADATA_KEY)
+            mode = image.mode
+            pixels = np.asarray(image)
+    finally:
+        Image.MAX_IMAGE_PIXELS = previous_limit
+
+    warnings: list[str] = []
+    exact_modes = {"P", "I;16", "I;16L", "I;16B", "I"}
+    if mode not in exact_modes:
+        warnings.append(
+            f"PNG mode {mode!r} is not an exact QMel integer mode."
+        )
+        return MelContainer(
+            states=np.asarray(pixels),
+            metadata={},
+            source_kind="png",
+            metadata_origin="none",
+            warnings=warnings,
+        )
+
+    pixel_metadata: dict[str, Any] | None = None
+    header_rows: int | None = None
+    try:
+        pixel_metadata, header_rows = decode_paired_pixel_header(pixels)
+    except ValueError as error:
+        warnings.append(str(error))
+
+    text_metadata: dict[str, Any] | None = None
+    if ancillary_text:
+        try:
+            text_metadata = json.loads(ancillary_text)
+        except json.JSONDecodeError as error:
+            warnings.append(f"Invalid {PNG_METADATA_KEY} iTXt JSON: {error}")
+
+    if pixel_metadata is not None and text_metadata is not None:
+        if compact_json(pixel_metadata) != compact_json(text_metadata):
+            raise ValueError("PNG iTXt metadata disagrees with pixel metadata.")
+    metadata = pixel_metadata or text_metadata
+    if metadata is None:
+        return MelContainer(
+            states=np.asarray(pixels),
+            metadata={},
+            source_kind="png",
+            metadata_origin="none",
+            warnings=warnings,
+        )
+    validate_roundtrip_metadata(metadata)
+    declared_mode = metadata["png"].get("mode")
+    pixel_codec = metadata["png"].get("state_pixel_codec")
+    if pixel_codec == "palette_index_equals_state" and mode != "P":
+        raise ValueError(
+            f"QMel metadata declares indexed states but PNG mode is {mode!r}."
+        )
+    if pixel_codec == "scaled_u16_state_lattice_v1" and mode == "P":
+        raise ValueError("QMel metadata declares 16-bit states in a palette PNG.")
+    levels = int(metadata["quantizer"]["levels"])
+    if pixel_codec == "palette_index_equals_state" and levels > 256:
+        raise ValueError("Palette QMel cannot represent more than 256 states.")
+    if pixel_codec == "scaled_u16_state_lattice_v1" and levels <= 256:
+        raise ValueError("16-bit QMel codec is inconsistent with its state count.")
+    if declared_mode == "P" and mode != "P":
+        raise ValueError("QMel PNG mode disagrees with its embedded metadata.")
+
+    if header_rows is None:
+        n_mels = int(metadata["shape"]["bands"])
+        frames = int(metadata["shape"]["timesteps"])
+        strips = int(math.ceil(frames / pixels.shape[1]))
+        payload_rows = strips * n_mels
+        header_rows = pixels.shape[0] - payload_rows
+        if header_rows < 0:
+            raise ValueError("PNG is shorter than its declared state payload.")
+        if header_rows == 0:
+            header_rows = 0
+            warnings.append("Pixel header was stripped; using surviving iTXt.")
+        else:
+            warnings.append(
+                "Pixel header is damaged; locating the payload from image "
+                "height and surviving iTXt."
+            )
+
+    states = extract_png_states(np.asarray(pixels), metadata, header_rows)
+    states = verify_states(states, metadata)
+    return MelContainer(
+        states=states,
+        metadata=metadata,
+        source_kind="png",
+        metadata_origin=(
+            "pixel_header+iTXt"
+            if pixel_metadata is not None and text_metadata is not None
+            else "pixel_header"
+            if pixel_metadata is not None
+            else "iTXt"
+        ),
+        warnings=warnings,
+    )
+
+
+def preset_from_name_or_columns(
+    input_path: Path,
+    columns: int,
+    requested: str | None,
+) -> Preset:
+    if requested:
+        preset = PRESETS[requested]
+        if preset.n_mels != columns:
+            raise ValueError(
+                f"--preset {requested} expects {preset.n_mels} columns, "
+                f"but the input has {columns}."
+            )
+        return preset
+    profile_pattern = "|".join(re.escape(name) for name in PRESETS)
+    filename_match = re.search(
+        rf"\.({profile_pattern})\.", input_path.name
+    )
+    if filename_match:
+        preset = PRESETS[filename_match.group(1)]
+        if preset.n_mels == columns:
+            return preset
+    candidates = [preset for preset in PRESETS.values() if preset.n_mels == columns]
+    if len(candidates) == 1:
+        return candidates[0]
+    raise ValueError(
+        "Metadata-free input is ambiguous. Pass --preset or use a v2 "
+        "self-describing CSV/PNG."
+    )
+
+
+def metadata_from_preset(
+    preset: Preset,
+    frame_count: int,
+    reference_power: float,
+    sample_count: int | None,
+    duration: float | None,
+) -> dict[str, Any]:
+    if duration is not None:
+        inferred_samples = int(round(duration * preset.sample_rate))
+    elif sample_count is not None:
+        inferred_samples = sample_count
+    else:
+        inferred_samples = frame_count * preset.hop_length
+    window = periodic_hann(preset.win_length)
+    return {
+        "format": "metadata_free_best_effort",
+        "version": 0,
+        "profile": preset.name,
+        "shape": {
+            "timesteps": frame_count,
+            "bands": preset.n_mels,
+            "axis_order": "TC",
+        },
+        "waveform": {
+            "sample_rate": preset.sample_rate,
+            "decoded_sample_count": inferred_samples,
+            "channels": 1,
+        },
+        "stft": {
+            "n_fft": preset.n_fft,
+            "win_length": preset.win_length,
+            "hop_length": preset.hop_length,
+            "window": "periodic_hann",
+            "frame_center": "t*hop",
+            "padding": "constant_zero",
+            "fft_zero_padding": "right",
+            "power_normalizer": max(float(window.sum()) / 2.0, 1.0e-12) ** 2,
+        },
+        "mel": {
+            "n_mels": preset.n_mels,
+            "fmin": preset.fmin,
+            "fmax": preset.fmax,
+            "scale": "HTK",
+            "filter_shape": "triangular",
+            "filter_normalization": "unit_sum",
+        },
+        "quantizer": {
+            "kind": "uniform_db",
+            "levels": preset.levels,
+            "integer_min": 0,
+            "integer_max": preset.levels - 1,
+            "db_min": preset.db_min,
+            "db_max": preset.db_max,
+            "clip": "saturate",
+            "zero_state_semantics": "lower_censored_or_silence",
+            "reference_power": reference_power,
+            "reference_mode": "metadata_free_assumption",
+            "silent": False,
+        },
+        "integrity": {},
+    }
+
+
+def fallback_preset_from_options(
+    preset_name: str | None,
+    columns_per_timestep: int | None,
+    states_per_column: int | None,
+    timestep_ms: float | None,
+) -> Preset | None:
+    manual_override = (
+        columns_per_timestep is not None
+        or states_per_column is not None
+        or timestep_ms is not None
+    )
+    if preset_name is None:
+        if manual_override:
+            raise ValueError(
+                "Metadata-free manual geometry/timestep overrides require "
+                "--preset to provide "
+                "the remaining sample-rate, STFT, mel-range, and dB settings."
+            )
+        return None
+
+    replacements: dict[str, Any] = {}
+    if columns_per_timestep is not None:
+        replacements["n_mels"] = columns_per_timestep
+    if states_per_column is not None:
+        replacements["levels"] = states_per_column
+    if timestep_ms is not None:
+        replacements["hop_ms"] = timestep_ms
+    preset = replace(PRESETS[preset_name], **replacements)
+    validate_preset(preset)
+    return preset
+
+
+def resolve_legacy_container(
+    container: MelContainer,
+    input_path: Path,
+    preset_name: str | None,
+    columns_per_timestep: int | None,
+    states_per_column: int | None,
+    timestep_ms: float | None,
+    reference_power: float,
+    frame_count: int | None,
+    sample_count: int | None,
+    duration: float | None,
+) -> MelContainer:
+    if container.metadata:
+        if preset_name and container.metadata.get("profile") != preset_name:
+            raise ValueError(
+                "--preset conflicts with embedded metadata; remove the override."
+            )
+        embedded_columns = int(container.metadata["shape"]["bands"])
+        embedded_states = int(container.metadata["quantizer"]["levels"])
+        if (
+            columns_per_timestep is not None
+            and columns_per_timestep != embedded_columns
+        ):
+            raise ValueError(
+                "--columns-per-timestep conflicts with embedded metadata "
+                f"({columns_per_timestep} requested, {embedded_columns} stored)."
+            )
+        if (
+            states_per_column is not None
+            and states_per_column != embedded_states
+        ):
+            raise ValueError(
+                "--states-per-column conflicts with embedded metadata "
+                f"({states_per_column} requested, {embedded_states} stored)."
+            )
+        if timestep_ms is not None:
+            sample_rate = int(container.metadata["waveform"]["sample_rate"])
+            embedded_hop = int(container.metadata["stft"]["hop_length"])
+            requested_hop = int(round(sample_rate * timestep_ms / 1000.0))
+            if requested_hop < 1:
+                raise ValueError(
+                    "--timestep-ms rounds to fewer than one sample at the "
+                    f"embedded sample rate ({sample_rate} Hz)."
+                )
+            if requested_hop != embedded_hop:
+                embedded_timestep_ms = 1000.0 * embedded_hop / sample_rate
+                raise ValueError(
+                    "--timestep-ms conflicts with embedded metadata "
+                    f"({timestep_ms:g} ms requested -> {requested_hop} samples, "
+                    f"{embedded_timestep_ms:g} ms / {embedded_hop} samples stored)."
+                )
+        return container
+
+    fallback_preset = fallback_preset_from_options(
+        preset_name,
+        columns_per_timestep,
+        states_per_column,
+        timestep_ms,
+    )
+    states = np.asarray(container.states)
+    if container.source_kind == "png":
+        if states.ndim != 2:
+            raise ValueError("Metadata-free PNG must be a 2-D integer raster.")
+        if fallback_preset is None:
+            raise ValueError(
+                "A non-QMel PNG requires --preset and should be an unlabelled "
+                "raw integer state raster in QMel strip orientation, not a "
+                "plotted screenshot."
+            )
+        preset = fallback_preset
+        if states.shape[0] % preset.n_mels != 0:
+            raise ValueError(
+                "Metadata-free PNG height is not a multiple of preset mel bands."
+            )
+        strips = states.shape[0] // preset.n_mels
+        inferred_frames = frame_count or strips * states.shape[1]
+        if inferred_frames > strips * states.shape[1]:
+            raise ValueError("--frame-count exceeds PNG payload capacity.")
+        compact_dtype = np.uint8 if preset.levels <= 256 else np.uint16
+        recovered = np.empty(
+            (inferred_frames, preset.n_mels), dtype=compact_dtype
+        )
+        for strip_index in range(strips):
+            start = strip_index * states.shape[1]
+            end = min(inferred_frames, start + states.shape[1])
+            if end <= start:
+                break
+            rows = slice(
+                strip_index * preset.n_mels,
+                (strip_index + 1) * preset.n_mels,
+            )
+            payload = states[rows, : end - start][::-1, :].T
+            if np.any(payload < 0) or np.any(payload >= preset.levels):
+                raise ValueError(
+                    "Metadata-free PNG contains a direct state ID outside "
+                    f"[0, {preset.levels - 1}]."
+                )
+            recovered[start:end] = payload
+        states = recovered
+    preset = fallback_preset or preset_from_name_or_columns(
+        input_path, int(states.shape[1]), None
+    )
+    if int(states.shape[1]) != preset.n_mels:
+        raise ValueError(
+            f"The input has {states.shape[1]} columns, but the requested "
+            f"geometry expects {preset.n_mels}."
+        )
+    metadata = metadata_from_preset(
+        preset,
+        int(states.shape[0]),
+        reference_power,
+        sample_count,
+        duration,
+    )
+    states = verify_states(states, metadata, verify_crc=False)
+    container.states = states
+    container.metadata = metadata
+    container.metadata_origin = "inferred"
+    container.warnings.append(
+        "Reconstruction settings were inferred; amplitude and duration may differ."
+    )
+    return container
+
+
+def dequantize_mel_power(
+    states: np.ndarray,
+    metadata: dict[str, Any],
+    floor_mode: str,
+) -> np.ndarray:
+    quantizer = metadata["quantizer"]
+    levels = int(quantizer["levels"])
+    db_min = float(quantizer["db_min"])
+    db_max = float(quantizer["db_max"])
+    reference = float(quantizer["reference_power"])
+    db = db_min + states.astype(np.float64) * (
+        (db_max - db_min) / (levels - 1)
+    )
+    mel_power = reference * np.power(10.0, db / 10.0)
+    if floor_mode == "zero":
+        mel_power[states == 0] = 0.0
+    if bool(quantizer.get("silent", False)):
+        mel_power.fill(0.0)
+    return mel_power.astype(np.float32)
+
+
+def multiplicative_mel_inverse_numpy(
+    mel_power: np.ndarray,
+    filterbank: np.ndarray,
+    iterations: int,
+    batch_frames: int,
+) -> np.ndarray:
+    frame_count = mel_power.shape[0]
+    frequency_bins = filterbank.shape[1]
+    output = np.empty((frame_count, frequency_bins), dtype=np.float32)
+    h = filterbank.astype(np.float64)
+    column_mass = h.sum(axis=0)[None, :]
+    epsilon = 1.0e-18
+    for start in range(0, frame_count, batch_frames):
+        end = min(frame_count, start + batch_frames)
+        target = mel_power[start:end].astype(np.float64)
+        numerator = target @ h
+        estimate = np.where(
+            column_mass > epsilon,
+            numerator / np.maximum(column_mass, epsilon),
+            0.0,
+        )
+        estimate = np.maximum(estimate, epsilon)
+        for _ in range(iterations):
+            denominator = ((estimate @ h.T) @ h) + epsilon
+            estimate *= numerator / denominator
+        output[start:end] = np.maximum(estimate, 0.0).astype(np.float32)
+    return output
+
+
+def pinv_mel_inverse(
+    mel_power: np.ndarray,
+    filterbank: np.ndarray,
+    batch_frames: int,
+) -> np.ndarray:
+    inverse = np.linalg.pinv(filterbank.T, rcond=1.0e-5)
+    output = np.empty(
+        (mel_power.shape[0], filterbank.shape[1]), dtype=np.float32
+    )
+    for start in range(0, mel_power.shape[0], batch_frames):
+        end = min(mel_power.shape[0], start + batch_frames)
+        estimate = mel_power[start:end] @ inverse
+        output[start:end] = np.maximum(estimate, 0.0).astype(np.float32)
+    return output
+
+
+def stft_exact_numpy(
+    audio: np.ndarray,
+    frame_count: int,
+    win_length: int,
+    hop_length: int,
+    n_fft: int,
+    window: np.ndarray,
+) -> np.ndarray:
+    half = win_length // 2
+    total_length = (frame_count - 1) * hop_length + win_length
+    padded = np.zeros((total_length,), dtype=np.float32)
+    available = max(0, min(audio.size, total_length - half))
+    if available:
+        padded[half : half + available] = audio[:available]
+    stride = padded.strides[0]
+    frames = np.lib.stride_tricks.as_strided(
+        padded,
+        shape=(frame_count, win_length),
+        strides=(hop_length * stride, stride),
+        writeable=False,
+    )
+    return np.fft.rfft(
+        frames * window[None, :], n=n_fft, axis=1
+    ).astype(np.complex64)
+
+
+def overlap_add_plan_numpy(
+    frame_count: int,
+    win_length: int,
+    hop_length: int,
+    window: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    frame_offsets = (
+        np.arange(frame_count, dtype=np.int64)[:, None] * hop_length
+    )
+    window_offsets = np.arange(win_length, dtype=np.int64)[None, :]
+    indices = (frame_offsets + window_offsets).reshape(-1)
+    total_length = (frame_count - 1) * hop_length + win_length
+    denominator = np.bincount(
+        indices,
+        weights=np.broadcast_to(
+            window.astype(np.float64) ** 2,
+            (frame_count, win_length),
+        ).reshape(-1),
+        minlength=total_length,
+    )
+    return indices, denominator
+
+
+def istft_exact_numpy(
+    spectrum: np.ndarray,
+    sample_count: int,
+    win_length: int,
+    hop_length: int,
+    n_fft: int,
+    window: np.ndarray,
+    overlap_indices: np.ndarray | None = None,
+    denominator: np.ndarray | None = None,
+) -> np.ndarray:
+    frame_count = spectrum.shape[0]
+    total_length = (frame_count - 1) * hop_length + win_length
+    frames = np.fft.irfft(spectrum, n=n_fft, axis=1)[:, :win_length]
+    window64 = window.astype(np.float64)
+    if overlap_indices is None or denominator is None:
+        overlap_indices, denominator = overlap_add_plan_numpy(
+            frame_count, win_length, hop_length, window
+        )
+    output = np.bincount(
+        overlap_indices,
+        weights=(frames * window64[None, :]).reshape(-1),
+        minlength=total_length,
+    )
+    valid = denominator > 1.0e-12
+    output[valid] /= denominator[valid]
+    output[~valid] = 0.0
+    half = win_length // 2
+    cropped = np.zeros((sample_count,), dtype=np.float32)
+    available = max(0, min(sample_count, total_length - half))
+    if available:
+        cropped[:available] = output[half : half + available].astype(np.float32)
+    return cropped
+
+
+def griffin_lim_numpy(
+    magnitude: np.ndarray,
+    sample_count: int,
+    win_length: int,
+    hop_length: int,
+    n_fft: int,
+    window: np.ndarray,
+    iterations: int,
+    seed: int,
+    initial_phase: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    phase = np.exp(
+        2j * np.pi * rng.random(magnitude.shape, dtype=np.float32)
+    ).astype(np.complex64)
+    if initial_phase is not None:
+        count = min(initial_phase.shape[0], phase.shape[0])
+        if initial_phase.shape[1] != phase.shape[1]:
+            raise ValueError("Initial phase frequency-bin count is inconsistent.")
+        phase[:count] = initial_phase[-count:]
+    if not np.any(magnitude > 0.0):
+        return np.zeros((sample_count,), dtype=np.float32), phase
+    spectrum = magnitude.astype(np.float32) * phase
+    audio = np.zeros((sample_count,), dtype=np.float32)
+    overlap_indices, denominator = overlap_add_plan_numpy(
+        magnitude.shape[0], win_length, hop_length, window
+    )
+    for _ in range(iterations):
+        audio = istft_exact_numpy(
+            spectrum,
+            sample_count,
+            win_length,
+            hop_length,
+            n_fft,
+            window,
+            overlap_indices,
+            denominator,
+        )
+        rebuilt = stft_exact_numpy(
+            audio,
+            magnitude.shape[0],
+            win_length,
+            hop_length,
+            n_fft,
+            window,
+        )
+        phase = rebuilt / np.maximum(np.abs(rebuilt), 1.0e-12)
+        spectrum = magnitude * phase
+    return (
+        istft_exact_numpy(
+            spectrum,
+            sample_count,
+            win_length,
+            hop_length,
+            n_fft,
+            window,
+            overlap_indices,
+            denominator,
+        ),
+        phase,
+    )
+
+
+def resolve_torch_device(request: str) -> tuple[Any | None, str]:
+    if request == "cpu":
+        return None, "numpy:cpu"
+    if request != "auto" and not request.startswith("cuda"):
+        raise ValueError("--device must be auto, cpu, cuda, or cuda:N.")
+    try:
+        import torch  # type: ignore
+    except ImportError as error:
+        if request.startswith("cuda"):
+            raise RuntimeError("CUDA requested but PyTorch is not installed.") from error
+        return None, "numpy:cpu"
+    if not torch.cuda.is_available():
+        if request.startswith("cuda"):
+            raise RuntimeError("CUDA requested but no CUDA device is available.")
+        return None, "numpy:cpu"
+    device = "cuda:0" if request in {"auto", "cuda"} else request
+    torch.empty((1,), device=device)
+    return torch, f"torch:{device}"
+
+
+def multiplicative_mel_inverse_torch(
+    torch: Any,
+    device: str,
+    mel_power: np.ndarray,
+    filterbank: np.ndarray,
+    iterations: int,
+    batch_frames: int,
+) -> np.ndarray:
+    h = torch.as_tensor(filterbank, dtype=torch.float32, device=device)
+    column_mass = h.sum(dim=0, keepdim=True)
+    output = np.empty(
+        (mel_power.shape[0], filterbank.shape[1]), dtype=np.float32
+    )
+    with torch.inference_mode():
+        for start in range(0, mel_power.shape[0], batch_frames):
+            end = min(mel_power.shape[0], start + batch_frames)
+            target = torch.as_tensor(
+                mel_power[start:end], dtype=torch.float32, device=device
+            )
+            numerator = target @ h
+            estimate = torch.where(
+                column_mass > 1.0e-12,
+                numerator / column_mass.clamp_min(1.0e-12),
+                torch.zeros_like(numerator),
+            ).clamp_min(1.0e-12)
+            for _ in range(iterations):
+                denominator = ((estimate @ h.T) @ h).clamp_min(1.0e-12)
+                estimate.mul_(numerator / denominator)
+            output[start:end] = estimate.clamp_min_(0).cpu().numpy()
+    return output
+
+
+def griffin_lim_torch(
+    torch: Any,
+    device: str,
+    magnitude_numpy: np.ndarray,
+    sample_count: int,
+    win_length: int,
+    hop_length: int,
+    n_fft: int,
+    window_numpy: np.ndarray,
+    iterations: int,
+    seed: int,
+    initial_phase: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    import torch.nn.functional as functional  # type: ignore
+
+    magnitude = torch.as_tensor(
+        magnitude_numpy, dtype=torch.float32, device=device
+    )
+    frame_count = magnitude.shape[0]
+    window = torch.as_tensor(window_numpy, dtype=torch.float32, device=device)
+    total_length = (frame_count - 1) * hop_length + win_length
+    half = win_length // 2
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed)
+
+    def inverse(spectrum: Any) -> Any:
+        frames = torch.fft.irfft(spectrum, n=n_fft, dim=1)[:, :win_length]
+        columns = (frames * window[None, :]).T.unsqueeze(0)
+        output = functional.fold(
+            columns,
+            output_size=(1, total_length),
+            kernel_size=(1, win_length),
+            stride=(1, hop_length),
+        ).reshape(-1)
+        norm_columns = (
+            window.square()[:, None]
+            .expand(win_length, frame_count)
+            .unsqueeze(0)
+        )
+        norm = functional.fold(
+            norm_columns,
+            output_size=(1, total_length),
+            kernel_size=(1, win_length),
+            stride=(1, hop_length),
+        ).reshape(-1)
+        output = output / norm.clamp_min(1.0e-12)
+        result = torch.zeros((sample_count,), dtype=torch.float32, device=device)
+        available = max(0, min(sample_count, total_length - half))
+        if available:
+            result[:available] = output[half : half + available]
+        return result
+
+    def analysis(audio: Any) -> Any:
+        padded = torch.zeros(
+            (total_length,), dtype=torch.float32, device=device
+        )
+        available = max(0, min(sample_count, total_length - half))
+        if available:
+            padded[half : half + available] = audio[:available]
+        frames = padded.unfold(0, win_length, hop_length)
+        return torch.fft.rfft(
+            frames * window[None, :], n=n_fft, dim=1
+        )
+
+    angles = 2.0 * math.pi * torch.rand(
+        magnitude.shape, generator=generator, device=device
+    )
+    phase = torch.polar(torch.ones_like(angles), angles)
+    if initial_phase is not None:
+        if initial_phase.shape[1] != phase.shape[1]:
+            raise ValueError("Initial phase frequency-bin count is inconsistent.")
+        count = min(initial_phase.shape[0], phase.shape[0])
+        phase[:count] = torch.as_tensor(
+            initial_phase[-count:], dtype=phase.dtype, device=device
+        )
+    if not bool(torch.any(magnitude > 0)):
+        return (
+            np.zeros((sample_count,), dtype=np.float32),
+            phase.cpu().numpy().astype(np.complex64),
+        )
+    spectrum = magnitude * phase
+    with torch.inference_mode():
+        for _ in range(iterations):
+            audio = inverse(spectrum)
+            rebuilt = analysis(audio)
+            phase = rebuilt / rebuilt.abs().clamp_min(1.0e-12)
+            spectrum = magnitude * phase
+        return (
+            inverse(spectrum).cpu().numpy().astype(np.float32),
+            phase.cpu().numpy().astype(np.complex64),
+        )
+
+
+def write_pcm16_wav(
+    output_path: Path,
+    audio: np.ndarray,
+    sample_rate: int,
+    peak_target: float,
+    block_samples: int = 4_000_000,
+) -> float:
+    original_peak = 0.0
+    for start in range(0, int(audio.size), block_samples):
+        block = np.nan_to_num(
+            np.asarray(audio[start : start + block_samples], dtype=np.float32),
+            copy=True,
+            nan=0.0,
+            posinf=0.0,
+            neginf=0.0,
+        )
+        if block.size:
+            original_peak = max(original_peak, float(np.max(np.abs(block))))
+    scale = (
+        peak_target / original_peak
+        if original_peak > 0.0 and peak_target > 0.0
+        else 1.0
+    )
+    with wave.open(str(output_path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(sample_rate)
+        for start in range(0, int(audio.size), block_samples):
+            block = np.nan_to_num(
+                np.asarray(
+                    audio[start : start + block_samples], dtype=np.float32
+                ),
+                copy=True,
+                nan=0.0,
+                posinf=0.0,
+                neginf=0.0,
+            )
+            np.multiply(block, scale, out=block)
+            np.clip(block, -1.0, 1.0, out=block)
+            pcm = np.rint(block * 32767.0).astype("<i2")
+            output.writeframes(pcm.tobytes(order="C"))
+    return original_peak
+
+
+def invert_state_chunk(
+    states: np.ndarray,
+    metadata: dict[str, Any],
+    filterbank: np.ndarray,
+    torch: Any | None,
+    device: str,
+    mel_inverse: str,
+    mel_iterations: int,
+    mel_batch_frames: int,
+    griffin_lim_iterations: int,
+    floor_mode: str,
+    sample_count: int,
+    seed: int,
+    initial_phase: np.ndarray | None,
+    error_frames: int,
+) -> tuple[np.ndarray, np.ndarray, float, float]:
+    stft = metadata["stft"]
+    mel_power = dequantize_mel_power(states, metadata, floor_mode)
+    if mel_inverse == "pinv":
+        linear_power = pinv_mel_inverse(
+            mel_power, filterbank, mel_batch_frames
+        )
+    elif torch is not None:
+        linear_power = multiplicative_mel_inverse_torch(
+            torch,
+            device,
+            mel_power,
+            filterbank,
+            mel_iterations,
+            mel_batch_frames,
+        )
+    else:
+        linear_power = multiplicative_mel_inverse_numpy(
+            mel_power,
+            filterbank,
+            mel_iterations,
+            mel_batch_frames,
+        )
+
+    magnitude = np.sqrt(
+        np.maximum(linear_power, 0.0)
+        * float(stft["power_normalizer"])
+    ).astype(np.float32)
+    window = periodic_hann(int(stft["win_length"]))
+    if torch is not None:
+        audio, phase = griffin_lim_torch(
+            torch,
+            device,
+            magnitude,
+            sample_count,
+            int(stft["win_length"]),
+            int(stft["hop_length"]),
+            int(stft["n_fft"]),
+            window,
+            griffin_lim_iterations,
+            seed,
+            initial_phase,
+        )
+    else:
+        audio, phase = griffin_lim_numpy(
+            magnitude,
+            sample_count,
+            int(stft["win_length"]),
+            int(stft["hop_length"]),
+            int(stft["n_fft"]),
+            window,
+            griffin_lim_iterations,
+            seed,
+            initial_phase,
+        )
+    error_frames = max(0, min(error_frames, mel_power.shape[0]))
+    target = mel_power[:error_frames]
+    residual = (linear_power[:error_frames] @ filterbank.T) - target
+    error_square = float(
+        np.sum(residual.astype(np.float64) ** 2, dtype=np.float64)
+    )
+    target_square = float(
+        np.sum(target.astype(np.float64) ** 2, dtype=np.float64)
+    )
+    return audio, phase, error_square, target_square
+
+
+def reconstruct(
+    container: MelContainer,
+    output_path: Path,
+    device_request: str,
+    mel_inverse: str,
+    mel_iterations: int,
+    mel_batch_frames: int,
+    griffin_lim_iterations: int,
+    griffin_lim_chunk_frames: int,
+    griffin_lim_overlap_frames: int,
+    floor_mode: str,
+    seed: int,
+    peak: float,
+) -> dict[str, Any]:
+    metadata = container.metadata
+    states = container.states
+    mel = metadata["mel"]
+    stft = metadata["stft"]
+    waveform = metadata["waveform"]
+    sample_rate = int(waveform["sample_rate"])
+    sample_count = int(waveform["decoded_sample_count"])
+    hop_length = int(stft["hop_length"])
+    win_length = int(stft["win_length"])
+    frame_count = int(states.shape[0])
+    preprocessing = metadata.get("preprocessing", {})
+    agc_metadata = (
+        preprocessing.get("agc")
+        if isinstance(preprocessing, dict)
+        else None
+    )
+    agc_applied = bool(
+        isinstance(agc_metadata, dict)
+        and agc_metadata.get("enabled") is True
+    )
+    agc_profile = (
+        str(agc_metadata.get("profile"))
+        if agc_applied and isinstance(agc_metadata, dict)
+        else None
+    )
+    if agc_applied and AGC_LOSS_WARNING not in container.warnings:
+        container.warnings.append(AGC_LOSS_WARNING)
+    filterbank, _, _ = make_mel_filterbank(
+        sample_rate,
+        int(stft["n_fft"]),
+        int(mel["n_mels"]),
+        float(mel["fmin"]),
+        float(mel["fmax"]),
+    )
+    torch, backend = resolve_torch_device(device_request)
+    device = backend.split(":", 1)[1] if torch is not None else "cpu"
+
+    use_chunks = (
+        griffin_lim_chunk_frames > 0
+        and frame_count > griffin_lim_chunk_frames
+    )
+    error_square = 0.0
+    target_square = 0.0
+    chunk_count = 1
+
+    if not use_chunks:
+        audio, _, error_square, target_square = invert_state_chunk(
+            states=states,
+            metadata=metadata,
+            filterbank=filterbank,
+            torch=torch,
+            device=device,
+            mel_inverse=mel_inverse,
+            mel_iterations=mel_iterations,
+            mel_batch_frames=mel_batch_frames,
+            griffin_lim_iterations=griffin_lim_iterations,
+            floor_mode=floor_mode,
+            sample_count=sample_count,
+            seed=seed,
+            initial_phase=None,
+            error_frames=frame_count,
+        )
+        original_peak = write_pcm16_wav(
+            output_path, audio, sample_rate, peak
+        )
+    else:
+        minimum_overlap = int(math.ceil(win_length / hop_length))
+        if griffin_lim_overlap_frames < minimum_overlap:
+            raise ValueError(
+                "--griffin-lim-overlap-frames must be at least "
+                f"{minimum_overlap} for this window and hop."
+            )
+        if griffin_lim_chunk_frames <= 2 * griffin_lim_overlap_frames:
+            raise ValueError(
+                "--griffin-lim-chunk-frames must exceed twice the overlap."
+            )
+        stride = (
+            griffin_lim_chunk_frames - griffin_lim_overlap_frames
+        )
+        with tempfile.TemporaryDirectory(
+            prefix="token_mel_to_audio_"
+        ) as temp_dir:
+            raw_output = Path(temp_dir) / "reconstructed.f32le"
+            synthesized = np.memmap(
+                raw_output,
+                dtype=np.float32,
+                mode="w+",
+                shape=(sample_count,),
+            )
+            synthesized[:] = 0.0
+            start = 0
+            previous_end_sample = 0
+            phase_carry: np.ndarray | None = None
+            chunk_index = 0
+            while start < frame_count:
+                end = min(
+                    frame_count, start + griffin_lim_chunk_frames
+                )
+                start_sample = start * hop_length
+                local_samples = min(
+                    sample_count - start_sample,
+                    (end - start) * hop_length,
+                )
+                unique_frames = (
+                    frame_count - start
+                    if end == frame_count
+                    else stride
+                )
+                audio, phase, chunk_error, chunk_target = invert_state_chunk(
+                    states=states[start:end],
+                    metadata=metadata,
+                    filterbank=filterbank,
+                    torch=torch,
+                    device=device,
+                    mel_inverse=mel_inverse,
+                    mel_iterations=mel_iterations,
+                    mel_batch_frames=mel_batch_frames,
+                    griffin_lim_iterations=griffin_lim_iterations,
+                    floor_mode=floor_mode,
+                    sample_count=local_samples,
+                    seed=seed + chunk_index,
+                    initial_phase=phase_carry,
+                    error_frames=unique_frames,
+                )
+                write_end = start_sample + audio.size
+                overlap_samples = max(
+                    0, min(previous_end_sample - start_sample, audio.size)
+                )
+                if overlap_samples:
+                    position = (
+                        np.arange(overlap_samples, dtype=np.float32) + 1.0
+                    ) / (overlap_samples + 1.0)
+                    fade_in = 0.5 - 0.5 * np.cos(np.pi * position)
+                    previous = np.asarray(
+                        synthesized[
+                            start_sample : start_sample + overlap_samples
+                        ],
+                        dtype=np.float32,
+                    )
+                    synthesized[
+                        start_sample : start_sample + overlap_samples
+                    ] = (
+                        previous * (1.0 - fade_in)
+                        + audio[:overlap_samples] * fade_in
+                    )
+                if overlap_samples < audio.size:
+                    synthesized[
+                        start_sample + overlap_samples : write_end
+                    ] = audio[overlap_samples:]
+                previous_end_sample = max(previous_end_sample, write_end)
+                error_square += chunk_error
+                target_square += chunk_target
+                carry_count = min(
+                    griffin_lim_overlap_frames, phase.shape[0]
+                )
+                phase_carry = phase[-carry_count:].copy()
+                chunk_index += 1
+                print(
+                    f"[inverse] frames {end}/{frame_count}",
+                    file=sys.stderr,
+                )
+                if end == frame_count:
+                    break
+                start += stride
+            chunk_count = chunk_index
+            synthesized.flush()
+            original_peak = write_pcm16_wav(
+                output_path, synthesized, sample_rate, peak
+            )
+            del synthesized
+
+    relative_mel_error = math.sqrt(
+        error_square / max(target_square, 1.0e-24)
+    )
+    return {
+        "output": str(output_path),
+        "source_kind": container.source_kind,
+        "metadata_origin": container.metadata_origin,
+        "timesteps": int(states.shape[0]),
+        "mel_columns": int(states.shape[1]),
+        "columns_per_timestep": int(states.shape[1]),
+        "states_per_column": int(metadata["quantizer"]["levels"]),
+        "timestep_ms": 1000.0 * hop_length / sample_rate,
+        "timesteps_per_second": sample_rate / hop_length,
+        "sample_rate": sample_rate,
+        "samples": sample_count,
+        "duration_seconds": (
+            sample_count / sample_rate
+        ),
+        "backend": backend,
+        "mel_inverse": mel_inverse,
+        "mel_inverse_iterations": (
+            mel_iterations if mel_inverse == "multiplicative" else None
+        ),
+        "griffin_lim_iterations": griffin_lim_iterations,
+        "griffin_lim_chunk_frames": (
+            griffin_lim_chunk_frames if use_chunks else None
+        ),
+        "griffin_lim_overlap_frames": (
+            griffin_lim_overlap_frames if use_chunks else None
+        ),
+        "reconstruction_chunks": chunk_count,
+        "floor_mode": floor_mode,
+        "relative_mel_reprojection_error": relative_mel_error,
+        "pre_normalization_waveform_peak": original_peak,
+        "agc_applied": agc_applied,
+        "agc_profile": agc_profile,
+        "warnings": container.warnings,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reconstruct best-effort WAV audio from one self-describing "
+            "token-mel CSV or QMel-PNG."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {VERSION}"
+    )
+    parser.add_argument("input", type=Path, help="Input .csv or .png file.")
+    parser.add_argument(
+        "-o", "--output", type=Path, required=True, help="Output PCM16 WAV."
+    )
+    parser.add_argument(
+        "--device", default="auto", help="auto, cpu, cuda, or cuda:N."
+    )
+    parser.add_argument(
+        "--mel-inverse",
+        choices=["multiplicative", "pinv"],
+        default="multiplicative",
+        help="Nonnegative iterative inversion or faster pseudoinverse.",
+    )
+    parser.add_argument(
+        "--mel-inverse-iters",
+        type=int,
+        default=32,
+        help="Multiplicative mel-inversion iterations.",
+    )
+    parser.add_argument(
+        "--mel-batch-frames",
+        type=int,
+        default=512,
+        help="Frames per mel-inversion batch.",
+    )
+    parser.add_argument(
+        "--griffin-lim-iters",
+        type=int,
+        default=64,
+        help="Phase-recovery iterations.",
+    )
+    parser.add_argument(
+        "--griffin-lim-chunk-frames",
+        type=int,
+        default=2048,
+        help="Bound long phase recovery to this many frames; 0 uses the full file.",
+    )
+    parser.add_argument(
+        "--griffin-lim-overlap-frames",
+        type=int,
+        default=32,
+        help="Overlapped frames used for phase handoff and seam crossfading.",
+    )
+    parser.add_argument(
+        "--floor-mode",
+        choices=["zero", "db-floor"],
+        default="zero",
+        help="Decode q=0 as zero power or as the finite dB floor.",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--peak",
+        type=float,
+        default=0.0,
+        help="Normalize reconstructed waveform to this peak; 0 disables.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing output WAV.",
+    )
+    parser.add_argument(
+        "--png-max-pixels",
+        type=int,
+        default=80_000_000,
+        help="Safety limit for a trusted standalone PNG raster.",
+    )
+    legacy = parser.add_argument_group("metadata-free best-effort fallback")
+    legacy.add_argument(
+        "--preset", choices=list(PRESETS)
+    )
+    legacy.add_argument(
+        "--columns-per-timestep",
+        "--n-mels",
+        dest="columns_per_timestep",
+        type=int,
+        action=StoreConsistentValue,
+        metavar="C",
+        help=(
+            "Expected tokenized columns; with metadata-free input this "
+            "overrides the selected preset. --n-mels is an exact alias."
+        ),
+    )
+    legacy.add_argument(
+        "--states-per-column",
+        "--levels",
+        dest="states_per_column",
+        type=int,
+        action=StoreConsistentValue,
+        metavar="K",
+        help=(
+            "Expected legal states per column; with metadata-free input this "
+            "overrides the selected preset. --levels is an exact alias."
+        ),
+    )
+    legacy.add_argument(
+        "--timestep-ms",
+        "--hop-ms",
+        dest="timestep_ms",
+        type=float,
+        action=StoreConsistentValue,
+        metavar="MS",
+        help=(
+            "Duration represented by each row; with metadata-free input this "
+            "overrides the selected preset. Equality with embedded metadata is "
+            "checked after rounding to integer samples. --hop-ms is an exact "
+            "alias."
+        ),
+    )
+    legacy.add_argument(
+        "--reference-power",
+        type=float,
+        default=1.0,
+        help="Assumed reference when metadata is absent.",
+    )
+    legacy.add_argument(
+        "--frame-count",
+        type=int,
+        help="Valid frame count for a metadata-free tiled PNG.",
+    )
+    legacy.add_argument(
+        "--sample-count",
+        type=int,
+        help="Original decoded sample count when metadata is absent.",
+    )
+    legacy.add_argument(
+        "--duration",
+        type=float,
+        help="Original duration in seconds when metadata is absent.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if not args.input.is_file():
+        parser.error(f"Input does not exist: {args.input}")
+    if args.output.suffix.lower() != ".wav":
+        parser.error("Output must use a .wav suffix.")
+    if args.output.exists() and not args.force:
+        parser.error("Output already exists; pass --force to overwrite it.")
+    if args.mel_inverse_iters < 0:
+        parser.error("--mel-inverse-iters must be nonnegative.")
+    if args.mel_batch_frames < 1:
+        parser.error("--mel-batch-frames must be positive.")
+    if args.griffin_lim_iters < 0:
+        parser.error("--griffin-lim-iters must be nonnegative.")
+    if args.griffin_lim_chunk_frames < 0:
+        parser.error("--griffin-lim-chunk-frames must be nonnegative.")
+    if args.griffin_lim_overlap_frames < 0:
+        parser.error("--griffin-lim-overlap-frames must be nonnegative.")
+    if args.png_max_pixels < 1:
+        parser.error("--png-max-pixels must be positive.")
+    if (
+        args.columns_per_timestep is not None
+        and not 1 <= args.columns_per_timestep <= 4096
+    ):
+        parser.error("--columns-per-timestep must be in [1, 4096].")
+    if (
+        args.states_per_column is not None
+        and not 2 <= args.states_per_column <= 65_536
+    ):
+        parser.error("--states-per-column must be in [2, 65536].")
+    if args.timestep_ms is not None and (
+        not math.isfinite(args.timestep_ms) or args.timestep_ms <= 0.0
+    ):
+        parser.error("--timestep-ms must be positive and finite.")
+    if not math.isfinite(args.peak) or not 0.0 <= args.peak <= 1.0:
+        parser.error("--peak must be finite and in [0,1].")
+    if (
+        not math.isfinite(args.reference_power)
+        or args.reference_power <= 0.0
+    ):
+        parser.error("--reference-power must be positive and finite.")
+    if args.frame_count is not None and args.frame_count < 1:
+        parser.error("--frame-count must be positive.")
+    if args.sample_count is not None and args.sample_count < 1:
+        parser.error("--sample-count must be positive.")
+    if args.duration is not None and (
+        not math.isfinite(args.duration) or args.duration <= 0.0
+    ):
+        parser.error("--duration must be positive and finite.")
+
+    temporary_output: Path | None = None
+    try:
+        suffix = args.input.suffix.lower()
+        if suffix == ".csv":
+            container = read_csv_container(args.input)
+        elif suffix == ".png":
+            container = read_png_container(
+                args.input, maximum_pixels=args.png_max_pixels
+            )
+        else:
+            raise ValueError("Input must be .csv or .png.")
+        container = resolve_legacy_container(
+            container,
+            args.input,
+            args.preset,
+            args.columns_per_timestep,
+            args.states_per_column,
+            args.timestep_ms,
+            args.reference_power,
+            args.frame_count,
+            args.sample_count,
+            args.duration,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{args.output.stem}.",
+            suffix=".tmp.wav",
+            dir=args.output.parent,
+            delete=False,
+        ) as temporary_file:
+            temporary_output = Path(temporary_file.name)
+        result = reconstruct(
+            container=container,
+            output_path=temporary_output,
+            device_request=args.device,
+            mel_inverse=args.mel_inverse,
+            mel_iterations=args.mel_inverse_iters,
+            mel_batch_frames=args.mel_batch_frames,
+            griffin_lim_iterations=args.griffin_lim_iters,
+            griffin_lim_chunk_frames=args.griffin_lim_chunk_frames,
+            griffin_lim_overlap_frames=args.griffin_lim_overlap_frames,
+            floor_mode=args.floor_mode,
+            seed=args.seed,
+            peak=args.peak,
+        )
+        os.replace(temporary_output, args.output)
+        temporary_output = None
+        result["output"] = str(args.output)
+    except (OSError, RuntimeError, ValueError, KeyError) as error:
+        if temporary_output is not None:
+            try:
+                temporary_output.unlink()
+            except FileNotFoundError:
+                pass
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This pull request introduces several new helper scripts and configuration improvements for the `mel_spectrogram` data pipeline. The main changes add automation for running audio feature extraction and conversion tasks, along with a `.gitignore` for generated files. These updates streamline the workflow for processing audio files into mel spectrogram representations and back.

**New scripts for audio processing and workflow automation:**

* Added `demo.sh`, a robust Bash script for running end-to-end mel spectrogram extraction and reconstruction with flexible options for presets, device selection, and AGC (Automatic Gain Control) parameters. The script validates inputs, constructs output paths, and calls the main Python scripts for feature extraction and audio reconstruction.
* Added `run.sh`, a simple workflow script demonstrating how to convert a FLAC file to WAV, extract mel spectrogram features with custom parameters, and reconstruct audio for playback.
* Added `helpers/convert_to_wav.sh`, a helper script for converting FLAC files to WAV format using `ffmpeg`.

**Project configuration and housekeeping:**

* Added a `.gitignore` file to exclude generated audio files (`*.wav`, `*.flac`, `*.mp3`), the output directory (`mel_out/`), and Python bytecode (`__pycache__`) from version control.