### PR TITLE
feat(monitor): add tight column width mode

### DIFF
--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -28,7 +28,7 @@ Interactive keybindings:
   c     - cycle colour-map for current column (high→low, low→high, off)
   D     - remove colour-maps from all columns
   C # # - correlation + scatter for columns (1-based indexes, e.g. C 1 2)
-  w     - toggle column width to fit largest visible cell
+  w     - cycle column width: default, fit data, tightly fit data
   u     - unsort / remove current column from the sort stack
   U     - clear *all* sorting
 
@@ -95,7 +95,7 @@ HOTKEYS_TEXT = (
     "c: cycle colour-map for current column (high→low, low→high, off)\n"
     "D: remove colour-maps from all columns\n"
     "C # #: correlation + scatter (1-based indexes, e.g. C 1 2)\n"
-    "w: toggle column width to fit largest visible cell\n"
+    "w: cycle column width (default, fit data, tightly fit data)\n"
     "u: unsort / remove current column from the sort stack\n"
     "U: clear *all* sorting\n"
 )
@@ -200,6 +200,7 @@ class MonitorApp(App):
         self.row_filters: List[tuple] = []     # (col, op, val) triples
         self.colour_columns: dict[int, str] = {}   # col index -> colour mode
         self.auto_fit_columns: set[str] = set()
+        self.tight_fit_columns: set[str] = set()
         self._bar_mode: bool = False           # are we collecting digits?
         self._bar_digits: List[int] = []       # collected numeric keys
         self._trim_mode: bool = False          # 'z' zoom-bar mode
@@ -281,6 +282,7 @@ class MonitorApp(App):
                     int(idx): str(mode) for idx, mode in raw_modes.items()
                 }
             self.auto_fit_columns = set(cfg.get("auto_fit_columns", []))
+            self.tight_fit_columns = set(cfg.get("tight_fit_columns", []))
             # Restore saved row filters
             self.row_filters = cfg.get("row_filters", [])
             self.current_entries = list(self.original_entries)
@@ -317,13 +319,27 @@ class MonitorApp(App):
 
     def _column_width(self, col: str) -> int:
         base_width = max(12, len(col) + 2)
-        if col not in self.auto_fit_columns:
+        if col not in self.auto_fit_columns and col not in self.tight_fit_columns:
             return base_width
         max_len = 0
         for entry in self.current_entries:
             text = self._format_cell(self.get_cell(entry, col))
             max_len = max(max_len, len(text))
+        if col in self.tight_fit_columns and self.current_entries:
+            return max_len + 2
         return max(base_width, max_len + 2)
+
+    def _cycle_column_width(self, col: str) -> str:
+        """Advance *col* through default, data-fit, and tight data-fit widths."""
+        if col in self.tight_fit_columns:
+            self.tight_fit_columns.remove(col)
+            return "reset"
+        if col in self.auto_fit_columns:
+            self.auto_fit_columns.remove(col)
+            self.tight_fit_columns.add(col)
+            return "tightly fit to data"
+        self.auto_fit_columns.add(col)
+        return "fit to data"
 
     def _move_column_to_edge(
         self,
@@ -817,6 +833,7 @@ class MonitorApp(App):
                 "sort_stack":  [[i, asc] for i, asc in self.sort_stack],
                 "colour_columns": self.colour_columns,
                 "auto_fit_columns": list(self.auto_fit_columns),
+                "tight_fit_columns": list(self.tight_fit_columns),
                 "row_filters": getattr(self, "row_filters", []),
             }
             self.config_file.write_text(json.dumps(cfg, indent=2))
@@ -975,12 +992,8 @@ class MonitorApp(App):
                 self._msg("No active column colours")
         elif key == "w":
             col = self.columns[c]
-            if col in self.auto_fit_columns:
-                self.auto_fit_columns.remove(col)
-                self._msg(f"Width reset for {col}")
-            else:
-                self.auto_fit_columns.add(col)
-                self._msg(f"Width fit to data for {col}")
+            mode = self._cycle_column_width(col)
+            self._msg(f"Width {mode} for {col}")
             self.refresh_table(new_cursor=c)
         elif key == "u":
             # ── remove current column from sort stack ────────────────────

--- a/tests/test_run_exploration_monitor.py
+++ b/tests/test_run_exploration_monitor.py
@@ -5,6 +5,30 @@ from run_exploration_monitor import ExplorationConfigScreen, MonitorApp
 
 
 class ColumnSettingRemapTests(unittest.TestCase):
+    def setUp(self):
+        self.app = object.__new__(MonitorApp)
+        self.app.current_entries = [{"short_column_name": "abc"}]
+        self.app.auto_fit_columns = set()
+        self.app.tight_fit_columns = set()
+
+    def test_width_cycle_adds_tight_fit_smaller_than_column_heading(self):
+        column = "short_column_name"
+
+        self.assertEqual(self.app._column_width(column), len(column) + 2)
+        self.assertEqual(self.app._cycle_column_width(column), "fit to data")
+        self.assertEqual(self.app._column_width(column), len(column) + 2)
+        self.assertEqual(self.app._cycle_column_width(column), "tightly fit to data")
+        self.assertEqual(self.app._column_width(column), len("abc") + 2)
+        self.assertEqual(self.app._cycle_column_width(column), "reset")
+        self.assertEqual(self.app._column_width(column), len(column) + 2)
+
+    def test_tight_fit_still_uses_largest_visible_value(self):
+        column = "value"
+        self.app.current_entries = [{column: "a"}, {column: "longest"}]
+        self.app.tight_fit_columns.add(column)
+
+        self.assertEqual(self.app._column_width(column), len("longest") + 2)
+
     def test_title_and_exploration_config_use_log_yaml_name(self):
         app = MonitorApp(
             log_file=Path("exploration_logs/default.yaml"),


### PR DESCRIPTION
This pull request enhances the column width adjustment functionality in `run_exploration_monitor.py` by introducing a new "tight fit" mode, improving user control over column display. The changes also ensure that the new mode is persisted in the configuration and thoroughly tested.

**Column Width Adjustment Improvements:**

* Added a new "tight fit" mode for columns, allowing users to cycle through default, fit-to-data, and tightly-fit-to-data widths using the `w` key. The UI and help text have been updated to reflect this new behavior. [[1]](diffhunk://#diff-743d3dde0677ea631afe9aff9f40a8b59296b22077ba544ac49d46f1472be6c5L31-R31) [[2]](diffhunk://#diff-743d3dde0677ea631afe9aff9f40a8b59296b22077ba544ac49d46f1472be6c5L98-R98) [[3]](diffhunk://#diff-743d3dde0677ea631afe9aff9f40a8b59296b22077ba544ac49d46f1472be6c5L320-R343) [[4]](diffhunk://#diff-743d3dde0677ea631afe9aff9f40a8b59296b22077ba544ac49d46f1472be6c5L978-R996)
* Introduced the `tight_fit_columns` set to track columns in tight fit mode, and updated the logic in `_column_width` and `_cycle_column_width` to handle the new mode. [[1]](diffhunk://#diff-743d3dde0677ea631afe9aff9f40a8b59296b22077ba544ac49d46f1472be6c5R203) [[2]](diffhunk://#diff-743d3dde0677ea631afe9aff9f40a8b59296b22077ba544ac49d46f1472be6c5L320-R343)

**Configuration Persistence:**

* Modified the configuration save/load logic to persist the `tight_fit_columns` setting, ensuring user preferences are retained across sessions. [[1]](diffhunk://#diff-743d3dde0677ea631afe9aff9f40a8b59296b22077ba544ac49d46f1472be6c5R285) [[2]](diffhunk://#diff-743d3dde0677ea631afe9aff9f40a8b59296b22077ba544ac49d46f1472be6c5R836)

**Testing:**

* Added unit tests to verify the behavior of the new width cycling, including correct handling when the column heading is longer than the data and ensuring tight fit uses the largest visible value.

These changes provide a more flexible and user-friendly experience when adjusting column widths in the monitor tool.